### PR TITLE
Adopt touki AGENTS.md tooling pattern

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -36,12 +36,21 @@ for the COM activation and per-struct partial.
 
 ## Maintenance
 
-Freshness is tracked from git history, not from a manual column. Re-read
-each skill end-to-end against the current codebase periodically. Confirm:
+Freshness is tracked from git history, not from a manual column. CI warns
+(does not fail) when a skill directory has no commits in the last 90 days
+&mdash; see
+[.github/workflows/agent-files.yml](../../.github/workflows/agent-files.yml).
+
+A stale warning means "re-read this skill end-to-end against the current
+codebase." Confirm:
 
 1. Every cross-reference resolves.
 2. Every file path / type / API mentioned still exists.
 3. Every claim about the codebase is still true.
+
+The only way to clear the warning is to commit a change to the skill
+directory &mdash; ideally the result of a real review pass, but at minimum
+a whitespace touch with a commit message stating "verified still current."
 
 When adding a new skill, append a row to the inventory above in the same
 change set; the skill is not "shipped" until the catalog reflects it.

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -1,0 +1,8 @@
+# Custom agents (`.github/agents/`)
+
+Copilot custom agent personas (`*.agent.md`) with restricted tool sets
+and handoff rules. None defined yet.
+
+See [docs/agent-customization.md](../../docs/agent-customization.md) for
+format requirements. Each file needs a `description` line; if `tools` is
+present it must be a YAML list.

--- a/.github/instructions/interop.instructions.md
+++ b/.github/instructions/interop.instructions.md
@@ -1,0 +1,67 @@
+---
+applyTo: "madowaku/Windows/Win32/**/*.cs, madowaku/Framework/**/*.cs, madowaku/NativeMethods.txt, madowaku/NativeMethods.json"
+---
+
+# CsWin32 interop and net472 polyfill rules
+
+Path-specific rules for hand-authored partials under `madowaku/Windows/Win32/`,
+net472 polyfills under `madowaku/Framework/`, and the CsWin32 generator
+inputs (`NativeMethods.txt`, `NativeMethods.json`). The general `AGENTS.md`
+rules still apply.
+
+For full patterns and recipes, consult:
+
+- [`cswin32-interop`](../../.agents/skills/cswin32-interop/SKILL.md)
+  &mdash; P/Invoke generation, TFM gating, `PInvoke` vs
+  `PInvokeMadowaku`, the `ComWrappers` shim, polyfill layout.
+- [`cswin32-com`](../../.agents/skills/cswin32-com/SKILL.md) &mdash;
+  `ComScope<T>`, `IComIID`, `IID.Get<T>()`, `delegate* unmanaged`
+  vtables, the per-struct net472 polyfill recipe.
+
+## Non-negotiables
+
+- **No hand-written `[DllImport]` for APIs available in Win32 metadata.**
+  Add the function to `NativeMethods.txt` and call it through the
+  generated `PInvoke` / `PInvokeMadowaku` surface instead.
+- **Use `nint` / `nuint`**, never `IntPtr` / `UIntPtr`.
+- **Use `HANDLE`, `HMODULE`, `HRESULT`, `BOOL` and friends** from
+  `Windows.Win32.Foundation` rather than raw `int` / `nint` at interop
+  boundaries.
+- **No `Enum.HasFlag`** &mdash; it boxes on net472. Use the Touki
+  enum extension methods (`AreFlagsSet`, `IsOnlyOneFlagSet`,
+  `AreAnyFlagsSet`, `SetFlags`, `ClearFlags`).
+
+## Polyfill layout (`madowaku/Framework/`)
+
+- The folder is **net472-only by construction** &mdash; conditioned in
+  the csproj. Do **not** use `#if NETFRAMEWORK` inside
+  `madowaku/Framework/`; if it compiles in this folder, it's already
+  net472.
+- A polyfill declares the BCL namespace it's polyfilling. The folder
+  hierarchy under `Framework/` mirrors the namespace:
+  `Framework/System/Runtime/InteropServices/ComWrappers.cs` &rarr;
+  `namespace System.Runtime.InteropServices;`.
+- The per-struct `IComIID` polyfill lives at
+  `madowaku/Framework/Windows/Win32/IComIID.cs` and is declared once;
+  individual COM structs add their `IComIID` implementation in a partial
+  next to the CsWin32-generated struct.
+
+## TFM gating
+
+- New types that are only meaningful on modern .NET (e.g. ones that take
+  a `ReadOnlySpan<char>` parameter that net472 doesn't have a sane shape
+  for) belong in source files conditioned by `#if NET` / `#if !NETFRAMEWORK`
+  at the top of the file or member, **outside** `madowaku/Framework/`.
+- Inside `madowaku/Framework/`, the file is already net472-scoped; no
+  `#if NETFRAMEWORK` is required or permitted.
+
+## CsWin32 generator inputs
+
+- `NativeMethods.txt`: one symbol per line. Keep alphabetized within
+  logical groups; add a comment header for each new grouping.
+- `NativeMethods.json`: tweak generator behavior (`allowMarshaling`,
+  custom mappings, COM interface generation mode). Document any
+  non-default override with a short comment in the JSON or in the PR
+  description.
+- After editing either file, build to surface generator diagnostics
+  before committing.

