### PR TITLE
Update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="KlutzyNinja.Touki" Version="0.1.0-alpha.8" />
+    <PackageVersion Include="KlutzyNinja.Touki" Version="0.1.0-alpha.8.11" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
@@ -12,13 +12,13 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.242" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="xunit.v3" Version="3.0.1" />
+    <PackageVersion Include="xunit.v3" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '$(DotNetCoreVersion)'">
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.10" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.3" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />

--- a/madowaku/Windows/Win32/System/Com/AgileComPointer.cs
+++ b/madowaku/Windows/Win32/System/Com/AgileComPointer.cs
@@ -78,7 +78,7 @@ public unsafe class AgileComPointer<TInterface> : IComPointer
     /// </summary>
     ~AgileComPointer()
     {
-        Debug.Fail($"Did not dispose {nameof(AgileComPointer<TInterface>)}");
+        Debug.Fail($"Did not dispose {nameof(AgileComPointer<>)}");
         Dispose(disposing: false);
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps several centrally managed packages and tweaks the `AgileComPointer` finalizer debug message.
> 
> - **Dependencies**:
>   - Update central versions in `Directory.Packages.props`:
>     - `KlutzyNinja.Touki` → `0.1.0-alpha.8.11`
>     - `Microsoft.Windows.CsWin32` → `0.3.242`
>     - `xunit.v3` → `3.2.0`
>     - `Microsoft.Bcl.Memory` → `9.0.10`
> - **Interop**:
>   - In `madowaku/Windows/Win32/System/Com/AgileComPointer.cs`, adjust finalizer debug message to use `nameof(AgileComPointer<>)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 214aca4fc36c505c885dac54080d5cf4b058e455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->