### PR TITLE
Add code coverage to CI

### DIFF
--- a/.config/coverage.settings.xml
+++ b/.config/coverage.settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*madowaku\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <ModulePath>.*madowaku\.tests\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+  </CodeCoverage>
+</Configuration>

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,8 +33,6 @@ jobs:
         New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 
         dotnet test --no-build `
-          -p:TestingPlatformCaptureOutput=false `
-          -- `
           --results-directory "$resultsDir" `
           --report-xunit-trx `
           --show-live-output on
@@ -44,8 +42,6 @@ jobs:
         New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 
         dotnet test -c Release --no-build `
-          -p:TestingPlatformCaptureOutput=false `
-          -- `
           --results-directory "$resultsDir" `
           --report-xunit-trx `
           --show-live-output on `

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,7 +48,60 @@ jobs:
           -- `
           --results-directory "$resultsDir" `
           --report-xunit-trx `
-          --show-live-output on
+          --show-live-output on `
+          --coverage `
+          --coverage-output-format cobertura `
+          --coverage-settings "$PWD/.config/coverage.settings.xml"
+    - name: Generate coverage report
+      if: always()
+      run: |
+        $reportGeneratorVersion = '5.5.9'
+        if (dotnet tool list -g | Select-String -SimpleMatch 'dotnet-reportgenerator-globaltool') {
+          dotnet tool update -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        }
+        else {
+          dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        }
+
+        if (-not (Test-Path artifacts)) {
+          Write-Warning 'No artifacts directory found; skipping report generation.'
+          exit 0
+        }
+        $reports = @(
+          Get-ChildItem -Path artifacts -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName }
+        )
+        if ($reports.Count -eq 0) {
+          Write-Warning 'No cobertura reports found; skipping report generation.'
+          exit 0
+        }
+        $reportsArg = ($reports -join ';')
+        New-Item -ItemType Directory -Force -Path artifacts/coverage | Out-Null
+        reportgenerator `
+          "-reports:$reportsArg" `
+          -targetdir:artifacts/coverage `
+          -reporttypes:'Cobertura;HtmlInline;MarkdownSummaryGithub' `
+          -title:'madowaku'
+        if (Test-Path artifacts/coverage/SummaryGithub.md) {
+          Get-Content artifacts/coverage/SummaryGithub.md |
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY
+        }
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: artifacts/coverage
+        if-no-files-found: warn
+        retention-days: 14
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        files: artifacts/coverage/Cobertura.xml
+        fail_ci_if_error: true
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload raw logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ _TeamCity*
 coverage*.json
 coverage*.xml
 coverage*.info
+!.config/coverage.settings.xml
 
 # Visual Studio code coverage results
 *.coverage

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.242" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="KlutzyNinja.Touki" Version="0.2.0-alpha.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.14.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/madowaku.tests/madowaku.tests.csproj
+++ b/madowaku.tests/madowaku.tests.csproj
@@ -18,9 +18,6 @@
 
     <!-- Use the Microsoft Testing Platform -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
-
-    <!-- This will no longer be needed for the .NET 10 SDK -->
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/madowaku.tests/madowaku.tests.csproj
+++ b/madowaku.tests/madowaku.tests.csproj
@@ -18,6 +18,9 @@
 
     <!-- Use the Microsoft Testing Platform -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    <!-- This will no longer be needed for the .NET 10 SDK -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/madowaku.tests/madowaku.tests.csproj
+++ b/madowaku.tests/madowaku.tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector"/>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>

--- a/madowaku.tests/madowaku.tests.csproj
+++ b/madowaku.tests/madowaku.tests.csproj
@@ -21,7 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector"/>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
     <PackageReference Include="xunit.v3"/>
     <PackageReference Include="AwesomeAssertions" />


### PR DESCRIPTION
Set up code coverage in CI, mirroring the touki repo's configuration.

## Changes

- **`.config/coverage.settings.xml`**: Microsoft.CodeCoverage settings restricting collection to `madowaku.dll`, excluding the test assembly, `[ExcludeFromCodeCoverage]`, and `[GeneratedCode]`.
- **`Directory.Packages.props`**: Pins `Microsoft.Testing.Extensions.CodeCoverage` 17.14.2.
- **`madowaku.tests/madowaku.tests.csproj`**: References the coverage package with `PrivateAssets="all"`.
- **`.gitignore`**: Adds a `!.config/coverage.settings.xml` exception so the settings file is tracked.
- **`.github/workflows/dotnet.yml`**: Release test run collects Cobertura coverage. New steps install ReportGenerator, produce Cobertura/HTML/MarkdownSummary, append the summary to `GITHUB_STEP_SUMMARY`, upload the report as a `coverage-report` artifact, and publish to Codecov via `codecov/codecov-action@v5`.

## Prerequisites

- Repo needs a `CODECOV_TOKEN` secret. The Codecov step uses `fail_ci_if_error: true` (matching touki), so without the token the workflow will fail.

Verified locally: `dotnet test -c Release` with the new flags produces a `*.cobertura.xml`.