### PR TITLE
Add Foundation tests and scope coverage to authored code

### DIFF
--- a/.config/coverage.settings.xml
+++ b/.config/coverage.settings.xml
@@ -12,8 +12,25 @@
     <Attributes>
       <Exclude>
         <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
-        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <!--
+         Do NOT exclude GeneratedCodeAttribute. CsWin32 emits user-authored partial
+         structs (BSTR, HRESULT, FILETIME, VARIANT, etc.) alongside a generated
+         partial decorated with [GeneratedCode]. Excluding the attribute drops
+         coverage of the user-authored partial too. Generated source files are
+         filtered out via the <Sources> exclude below instead.
+        -->
       </Exclude>
     </Attributes>
+    <Sources>
+      <Exclude>
+        <!--
+         Drop source-generator output (CsWin32, ResxSourceGenerator, etc.) so
+         coverage measures only hand-written madowaku code. This filters at line
+         level, leaving the user-authored half of each partial intact.
+        -->
+        <Source>.*[\\/]obj[\\/].*</Source>
+        <Source>.*\.g\.cs$</Source>
+      </Exclude>
+    </Sources>
   </CodeCoverage>
 </Configuration>

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,6 +73,9 @@ jobs:
         }
         $reportsArg = ($reports -join ';')
         New-Item -ItemType Directory -Force -Path artifacts/coverage | Out-Null
