### PR TITLE
Replace FluentAssertions with AwesomeAssertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="KlutzyNinja.Touki" Version="0.2.0-alpha.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.14.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/madowaku.tests/madowaku.tests.csproj
+++ b/madowaku.tests/madowaku.tests.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector"/>
     <PackageReference Include="xunit.v3"/>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Switch the test dependency from FluentAssertions 6.12.2 to AwesomeAssertions 9.4.0, the Apache-2.0 community fork. The API is compatible, so no test source changes are required.

- `Directory.Packages.props`: package version replaced
- `madowaku.tests/madowaku.tests.csproj`: `PackageReference` updated

Build verified locally on both target frameworks.