--- a/.github/instructions/msbuild.instructions.md
+++ b/.github/instructions/msbuild.instructions.md
@@ -1,0 +1,55 @@
+---
+applyTo: "**/*.csproj, **/*.props, **/*.targets, **/Directory.Packages.props"
+---
+
+# MSBuild file conventions
+
+Path-specific rules for `.csproj`, `.props`, `.targets`, and central
+package management files. The general `AGENTS.md` rules still apply.
+
+## Target frameworks
+
+- The library multi-targets `$(DotNetCoreVersion)-$(WindowsPlatformVersion)`,
+  `$(DotNetCoreVersion)`, and `$(DotNetFrameworkVersion)`. These are
+  defined in [Directory.Build.props](../../Directory.Build.props):
+  - `DotNetCoreVersion` = `net10.0`
+  - `DotNetFrameworkVersion` = `net472`
+  - `WindowsPlatformVersion` = `windows10.0.22000.0`
+- The test project multi-targets the windowed modern TFM and `net481`.
+- **Never hard-code `net10.0`, `net472`, or the windows platform suffix**
+  in csproj `TargetFrameworks` lists. Reference the properties instead so
+  the values stay in one place.
+
+## Central package management
+
+- Package versions live in
+  [Directory.Packages.props](../../Directory.Packages.props). Individual
+  csproj files list `<PackageReference Include="..."/>` **without** a
+  `Version` attribute.
+- When adding a new dependency, add the `PackageVersion` entry in
+  `Directory.Packages.props` first, then reference it from the csproj.
+
+## Conditionals
+
+- Prefer property-based conditions over hard-coded TFM strings:
+  `Condition="'$(TargetFramework)' == '$(DotNetFrameworkVersion)'"` over
+  `Condition="'$(TargetFramework)' == 'net472'"`.
+- Group net472-only items inside a single `ItemGroup` with a
+  `Condition` on the group, not per-item conditions.
+
+## Formatting
+
+- 2-space indent for MSBuild XML (matches existing files).
+- One blank line between top-level `PropertyGroup` / `ItemGroup`
+  elements.
+- Comment non-obvious settings inline with `<!-- ... -->`; mention
+  *why*, not *what*.
+
+## What not to do
+
+- Do not add `<NoWarn>` entries to silence platform-compatibility
+  warnings (CA1416) without a clear justification comment.
+- Do not introduce per-project `nuget.config` or per-project package
+  source overrides.
+- Do not change `LangVersion`, `Nullable`, or `ImplicitUsings` defaults
+  in `Directory.Build.props` without coordinating across all projects.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,62 @@
+---
+applyTo: "madowaku.tests/**/*.cs"
+---
+
+# Test conventions (`madowaku.tests/`)
+
+Path-specific rules for the xUnit v3 test project. The general `AGENTS.md`
+rules (coding style, whitespace, file header) still apply.
+
+## Framework
+
+- xUnit v3 with the **Microsoft Testing Platform** runner
+  (`UseMicrosoftTestingPlatformRunner` is set in the csproj). Run tests
+  with `dotnet test`; do not invoke `vstest` directly.
+- Target frameworks: `net10.0-windows10.0.22000.0` and `net481`. All
+  tests must build and pass on both.
+- `Xunit` is available via a project-level `<Using>`; `using Xunit;` is
+  unnecessary.
+- `FluentAssertions` is referenced. Either `Assert.*` (xUnit) or
+  `.Should().*` (FluentAssertions) is acceptable; pick one style per
+  file and stay consistent within it.
+
+## Naming and structure
+
+- Name tests `MethodName_StateUnderTest_ExpectedBehavior` (e.g.
+  `IntConversion_RoundTrip`, `EmptyVariant_HasExpectedProperties`).
+- Mirror the source layout: a test for `madowaku/Windows/Win32/Foo.cs`
+  lives at `madowaku.tests/Windows/Win32/FooTests.cs` with namespace
+  matching the production type.
+- One `public class FooTests` per type under test. Multiple `[Fact]`s
+  per class is fine.
+- Do **not** add "Arrange / Act / Assert" comments. The structure should
+  be obvious from the code.
+
+## Coverage expectations
+
+- Cover edge cases and negative paths, not just the happy path.
+- For every public API change, add or update at least one test that
+  exercises the new shape.
+- For cross-TFM bugs, add a regression test that would fail on the
+  affected TFM specifically.
+
+## Cross-TFM gotchas
+
+- **`nint` does not implement `IEquatable<nint>` on net472/net481.**
+  Generic type parameters constrained to `unmanaged, IEquatable<T>`
+  cannot be instantiated with `nint` in cross-TFM tests. Use `int` or
+  another concrete value type.
+- **Release-mode inlining changes codegen.** Run
+  `dotnet test -c Release` before declaring a fix done; `Unsafe.As` on a
+  method parameter is a known foot-gun on net481 RyuJIT.
+- **`[ExcludeFromCodeCoverage(Justification = ...)]` is .NET 5+ only.**
+  Not available on net481. Use bare `[ExcludeFromCodeCoverage]` with the
+  rationale in a `//` comment above the attribute.
+
+## What not to do
+
+- Do not introduce a separate test SDK (MSTest, NUnit) alongside xUnit.
+- Do not gate tests on a specific machine, locale, or installed SDK
+  without a clear `[Fact(Skip = "...")]` reason.
+- Do not use `Thread.Sleep` for synchronization; use the appropriate
+  xUnit / `Task`-based primitives.

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -1,0 +1,8 @@
+# Slash-command prompts (`.github/prompts/`)
+
+Reusable `*.prompt.md` files that surface as slash commands in Copilot
+Chat. None defined yet.
+
+See [docs/agent-customization.md](../../docs/agent-customization.md) for
+format requirements. The recommended frontmatter is a `description` line
+so the prompt is discoverable.