+        # Source-generator output (CsWin32, ResxSourceGenerator, etc.) is
+        # filtered out at collection time via .config/coverage.settings.xml so
+        # coverage reflects only hand-written madowaku source.
         reportgenerator `
           "-reports:$reportsArg" `
           -targetdir:artifacts/coverage `

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ﻿# Madowaku (窓枠): Win32 CsWin32 support for .NET and .NET Framework
 
 [![Build](https://github.com/JeremyKuhne/madowaku/actions/workflows/dotnet.yml/badge.svg)](https://github.com/JeremyKuhne/madowaku/actions/workflows/dotnet.yml)
+[![codecov](https://codecov.io/gh/JeremyKuhne/madowaku/branch/main/graph/badge.svg)](https://codecov.io/gh/JeremyKuhne/madowaku)
 [![NuGet](https://img.shields.io/nuget/v/KlutzyNinja.Madowaku.svg)](https://www.nuget.org/packages/KlutzyNinja.Madowaku/)
 
 Provides useful Win32 functionality based on both for .NET and .NET Framework applications.

--- a/madowaku.tests/Windows/Win32/Foundation/BSTRTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/BSTRTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.Foundation;
+
+public class BSTRTests
+{
+    [Fact]
+    public void Constructor_ManagedString_RoundTripsValue()
+    {
+        using BSTR bstr = new("hello");
+        Assert.False(bstr.IsNull);
+        Assert.Equal("hello", bstr.ToString());
+    }
+
+    [Fact]
+    public void IsNull_DefaultInstance_ReturnsTrue()
+    {
+        BSTR bstr = default;
+        Assert.True(bstr.IsNull);
+    }
+
+    [Fact]
+    public void ToStringAndFree_ReturnsValueAndFrees()
+    {
+        BSTR bstr = new("disposable");
+        string result = bstr.ToStringAndFree();
+        Assert.Equal("disposable", result);
+        Assert.True(bstr.IsNull);
+    }
+
+    [Fact]
+    public void Dispose_ClearsPointer()
+    {
+        BSTR bstr = new("clear me");
+        bstr.Dispose();
+        Assert.True(bstr.IsNull);
+    }
+
+    [Fact]
+    public void TryFormat_DestinationLargeEnough_WritesAllChars()
+    {
+        using BSTR bstr = new("abc");
+        Span<char> buffer = stackalloc char[8];
+        bool result = bstr.TryFormat(buffer, out int written, default, null);
+        Assert.True(result);
+        Assert.Equal(3, written);
+        Assert.Equal("abc", buffer[..written].ToString());
+    }
+
+    [Fact]
+    public void TryFormat_DestinationTooSmall_ReturnsFalse()
+    {
+        using BSTR bstr = new("abcdef");
+        Span<char> buffer = stackalloc char[3];
+        bool result = bstr.TryFormat(buffer, out int written, default, null);
+        Assert.False(result);
+        Assert.Equal(0, written);
+    }
+
+    [Fact]
+    public void ToStringWithFormat_IgnoresFormatAndProvider()
+    {
+        using BSTR bstr = new("value");
+        Assert.Equal("value", bstr.ToString("X", null));
+    }
+}

--- a/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.Foundation;
+
+public class ErrorTests
+{
+    [Fact]
+    public void ToHRESULT_Success_ReturnsZero()
+    {
+        HRESULT hr = WIN32_ERROR.ERROR_SUCCESS.ToHRESULT();
+        Assert.Equal(0, hr.Value);
+    }
+
+    [Fact]
+    public void ToHRESULT_NonSuccess_SetsFacilityWin32()
+    {
+        HRESULT hr = WIN32_ERROR.ERROR_ACCESS_DENIED.ToHRESULT();
+        Assert.Equal(unchecked((int)0x80070005), hr.Value);
+    }
+
+    [Fact]
+    public void ErrorToString_Success_StartsWithErrorSuccess()
+    {
+        string text = WIN32_ERROR.ERROR_SUCCESS.ErrorToString();
+        Assert.StartsWith("ERROR_SUCCESS", text);
+    }
+
+    [Fact]
+    public void ErrorToString_KnownError_IncludesEnumName()
+    {
+        string text = WIN32_ERROR.ERROR_FILE_NOT_FOUND.ErrorToString();
+        Assert.Contains("ERROR_FILE_NOT_FOUND", text);
+    }
+
+    [Fact]
+    public void GetException_FileNotFound_ReturnsFileNotFoundException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_FILE_NOT_FOUND.GetException("foo.txt");
+        Assert.IsType<FileNotFoundException>(ex);
+    }
+
+    [Fact]
+    public void GetException_PathNotFound_ReturnsDirectoryNotFoundException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_PATH_NOT_FOUND.GetException();
+        Assert.IsType<DirectoryNotFoundException>(ex);
+    }
+
+    [Fact]
+    public void GetException_AccessDenied_ReturnsUnauthorizedAccessException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_ACCESS_DENIED.GetException();
+        Assert.IsType<UnauthorizedAccessException>(ex);
+    }
+
+    [Fact]
+    public void GetException_InvalidParameter_ReturnsArgumentException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_INVALID_PARAMETER.GetException();
+        Assert.IsType<ArgumentException>(ex);
+    }
+
+    [Fact]
+    public void GetException_NotSupported_ReturnsNotSupportedException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_NOT_SUPPORTED.GetException();
+        Assert.IsType<NotSupportedException>(ex);
+    }
+
+    [Fact]
+    public void Throw_AlwaysThrows()
+    {
+        Assert.Throws<FileNotFoundException>(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.Throw());
+    }
+
+    [Fact]
+    public void ThrowIfFailed_Success_DoesNotThrow()
+    {
+        WIN32_ERROR.ERROR_SUCCESS.ThrowIfFailed();
+    }
+
+    [Fact]
+    public void ThrowIfFailed_Failure_Throws()
+    {
+        Assert.Throws<FileNotFoundException>(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.ThrowIfFailed());
+    }
+}

--- a/madowaku.tests/Windows/Win32/Foundation/FILETIMETests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/FILETIMETests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.Foundation;
+
+public class FILETIMETests
+{
+    [Fact]
+    public void ExplicitCast_DateTimeRoundTrip_PreservesValue()
+    {
+        DateTime original = new DateTime(2025, 5, 11, 13, 45, 30, DateTimeKind.Utc).ToLocalTime();
+        FILETIME ft = (FILETIME)original;
+        DateTime roundTripped = (DateTime)ft;
+        Assert.Equal(original, roundTripped);
+    }
+
+    [Fact]
+    public void ExplicitCast_FromDateTime_PopulatesLowAndHighParts()
+    {
+        DateTime value = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
+        FILETIME ft = (FILETIME)value;
+        long combined = ((long)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+        Assert.Equal(value.ToFileTime(), combined);
+    }
+}

--- a/madowaku.tests/Windows/Win32/Foundation/HRESULTTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HRESULTTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.System.Diagnostics.Debug;
+
+namespace Windows.Win32.Foundation;
+
+public class HRESULTTests
+{
+    [Fact]
+    public void Code_ReturnsLowSixteenBits()
+    {
+        HRESULT hr = (HRESULT)unchecked((int)0x80070005);
+        Assert.Equal(0x0005, hr.Code);
+    }
+
+    [Fact]
+    public void Facility_ReturnsExpectedFacility()
+    {
+        HRESULT hr = (HRESULT)unchecked((int)0x80070005);
+        Assert.Equal(FACILITY_CODE.FACILITY_WIN32, hr.Facility);
+    }
+
+    [Fact]
+    public void ExplicitCastFromWin32Error_Success_ReturnsZero()
+    {
+        HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_SUCCESS;
+        Assert.Equal(0, hr.Value);
+    }
+
+    [Fact]
+    public void ExplicitCastFromWin32Error_NonZero_SetsFacilityWin32AndSeverityBit()
+    {
+        HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND;
+        Assert.Equal(unchecked((int)0x80070002), hr.Value);
+        Assert.Equal(FACILITY_CODE.FACILITY_WIN32, hr.Facility);
+        Assert.Equal((int)WIN32_ERROR.ERROR_FILE_NOT_FOUND, hr.Code);
+    }
+
+    [Fact]
+    public void ImplicitCastToException_FailingHResult_ReturnsException()
+    {
+        Exception ex = HRESULT.COR_E_ARGUMENT;
+        Assert.NotNull(ex);
+    }
+
+    [Fact]
+    public void ToStringWithDescription_Win32Facility_ContainsErrorName()
+    {
+        HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND;
+        string text = hr.ToStringWithDescription();
+        Assert.Contains("0x80070002", text);
+        Assert.Contains("ERROR_FILE_NOT_FOUND", text);
+    }
+
+    [Fact]
+    public void ToStringWithDescription_NonWin32Facility_ContainsHexValue()
+    {
+        string text = HRESULT.COR_E_OBJECTDISPOSED.ToStringWithDescription();
+        Assert.Contains("0x80131622", text);
+    }
+}


### PR DESCRIPTION
Adds Foundation unit tests and tightens the coverage filter so reported numbers reflect only hand-written madowaku code.

## Tests

Four new test files covering `madowaku/Windows/Win32/Foundation/`:

- `BSTRTests` &mdash; ctor, `IsNull`, `Dispose`, `ToStringAndFree`, `TryFormat` (success / too-small destination), `IFormattable.ToString`.
- `HRESULTTests` &mdash; `Code`, `Facility`, `(HRESULT)WIN32_ERROR` cast, implicit `Exception` cast, `ToStringWithDescription` for Win32 / non-Win32 facilities.
- `FILETIMETests` &mdash; `DateTime` round-trip and low/high decomposition.
- `ErrorTests` &mdash; `ToHRESULT`, `ErrorToString`, `GetException` mappings (FileNotFound, PathNotFound, AccessDenied, InvalidParameter, NotSupported), `Throw`, `ThrowIfFailed`.

Total test count goes from 22 to 78 (39 per TFM).

## Coverage scoping

- `.config/coverage.settings.xml`: drop the `GeneratedCodeAttribute` exclude (it was hiding the user-authored half of every CsWin32 partial &mdash; `BSTR`, `HRESULT`, `FILETIME`, `PWSTR`, `VARIANT`, etc.). Add a `<Sources><Exclude>` that drops `**/obj/**` and `*.g.cs` at collection time so generator output isn't counted.
- `.github/workflows/dotnet.yml`: no per-partial file-filter list needed any more; ReportGenerator runs against the already-filtered cobertura.

## Resulting metrics (Release, both TFMs)

| Metric | Coverage |
|---|---|
| Line | 17.8% (168 / 941) |
| Branch | 20.1% (92 / 457) |
| Method | 30.1% (48 / 159) |

Per-class highlights: `BSTR`, `FILETIME`, `HRESULT`, `PWSTR` at 100%; `Error` 74.3%; `StringParameterArray` 37.5%; `VARIANT` 13.2%; remaining COM helpers and polyfills at 0% (work for follow-up PRs).

## README

Added a Codecov badge.