--- a/.github/workflows/agent-files.yml
+++ b/.github/workflows/agent-files.yml
@@ -1,0 +1,91 @@
+name: Agent files
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate agent customization files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            agent:
+              - AGENTS.md
+              - '**/AGENTS.md'
+              - .github/copilot-instructions.md
+              - .github/instructions/**
+              - .github/prompts/**
+              - .github/agents/**
+              - .agents/**
+              - docs/agent-customization.md
+              - tools/Validate-AgentFiles.ps1
+              - .markdownlint.jsonc
+              - .github/workflows/agent-files.yml
+
+      - name: Validate frontmatter, mirror, whitespace
+        if: steps.changes.outputs.agent == 'true'
+        shell: pwsh
+        run: pwsh tools/Validate-AgentFiles.ps1
+
+      - name: Skill freshness warning (90 days)
+        if: steps.changes.outputs.agent == 'true'
+        shell: pwsh
+        run: |
+          $threshold = (Get-Date).AddDays(-90)
+          $skillDirs = Get-ChildItem -Directory -Path '.agents/skills' -ErrorAction SilentlyContinue
+          $stale = @()
+          foreach ($dir in $skillDirs) {
+              $rel = ".agents/skills/$($dir.Name)"
+              $lastCommit = git log -1 --format=%cI -- $rel 2>$null
+              if (-not $lastCommit) { continue }
+              $when = [DateTime]::Parse($lastCommit)
+              if ($when -lt $threshold) {
+                  $stale += "$($dir.Name) (last touched $($when.ToString('yyyy-MM-dd')))"
+              }
+          }
+          if ($stale.Count -gt 0) {
+              foreach ($s in $stale) { Write-Host "::warning::Skill stale: $s" }
+          } else {
+              Write-Host 'OK: all skills touched within the last 90 days.'
+          }
+
+      - name: markdownlint
+        if: steps.changes.outputs.agent == 'true'
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: |
+            AGENTS.md
+            .github/copilot-instructions.md
+            .github/instructions/**/*.md
+            .github/prompts/**/*.md
+            .github/agents/**/*.md
+            .agents/**/*.md
+            docs/agent-customization.md
+          config: .markdownlint.jsonc
+
+      - name: Link check
+        if: steps.changes.outputs.agent == 'true'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --offline
+            AGENTS.md
+            .github/copilot-instructions.md
+            .github/instructions/**/*.md
+            .github/prompts/**/*.md
+            .github/agents/**/*.md
+            .agents/**/*.md
+            docs/agent-customization.md
+          fail: true

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,13 @@
+{
+  // Used by .github/workflows/agent-files.yml to lint agent-customization
+  // Markdown. See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  "default": true,
+  "MD013": false,
+  "MD022": false,
+  "MD024": { "siblings_only": true },
+  "MD032": false,
+  "MD033": false,
+  "MD041": false,
+  "no-trailing-spaces": true,
+  "no-hard-tabs": true
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,10 @@
+{
+    // MCP servers wired up for this workspace.
+    // See docs/agent-customization.md "MCP servers" for rationale.
+    "servers": {
+        "microsoft-learn": {
+            "type": "http",
+            "url": "https://learn.microsoft.com/api/mcp"
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
     // an explicit in-chat Allow click before the command runs; allow
     // entries keep routine read-only git verbs frictionless.
     "chat.tools.terminal.autoApprove": {
-        "/^git\\s+(status|diff|log|show|branch|stash\\s+list|rev-parse|ls-files|config\\s+--get)\\b/": true,
+        "/^git\\s+(status|diff|log|show|branch(?!\\s+-[dD])|stash\\s+list|rev-parse|ls-files|config\\s+--get)\\b/": true,
         "/^git\\s+commit\\b/": false,
         "/^git\\s+push\\b/": false,
         "/^git\\s+reset\\s+--hard\\b/": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+    "editor.trimAutoWhitespace": true,
+    "dotnet.testWindow.useTestingPlatformProtocol": true,
+    "cSpell.words": [
+        "CsWin32",
+        "Kuhne",
+        "Madowaku",
+        "NETFRAMEWORK",
+        "PInvoke",
+        "slnx",
+        "Touki"
+    ],
+    // Publish-boundary enforcement for Copilot agent-mode terminal calls.
+    // See AGENTS.md "Working with the user on changes". Deny entries force
+    // an explicit in-chat Allow click before the command runs; allow
+    // entries keep routine read-only git verbs frictionless.
+    "chat.tools.terminal.autoApprove": {
+        "/^git\\s+(status|diff|log|show|branch|stash\\s+list|rev-parse|ls-files|config\\s+--get)\\b/": true,
+        "/^git\\s+commit\\b/": false,
+        "/^git\\s+push\\b/": false,
+        "/^git\\s+reset\\s+--hard\\b/": false,
+        "/^git\\s+rebase\\b/": false,
+        "/^git\\s+merge\\b/": false,
+        "/^git\\s+cherry-pick\\b/": false,
+        "/^git\\s+tag\\b/": false,
+        "/^git\\s+branch\\s+-[dD]\\b/": false,
+        "/^gh\\s+pr\\s+(create|merge|close|edit)\\b/": false,
+        "/^gh\\s+(repo|release)\\s+/": false
+    }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,3 @@
-<!-- DO NOT EDIT. Generated mirror of /AGENTS.md. Edit AGENTS.md and run: pwsh tools/Validate-AgentFiles.ps1 -Fix -->
 # AGENTS.md
 
 Instructions for AI coding agents working in this repository.
@@ -7,15 +6,15 @@ agent), Claude Code, OpenAI Codex, Cursor, Aider, Gemini CLI, and any other
 tool that supports the [AGENTS.md](https://agents.md/) standard.
 
 This file is the single source of truth.
-[.github/copilot-instructions.md](copilot-instructions.md) mirrors
+[.github/copilot-instructions.md](.github/copilot-instructions.md) mirrors
 this file for Copilot features that read it directly; do not edit the
 mirror by hand &mdash; regenerate it via
 `pwsh tools/Validate-AgentFiles.ps1 -Fix`.
 
-For broader contributor guidance, see [CONTRIBUTING.md](../CONTRIBUTING.md).
+For broader contributor guidance, see [CONTRIBUTING.md](CONTRIBUTING.md).
 For how to add or update agent customizations (skills, prompts, custom
 agents, path-specific instructions), see
-[docs/agent-customization.md](../docs/agent-customization.md).
+[docs/agent-customization.md](docs/agent-customization.md).
 
 ## Project overview
 
@@ -127,7 +126,7 @@ Top-level layout:
 ## Testing
 
 Detailed test conventions live in
-[.github/instructions/tests.instructions.md](instructions/tests.instructions.md)
+[.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md)
 (applies to `madowaku.tests/**/*.cs`). Headline rules: place tests in
 `madowaku.tests`; name them `MethodName_StateUnderTest_ExpectedBehavior`;
 use FluentAssertions; xUnit v3 with the Microsoft Testing Platform
@@ -174,7 +173,7 @@ The publish-boundary rule above is also enforced mechanically so that
 model rationalization cannot bypass it:
 
 - **VS Code Copilot agent mode.**
-  [.vscode/settings.json](../.vscode/settings.json) configures
+  [.vscode/settings.json](.vscode/settings.json) configures
   `chat.tools.terminal.autoApprove` to deny `git commit`, `git push`,
   `git reset --hard`, `git rebase`, `git merge`, `git cherry-pick`,
   `git tag`, destructive `git branch -d/-D`, and
@@ -203,8 +202,8 @@ not a license to skip the conversation.
 - CsWin32-generated P/Invoke lives under the `Windows.Win32` namespace via
   `NativeMethods.txt` / `NativeMethods.json`. Prefer the generated
   `PInvoke` / `PInvokeMadowaku` surface over hand-written `[DllImport]`.
-  See the [`cswin32-interop`](../.agents/skills/cswin32-interop/SKILL.md) and
-  [`cswin32-com`](../.agents/skills/cswin32-com/SKILL.md) skills for
+  See the [`cswin32-interop`](.agents/skills/cswin32-interop/SKILL.md) and
+  [`cswin32-com`](.agents/skills/cswin32-com/SKILL.md) skills for
   patterns, TFM gating, and the per-struct net472 polyfill recipe.
 - Hand-rolled net472 polyfills live under `madowaku/Framework/` and
   declare the BCL namespace they're polyfilling (e.g.
@@ -216,16 +215,16 @@ not a license to skip the conversation.
 ## Path-specific instructions
 
 Additional rules apply to specific file types and live under
-[.github/instructions/](instructions/). Tools that support the
+[.github/instructions/](.github/instructions/). Tools that support the
 `*.instructions.md` format (Copilot cloud agent, Copilot code review, VS
 Code) load them automatically based on each file's `applyTo` glob.
 
 Currently:
 
-- [.github/instructions/msbuild.instructions.md](instructions/msbuild.instructions.md)
+- [.github/instructions/msbuild.instructions.md](.github/instructions/msbuild.instructions.md)
   &mdash; rules for `*.csproj`, `*.props`, `*.targets`.
-- [.github/instructions/tests.instructions.md](instructions/tests.instructions.md)
+- [.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md)
   &mdash; conventions for `madowaku.tests/**/*.cs`.
-- [.github/instructions/interop.instructions.md](instructions/interop.instructions.md)
+- [.github/instructions/interop.instructions.md](.github/instructions/interop.instructions.md)
   &mdash; CsWin32 P/Invoke and COM rules for `madowaku/Windows/Win32/**`
   and `madowaku/Framework/**`.

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -1,0 +1,162 @@
+# Agent customization guide
+
+This repository supports several formats for customizing AI coding agents.
+Pick the right one for your needs, place it in the right folder, and CI
+will validate it.
+
+## Decision matrix
+
+| I want to&hellip;                                              | Use                                                                                 |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Set project-wide rules every agent should follow               | [AGENTS.md](../AGENTS.md) (canonical; mirrored to `.github/copilot-instructions.md`) |
+| Apply rules only to files matching a glob                      | [.github/instructions/](../.github/instructions/)`<name>.instructions.md`           |
+| Provide a reusable slash-command prompt                        | [.github/prompts/](../.github/prompts/)`<name>.prompt.md`                           |
+| Define a persona with restricted tools and/or handoffs         | [.github/agents/](../.github/agents/)`<name>.agent.md`                              |
+| Package a portable workflow (instructions + scripts/resources) | [.agents/skills/](../.agents/skills/)`<name>/SKILL.md`                              |
+
+## Tool support
+
+| Format                            | Copilot VS Code | Copilot Visual Studio | Copilot CLI | Copilot cloud / github.com | Claude Code   | Codex / Cursor / Aider / Gemini |
+| --------------------------------- | --------------- | --------------------- | ----------- | -------------------------- | ------------- | ------------------------------- |
+| `AGENTS.md`                       | yes             | yes                   | yes         | yes                        | yes           | yes                             |
+| `.github/copilot-instructions.md` | yes             | yes                   | yes         | yes                        | no            | no                              |
+| `*.instructions.md` (`applyTo`)   | yes             | yes                   | partial     | yes                        | no            | no                              |
+| `*.prompt.md`                     | yes             | yes                   | no          | no                         | no            | no                              |
+| `*.agent.md`                      | yes             | yes                   | no          | no                         | via `.claude` | no                              |
+| `SKILL.md` (Agent Skills)         | yes             | yes                   | yes         | yes                        | yes           | varies                          |
+
+`AGENTS.md` is the most broadly portable. Prefer it for anything that
+should apply universally; reach for the more specialized formats only
+when you need their extra features (path scoping, tool restrictions,
+slash-command UX, packaged scripts).
+
+## MCP servers
+
+Workspace-scoped MCP server config lives in
+[.vscode/mcp.json](../.vscode/mcp.json). Add a server here only when the
+agent genuinely cannot reach the data otherwise &mdash; prefer
+instructions and skills first (instructions &rarr; skills &rarr; MCP).
+
+Currently wired up:
+
+| Server                                                       | Purpose                                                                                                                                                 |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `microsoft-learn` (`https://learn.microsoft.com/api/mcp`)    | Current official .NET BCL and Win32 docs. Used by the CsWin32 skills when verifying API shapes before deciding whether to hand-roll a polyfill or shim. |
+
+## Frontmatter requirements
+
+| Format              | Required                              | Notes                                                                  |
+| ------------------- | ------------------------------------- | ---------------------------------------------------------------------- |
+| `*.instructions.md` | `applyTo` (non-empty string)          | Comma-separated globs relative to repo root.                           |
+| `*.prompt.md`       | none                                  | `description` recommended.                                             |
+| `*.agent.md`        | `description`                         | If `tools` is present it must be a YAML list (inline `['a', 'b']` or block syntax). |
+| `SKILL.md`          | `name`, `description`                 | `name` must match parent directory name; `^[a-z0-9-]{1,64}$`.          |
+
+## Authoring rules
+
+These come from [AGENTS.md](../AGENTS.md) and apply to every agent file in
+the repo:
+
+- No trailing whitespace; no whitespace-only lines.
+- Use spaces (not tabs) inside Markdown bodies and YAML frontmatter.
+- Keep lines under ~120 characters where practical.
+- Single blank line between sections; preserve existing whitespace when
+  editing.
+
+## Local validation
+
+Run the validator before pushing:
+
+```pwsh
+pwsh tools/Validate-AgentFiles.ps1
+```
+
+Use `-Fix` to regenerate `.github/copilot-instructions.md` from
+`AGENTS.md`:
+
+```pwsh
+pwsh tools/Validate-AgentFiles.ps1 -Fix
+```
+
+The same checks run in CI via
+[.github/workflows/agent-files.yml](../.github/workflows/agent-files.yml).
+
+## Improvement loop
+
+The customization layer is source code: it is iterated, not set once.
+Every correction you give an agent is a signal that something is missing.
+
+### Triage matrix
+
+When the agent does something wrong, classify the failure and place the
+fix at the right layer.
+
+| Failure class                                 | Right layer                                                    |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| Factual: wrong about *what the code is*       | [AGENTS.md](../AGENTS.md) or path-specific `*.instructions.md` |
+| Procedural: wrong *workflow*, repeated        | New skill in [.agents/skills/](../.agents/skills/)             |
+| Capability: agent literally cannot reach data | MCP server (or a script the agent can run)                     |
+| Enforcement: agent rationalizes around a rule | Hook, CI check, or `chat.tools.terminal.autoApprove` denylist  |
+
+The order matters. Try instructions before skills, skills before MCP, and
+prefer deterministic enforcement (CI, denylist, branch protection) over
+more prose anywhere a rule has been violated before.
+
+### Size budget
+
+Attention to instructions degrades as files grow. Targets:
+
+- [AGENTS.md](../AGENTS.md): &le; 10 KB. If it grows past this, split
+  rules into a path-specific `*.instructions.md` and leave a one-line
+  summary pointer.
+- Each `*.instructions.md`: &le; 8 KB. If a single area needs more, split
+  it further by glob.
+- Each `SKILL.md`: &le; 15 KB body. Move long examples or scripts into
+  sibling files within the skill directory.
+
+### Periodic maintenance
+
+Roughly monthly:
+
+1. Read [AGENTS.md](../AGENTS.md) end to end. Anything stale,
+   contradictory, or vague? Tighten.
+2. Skim each `*.instructions.md`. Same.
+3. Check [.agents/skills/README.md](../.agents/skills/README.md): every
+   cross-reference should resolve, every disambiguation should still
+   match the skills it names. The CI freshness warning (90 days, derived
+   from git history) flags individual skills that have not been touched.
+4. Scan the recent git log for repeated CI fixes to the same rule,
+   repeated "fix the comments" cycles on PRs, or repeated permission
+   requests for the same command. These are gap signals; address them at
+   the right layer from the matrix above.
+
+### Hygiene rules
+
+- The phrasing-bank lists in [AGENTS.md](../AGENTS.md) "Working with the
+  user on changes" (verbs that are / are not approval) are **append-only**.
+  Add new misreads when they occur. Do not rewrite past entries except to
+  deduplicate.
+- When changing a skill, also update any cross-reference in
+  [.agents/skills/README.md](../.agents/skills/README.md) within the same
+  change set.
+- When a rule moves from instructions to a CI check (or vice versa),
+  keep the prose in instructions explaining *why*. The mechanical gate is
+  the *what*; instructions explain the *why*.
+
+## Verifying instructions are loaded
+
+- **VS Code**: right-click in the Chat view, choose **Diagnostics**
+  &mdash; lists all loaded instruction/skill/agent files and any errors.
+- **github.com**: open a PR; the Copilot code review check lists the
+  instruction files it consulted.
+- **Visual Studio**: same Copilot stack as VS Code; instructions load
+  from `.github/copilot-instructions.md` and `.github/instructions/`.
+
+## References
+
+- [AGENTS.md standard](https://agents.md/)
+- [Agent Skills standard](https://agentskills.io/)
+- [GitHub Copilot custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions)
+- [VS Code custom instructions](https://code.visualstudio.com/docs/copilot/customization/custom-instructions)
+- [VS Code Agent Skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
+- [VS Code custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents)

--- a/tools/Validate-AgentFiles.ps1
+++ b/tools/Validate-AgentFiles.ps1
@@ -1,0 +1,282 @@
+<#
+.SYNOPSIS
+    Validate AI-agent customization files in the repo.
+
+.DESCRIPTION
+    Checks performed:
+
+    1. AGENTS.md matches the text content of .github/copilot-instructions.md
+       (after the single DO-NOT-EDIT comment line at the top of the mirror,
+       and after rewriting relative Markdown links so they resolve from
+       .github/).
+    2. *.instructions.md files have a non-empty `applyTo` frontmatter value.
+    3. SKILL.md files have `name` (^[a-z0-9-]{1,64}$, matching parent
+       directory) and `description`.
+    4. *.agent.md files have `description`; if `tools` is present it must
+       be a YAML list.
+    5. No trailing whitespace or whitespace-only lines in any agent file.
+
+    Frontmatter is parsed with a small hand-written parser that handles
+    the flat scalars and flat lists used by this repo's schema. If the
+    schema grows beyond that, swap in the `powershell-yaml` module.
+
+.PARAMETER Fix
+    Regenerate .github/copilot-instructions.md from AGENTS.md.
+
+.EXAMPLE
+    pwsh tools/Validate-AgentFiles.ps1
+    pwsh tools/Validate-AgentFiles.ps1 -Fix
+#>
+[CmdletBinding()]
+param(
+    [switch]$Fix
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$AgentsMd = Join-Path $RepoRoot 'AGENTS.md'
+$CopilotMirror = Join-Path $RepoRoot '.github/copilot-instructions.md'
+$MirrorHeaderText = '<!-- DO NOT EDIT. Generated mirror of /AGENTS.md. Edit AGENTS.md and run: pwsh tools/Validate-AgentFiles.ps1 -Fix -->'
+
+$ScanDirs = @(
+    (Join-Path $RepoRoot '.github/instructions'),
+    (Join-Path $RepoRoot '.github/prompts'),
+    (Join-Path $RepoRoot '.github/agents'),
+    (Join-Path $RepoRoot '.agents')
+)
+$ExtraWhitespaceFiles = @(
+    $AgentsMd,
+    $CopilotMirror,
+    (Join-Path $RepoRoot 'docs/agent-customization.md')
+)
+
+$SkillNamePattern = '^[a-z0-9-]{1,64}$'
+$Errors = [System.Collections.Generic.List[string]]::new()
+
+function Add-Error([string]$Message) {
+    $Errors.Add($Message) | Out-Null
+}
+
+function Get-RelativePath([string]$Path) {
+    return [System.IO.Path]::GetRelativePath($RepoRoot, $Path).Replace('\', '/')
+}
+
+function Get-ExpectedMirror() {
+    # Use the line-ending convention of AGENTS.md on disk so the result
+    # matches whatever Git's autocrlf produced on this checkout.
+    $agents = Get-Content -Raw -LiteralPath $AgentsMd
+    $newline = if ($agents -match "`r`n") { "`r`n" } else { "`n" }
+    # Rewrite repo-relative Markdown links so they resolve from .github/,
+    # where the mirror lives. Links to .github/<x> become <x>; everything
+    # else gets ../ prepended. External URLs (http/https/mailto) and
+    # anchors are left alone, as are absolute paths starting with '/'.
+    $rewritten = [regex]::Replace($agents, '\]\(([^)]+)\)', {
+        param($m)
+        $target = $m.Groups[1].Value
+        if ($target -match '^(https?:|mailto:|#|/)') { return $m.Value }
+        if ($target.StartsWith('.github/')) {
+            return "](" + $target.Substring('.github/'.Length) + ")"
+        }
+        return "](../" + $target + ")"
+    })
+    return $MirrorHeaderText + $newline + $rewritten
+}
+
+# Parse a small subset of YAML frontmatter: flat scalars (`key: value`),
+# inline lists (`key: [a, b]` or `key: ['a', 'b']`), and block lists
+# (`key:` followed by indented `- item` lines). Returns a hashtable, or
+# $null if no frontmatter block is present.
+function Get-Frontmatter([string]$Path) {
+    $text = Get-Content -Raw -LiteralPath $Path
+    if (-not $text.StartsWith("---`n") -and -not $text.StartsWith("---`r`n")) {
+        return $null
+    }
+    $lines = $text -split "`r?`n"
+    $end = -1
+    for ($i = 1; $i -lt $lines.Length; $i++) {
+        if ($lines[$i] -eq '---') { $end = $i; break }
+    }
+    if ($end -lt 0) { return $null }
+
+    $result = @{}
+    $i = 1
+    while ($i -lt $end) {
+        $line = $lines[$i]
+        if ($line -match '^\s*$' -or $line -match '^\s*#') { $i++; continue }
+        if ($line -notmatch '^([A-Za-z0-9_-]+)\s*:\s*(.*)$') { $i++; continue }
+        $key = $Matches[1]
+        $rawValue = $Matches[2].Trim()
+
+        if ($rawValue -eq '') {
+            $blockItems = @()
+            $j = $i + 1
+            while ($j -lt $end -and $lines[$j] -match '^\s+-\s*(.*)$') {
+                $item = $Matches[1].Trim()
+                if ($item -match "^'(.*)'$" -or $item -match '^"(.*)"$') { $item = $Matches[1] }
+                $blockItems += $item
+                $j++
+            }
+            if ($blockItems.Count -gt 0) {
+                $result[$key] = @($blockItems)
+                $i = $j
+                continue
+            }
+            $result[$key] = ''
+            $i++
+            continue
+        }
+        if ($rawValue -match '^\[(.*)\]\s*$') {
+            $inner = $Matches[1].Trim()
+            if ($inner -eq '') {
+                $result[$key] = @()
+            }
+            else {
+                $items = $inner -split ',' | ForEach-Object {
+                    $item = $_.Trim()
+                    if ($item -match "^'(.*)'$" -or $item -match '^"(.*)"$') { $Matches[1] } else { $item }
+                }
+                $result[$key] = @($items)
+            }
+            $i++
+            continue
+        }
+        if ($rawValue -match "^'(.*)'\s*$" -or $rawValue -match '^"(.*)"\s*$') {
+            $result[$key] = $Matches[1]
+            $i++
+            continue
+        }
+        $result[$key] = $rawValue
+        $i++
+    }
+    return $result
+}
+
+function Test-Mirror() {
+    if (-not (Test-Path -LiteralPath $CopilotMirror)) {
+        Add-Error "$(Get-RelativePath $CopilotMirror) is missing."
+        return
+    }
+    $expected = Get-ExpectedMirror
+    $actual = Get-Content -Raw -LiteralPath $CopilotMirror
+    if ($actual -ne $expected) {
+        Add-Error "$(Get-RelativePath $CopilotMirror) is out of sync with AGENTS.md. Run: pwsh tools/Validate-AgentFiles.ps1 -Fix"
+    }
+}
+
+function Test-Instructions([string]$Path) {
+    $fm = Get-Frontmatter $Path
+    $rel = Get-RelativePath $Path
+    if ($null -eq $fm -or -not $fm.ContainsKey('applyTo') -or [string]::IsNullOrWhiteSpace([string]$fm['applyTo'])) {
+        Add-Error "${rel}: missing or empty ``applyTo`` frontmatter."
+    }
+}
+
+function Test-Skill([string]$Path) {
+    $fm = Get-Frontmatter $Path
+    $rel = Get-RelativePath $Path
+    $parent = Split-Path -Leaf (Split-Path -Parent $Path)
+    if ($null -eq $fm) {
+        Add-Error "${rel}: missing frontmatter."
+        return
+    }
+    $name = if ($fm.ContainsKey('name')) { [string]$fm['name'] } else { '' }
+    $desc = if ($fm.ContainsKey('description')) { [string]$fm['description'] } else { '' }
+    if ($name -notmatch $SkillNamePattern) {
+        Add-Error "${rel}: ``name`` must match $SkillNamePattern (got '$name')."
+    }
+    elseif ($name -ne $parent) {
+        Add-Error "${rel}: ``name`` ('$name') must equal parent directory ('$parent')."
+    }
+    if ([string]::IsNullOrWhiteSpace($desc)) {
+        Add-Error "${rel}: missing or empty ``description``."
+    }
+}
+
+function Test-Agent([string]$Path) {
+    $fm = Get-Frontmatter $Path
+    $rel = Get-RelativePath $Path
+    if ($null -eq $fm) {
+        Add-Error "${rel}: missing frontmatter."
+        return
+    }
+    $desc = if ($fm.ContainsKey('description')) { [string]$fm['description'] } else { '' }
+    if ([string]::IsNullOrWhiteSpace($desc)) {
+        Add-Error "${rel}: missing or empty ``description``."
+    }
+    if ($fm.ContainsKey('tools') -and -not ($fm['tools'] -is [array])) {
+        Add-Error "${rel}: ``tools`` must be a list."
+    }
+}
+
+function Test-Whitespace([string]$Path) {
+    $rel = Get-RelativePath $Path
+    $raw = Get-Content -Raw -LiteralPath $Path
+    if ($null -ne $raw -and $raw.Length -gt 0 -and -not $raw.EndsWith("`n")) {
+        Add-Error "${rel}: file must end with a single newline (markdownlint MD047)."
+    }
+    $lines = $raw -split "`r?`n"
+    for ($i = 0; $i -lt $lines.Length; $i++) {
+        $line = $lines[$i]
+        $lineNum = $i + 1
+        if ($line -ne $line.TrimEnd()) {
+            Add-Error "${rel}:${lineNum}: trailing whitespace."
+        }
+        if ($line.Length -gt 0 -and [string]::IsNullOrWhiteSpace($line)) {
+            Add-Error "${rel}:${lineNum}: whitespace-only line."
+        }
+    }
+}
+
+# --fix mode
+if ($Fix) {
+    [System.IO.File]::WriteAllText($CopilotMirror, (Get-ExpectedMirror))
+    Write-Host "Wrote $(Get-RelativePath $CopilotMirror)"
+}
+
+# Discover files
+$instructionFiles = @()
+$skillFiles = @()
+$agentFiles = @()
+$whitespaceFiles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+foreach ($dir in $ScanDirs) {
+    if (-not (Test-Path -LiteralPath $dir)) { continue }
+    foreach ($file in Get-ChildItem -LiteralPath $dir -Recurse -File) {
+        $name = $file.Name
+        if ($name -like '*.instructions.md') {
+            $instructionFiles += $file.FullName
+            [void]$whitespaceFiles.Add($file.FullName)
+        }
+        elseif ($name -eq 'SKILL.md') {
+            $skillFiles += $file.FullName
+            [void]$whitespaceFiles.Add($file.FullName)
+        }
+        elseif ($name -like '*.agent.md') {
+            $agentFiles += $file.FullName
+            [void]$whitespaceFiles.Add($file.FullName)
+        }
+        elseif ($name -like '*.md') {
+            [void]$whitespaceFiles.Add($file.FullName)
+        }
+    }
+}
+foreach ($p in $ExtraWhitespaceFiles) {
+    if (Test-Path -LiteralPath $p) { [void]$whitespaceFiles.Add((Resolve-Path -LiteralPath $p).Path) }
+}
+
+# Run checks
+Test-Mirror
+foreach ($p in $instructionFiles) { Test-Instructions $p }
+foreach ($p in $skillFiles) { Test-Skill $p }
+foreach ($p in $agentFiles) { Test-Agent $p }
+foreach ($p in $whitespaceFiles) { Test-Whitespace $p }
+
+if ($Errors.Count -gt 0) {
+    Write-Host "Agent-file validation failed:" -ForegroundColor Red
+    foreach ($e in $Errors) { Write-Host "  - $e" }
+    exit 1
+}
+Write-Host "Agent-file validation passed." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
Adopt the AGENTS.md tooling pattern from [touki#136](https://github.com/JeremyKuhne/touki/pull/136), adapted for madowaku.

## What

- **`AGENTS.md`** is now the single source of truth (project overview, coding style, whitespace, testing pointer, publish-boundary rules + enforcement subsection, general guidance, path-specific index).
- **`.github/copilot-instructions.md`** is a generated mirror: header + body with repo-relative links rewritten to resolve from `.github/`. Regenerate with `pwsh tools/Validate-AgentFiles.ps1 -Fix`.
- **`.github/instructions/`** — three new path-specific files:
  - `tests.instructions.md` (`madowaku.tests/**/*.cs`) — xUnit v3 + MTP, cross-TFM gotchas (`nint`/`IEquatable<nint>`, `Unsafe.As` on net481 Release).
  - `interop.instructions.md` (`madowaku/Windows/Win32/**`, `madowaku/Framework/**`, `NativeMethods.{txt,json}`) — no hand `[DllImport]`, `nint`/`nuint`, `HANDLE`/`HRESULT`, no `Enum.HasFlag`, polyfill layout rules.
  - `msbuild.instructions.md` (`*.csproj`/`*.props`/`*.targets`/`Directory.Packages.props`) — use `Directory.Build.props` properties, CPM rules.
- **`docs/agent-customization.md`** — decision matrix, MCP policy, frontmatter requirements, authoring rules, improvement loop, size budgets, hygiene rules.
- **`.vscode/settings.json`** — `chat.tools.terminal.autoApprove` denylist for `git commit`/`push`/`reset --hard`/`rebase`/`merge`/`cherry-pick`/`tag`/`branch -d/-D`, and `gh pr create|merge|close|edit` / `gh repo|release ...`; allowlist for read-only git verbs.
- **`.vscode/mcp.json`** — `microsoft-learn` HTTP MCP server.
- **`tools/Validate-AgentFiles.ps1`** — mirror sync (with `-Fix`), frontmatter checks for `*.instructions.md` / `SKILL.md` / `*.agent.md`, whitespace checks.
- **`.github/workflows/agent-files.yml`** — paths-filter gate, validator, 90-day skill-freshness `::warning::`, `markdownlint-cli2-action`, `lychee-action --offline` link check.
- **`.markdownlint.jsonc`** — ruleset used by the workflow.
- **`.agents/skills/README.md`** — Maintenance section references the new 90-day CI freshness warning.

## Verification

```
pwsh tools/Validate-AgentFiles.ps1
# Agent-file validation passed.
```

## What was deferred

- **Branch protection on `main`** — repo-settings change, not in this diff. Documented in `AGENTS.md` "Enforcement". Will configure after merge.
- **`madowaku-reviewer.agent.md`** custom agent — defer until the review surface settles.
