### PR TITLE
Expand test coverage for Foundation, COM, and Variant types

### DIFF
--- a/madowaku.tests/Windows/Win32/Foundation/HMODULETests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HMODULETests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.Foundation;
+
+public class HMODULETests
+{
+    [Fact]
+    public void GetLaunchingExecutable_ReturnsNonNullModule()
+    {
+        HMODULE module = HMODULE.GetLaunchingExecutable();
+        Assert.False(module.IsNull);
+    }
+
+    [Fact]
+    public void FromName_KnownSystemDll_ReturnsLoadedModule()
+    {
+        // kernel32 is always loaded in any Windows process.
+        HMODULE module = HMODULE.FromName("kernel32.dll");
+        Assert.False(module.IsNull);
+    }
+
+    [Fact]
+    public void FromName_UnknownModule_ReturnsNullHandle()
+    {
+        HMODULE module = HMODULE.FromName("definitely-not-a-real-module.dll");
+        Assert.True(module.IsNull);
+    }
+
+    [Fact]
+    public void LoadModule_KnownSystemDll_ReturnsModule()
+    {
+        HMODULE module = HMODULE.LoadModule("shell32.dll");
+        Assert.False(module.IsNull);
+    }
+
+    [Fact]
+    public void LoadModule_NonexistentPath_Throws()
+    {
+        Assert.ThrowsAny<Exception>(() => HMODULE.LoadModule("madowaku-no-such-file.dll"));
+    }
+
+    [Fact]
+    public void GetProcAddress_KnownExport_ReturnsNonNullAddress()
+    {
+        HMODULE module = HMODULE.FromName("kernel32.dll");
+        FARPROC proc = module.GetProcAddress("GetCurrentProcessId");
+        Assert.False(proc.IsNull);
+    }
+
+    [Fact]
+    public void GetProcAddress_UnknownExport_Throws()
+    {
+        HMODULE module = HMODULE.FromName("kernel32.dll");
+        Assert.ThrowsAny<Exception>(() => module.GetProcAddress("MadowakuNoSuchExport"));
+    }
+
+    [Fact]
+    public void GetDllVersion_Shell32_ReturnsVersion()
+    {
+        HMODULE module = HMODULE.LoadModule("shell32.dll");
+        Version version = module.GetDllVersion();
+        Assert.True(version.Major >= 5);
+    }
+
+    [Fact]
+    public unsafe void FromAddress_AddressInsideKernel32_ReturnsKernel32()
+    {
+        HMODULE kernel32 = HMODULE.FromName("kernel32.dll");
+        FARPROC proc = kernel32.GetProcAddress("GetCurrentProcessId");
+        HMODULE byAddress = HMODULE.FromAddress(proc.Value);
+        Assert.Equal(kernel32, byAddress);
+    }
+}

--- a/madowaku.tests/Windows/Win32/Foundation/HMODULETests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HMODULETests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.ComponentModel;
+
 namespace Windows.Win32.Foundation;
 
 public class HMODULETests
@@ -32,13 +34,26 @@ public class HMODULETests
     public void LoadModule_KnownSystemDll_ReturnsModule()
     {
         HMODULE module = HMODULE.LoadModule("shell32.dll");
-        Assert.False(module.IsNull);
+        try
+        {
+            Assert.False(module.IsNull);
+        }
+        finally
+        {
+            PInvokeMadowaku.FreeLibrary(module);
+        }
     }
 
     [Fact]
-    public void LoadModule_NonexistentPath_Throws()
+    public void LoadModule_NonexistentPath_ThrowsWin32Exception()
     {
-        Assert.ThrowsAny<Exception>(() => HMODULE.LoadModule("madowaku-no-such-file.dll"));
+        Win32Exception ex = Assert.Throws<Win32Exception>(
+            () => HMODULE.LoadModule("madowaku-no-such-file.dll"));
+
+        // ERROR_MOD_NOT_FOUND = 126, ERROR_FILE_NOT_FOUND = 2, ERROR_PATH_NOT_FOUND = 3
+        Assert.True(
+            ex.NativeErrorCode is 126 or 2 or 3,
+            $"Unexpected NativeErrorCode {ex.NativeErrorCode}");
     }
 
     [Fact]
@@ -50,18 +65,29 @@ public class HMODULETests
     }
 
     [Fact]
-    public void GetProcAddress_UnknownExport_Throws()
+    public void GetProcAddress_UnknownExport_ThrowsWin32Exception()
     {
         HMODULE module = HMODULE.FromName("kernel32.dll");
-        Assert.ThrowsAny<Exception>(() => module.GetProcAddress("MadowakuNoSuchExport"));
+        Win32Exception ex = Assert.Throws<Win32Exception>(
+            () => module.GetProcAddress("MadowakuNoSuchExport"));
+
+        // ERROR_PROC_NOT_FOUND = 127
+        Assert.Equal(127, ex.NativeErrorCode);
     }
 
     [Fact]
     public void GetDllVersion_Shell32_ReturnsVersion()
     {
         HMODULE module = HMODULE.LoadModule("shell32.dll");
-        Version version = module.GetDllVersion();
-        Assert.True(version.Major >= 5);
+        try
+        {
+            Version version = module.GetDllVersion();
+            Assert.True(version.Major >= 5);
+        }
+        finally
+        {
+            PInvokeMadowaku.FreeLibrary(module);
+        }
     }
 
     [Fact]

--- a/madowaku.tests/Windows/Win32/Foundation/StringParameterArrayTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/StringParameterArrayTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.Foundation;
+
+public class StringParameterArrayTests
+{
+    [Fact]
+    public unsafe void Constructor_NullArray_ProducesNullPointer()
+    {
+        using StringParameterArray array = new(null);
+        char** ptr = array;
+        Assert.True(ptr is null);
+    }
+
+    [Fact]
+    public unsafe void Constructor_EmptyArray_ProducesNullPointer()
+    {
+        using StringParameterArray array = new([]);
+        char** ptr = array;
+        Assert.True(ptr is null);
+    }
+
+    [Fact]
+    public unsafe void Constructor_PopulatedArray_PointersPointToPinnedStrings()
+    {
+        string[] values = ["alpha", "beta", "gamma"];
+        using StringParameterArray array = new(values);
+        char** ptr = array;
+        Assert.False(ptr is null);
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            string actual = new(ptr[i]);
+            Assert.Equal(values[i], actual);
+        }
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_SbyteDoublePointer_NonNullForPopulated()
+    {
+        string[] values = ["x"];
+        using StringParameterArray array = new(values);
+        sbyte** ptr = array;
+        Assert.False(ptr is null);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_SbyteDoublePointer_NullForEmpty()
+    {
+        using StringParameterArray array = new(null);
+        sbyte** ptr = array;
+        Assert.True(ptr is null);
+    }
+
+    [Fact]
+    public void Dispose_NullArray_DoesNotThrow()
+    {
+        StringParameterArray array = new(null);
+        array.Dispose();
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Com/CLSIDTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/CLSIDTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.System.Com;
+
+public class CLSIDTests
+{
+    [Fact]
+    public void StdGlobalInterfaceTable_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("00000323-0000-0000-c000-000000000046"), CLSID.StdGlobalInterfaceTable);
+    }
+
+    [Fact]
+    public void FileOpenDialog_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("dc1c5a9c-e88a-4dde-a5a1-60f82a20aef7"), CLSID.FileOpenDialog);
+    }
+
+    [Fact]
+    public void FileSaveDialog_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("c0b4e2f3-ba21-4773-8dba-335ec946eb8b"), CLSID.FileSaveDialog);
+    }
+
+    [Fact]
+    public void AutoComplete_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("00bb2763-6a77-11d0-a535-00c04fd7d062"), CLSID.AutoComplete);
+    }
+
+    [Fact]
+    public void DragDropHelper_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("4657278a-411b-11d2-839a-00c04fd918d0"), CLSID.DragDropHelper);
+    }
+
+    [Fact]
+    public void SetupConfiguration_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("177f0c4a-1cd3-4de7-a32c-71dbbb9fa36d"), CLSID.SetupConfiguration);
+    }
+
+    [Fact]
+    public void SetupConfiguration2_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("42843719-db4c-46c2-8e7c-64f1816efd5b"), CLSID.SetupConfiguration2);
+    }
+
+    [Fact]
+    public void StdComponentCategoriesManager_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("0002e005-0000-0000-c000-000000000046"), CLSID.StdComponentCategoriesManager);
+    }
+
+    [Fact]
+    public void WindowsMediaPlayer_HasExpectedGuid()
+    {
+        Assert.Equal(new Guid("6bf52a52-394a-11d3-b153-00c04f79faa6"), CLSID.WindowsMediaPlayer);
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.System.Com;
+
+namespace Windows.Win32.System.Com;
+
+public class ComScopeTests
+{
+    [Fact]
+    public unsafe void Constructor_NullPointer_IsNullTrue()
+    {
+        using ComScope<IUnknown> scope = new((IUnknown*)null);
+        Assert.True(scope.IsNull);
+        Assert.True(scope.Pointer is null);
+    }
+
+    [Fact]
+    public unsafe void Constructor_VoidNull_IsNullTrue()
+    {
+        using ComScope<IUnknown> scope = new((void*)null);
+        Assert.True(scope.IsNull);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_TStar_NullPointer_ReturnsNull()
+    {
+        using ComScope<IUnknown> scope = new((IUnknown*)null);
+        IUnknown* p = scope;
+        Assert.True(p is null);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_VoidStar_NullPointer_ReturnsNull()
+    {
+        using ComScope<IUnknown> scope = new((IUnknown*)null);
+        void* p = scope;
+        Assert.True(p is null);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_Nint_NullPointer_ReturnsZero()
+    {
+        using ComScope<IUnknown> scope = new((IUnknown*)null);
+        nint p = scope;
+        Assert.Equal(0, p);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_TStarStar_NonNull()
+    {
+        using ComScope<IUnknown> scope = new((IUnknown*)null);
+        IUnknown** pp = scope;
+        Assert.False(pp is null);
+    }
+
+    [Fact]
+    public unsafe void Dispose_NullPointer_DoesNotThrow()
+    {
+        ComScope<IUnknown> scope = new((IUnknown*)null);
+        scope.Dispose();
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using Windows.Win32.System.Com;
-
 namespace Windows.Win32.System.Com;
 
 public class ComScopeTests

--- a/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.System.Com;
+
+public class SafeArrayScopeTests
+{
+    [Fact]
+    public void Constructor_IntSize_CreatesSafeArray()
+    {
+        using SafeArrayScope<int> array = new(3);
+        unsafe { Assert.False(array.Value is null); }
+    }
+
+    [Fact]
+    public void Indexer_Int_RoundTripsValues()
+    {
+        using SafeArrayScope<int> array = new(3);
+        array[0] = 10;
+        array[1] = 20;
+        array[2] = 30;
+        Assert.Equal(10, array[0]);
+        Assert.Equal(20, array[1]);
+        Assert.Equal(30, array[2]);
+    }
+
+    [Fact]
+    public void Constructor_FromIntArray_PopulatesValues()
+    {
+        using SafeArrayScope<int> array = new([1, 2, 3, 4]);
+        Assert.Equal(1, array[0]);
+        Assert.Equal(4, array[3]);
+    }
+
+    [Fact]
+    public void Indexer_String_RoundTripsValues()
+    {
+        using SafeArrayScope<string> array = new(2);
+        array[0] = "alpha";
+        array[1] = "beta";
+        Assert.Equal("alpha", array[0]);
+        Assert.Equal("beta", array[1]);
+    }
+
+    [Fact]
+    public void Indexer_Double_RoundTripsValues()
+    {
+        using SafeArrayScope<double> array = new(2);
+        array[0] = 1.5;
+        array[1] = 2.5;
+        Assert.Equal(1.5, array[0]);
+        Assert.Equal(2.5, array[1]);
+    }
+
+    [Fact]
+    public void Constructor_UnsupportedType_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => new SafeArrayScope<byte>(1));
+    }
+
+    [Fact]
+    public void Constructor_NintType_ThrowsWithComSafeArrayScopeMessage()
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => new SafeArrayScope<nint>(1));
+        Assert.Contains("ComSafeArrayScope", ex.Message);
+    }
+
+    [Fact]
+    public unsafe void Constructor_NullSafearrayPointer_ValueIsNull()
+    {
+        using SafeArrayScope<int> array = new((SAFEARRAY*)null);
+        Assert.True(array.Value is null);
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantConversionTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantConversionTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Com;
+
+namespace Windows.Win32.System.Variant;
+
+public class VariantConversionTests
+{
+    [Fact]
+    public void StringExplicitCast_RoundTrip()
+    {
+        VARIANT v = (VARIANT)"hello";
+        Assert.Equal(VARENUM.VT_BSTR, v.vt);
+        Assert.Equal("hello", (string)v);
+        v.Dispose();
+    }
+
+    [Fact]
+    public void DoubleExplicitCast_ProducesR8Variant()
+    {
+        VARIANT v = (VARIANT)3.14;
+        Assert.Equal(VARENUM.VT_R8, v.vt);
+        Assert.Equal(3.14, v.data.dblVal);
+    }
+
+    [Fact]
+    public unsafe void IDispatchPointer_NullRoundTrip()
+    {
+        VARIANT v = (VARIANT)(IDispatch*)null;
+        Assert.Equal(VARENUM.VT_DISPATCH, v.vt);
+        Assert.True((IDispatch*)v is null);
+    }
+
+    [Fact]
+    public unsafe void InvalidIDispatchCast_Throws()
+    {
+        VARIANT v = VARIANT.Empty;
+        Assert.Throws<InvalidCastException>(() => { IDispatch* _ = (IDispatch*)v; });
+    }
+
+    [Fact]
+    public void FromObject_Null_ReturnsEmpty()
+    {
+        VARIANT v = VARIANT.FromObject(null);
+        Assert.True(v.IsEmpty);
+    }
+
+    [Fact]
+    public void FromObject_String_ReturnsBstrVariant()
+    {
+        VARIANT v = VARIANT.FromObject("text");
+        Assert.Equal(VARENUM.VT_BSTR, v.vt);
+        Assert.Equal("text", (string)v);
+        v.Dispose();
+    }
+
+    [Fact]
+    public void FromObject_Int_ReturnsI4Variant()
+    {
+        VARIANT v = VARIANT.FromObject(123);
+        Assert.Equal(VARENUM.VT_I4, v.vt);
+        Assert.Equal(123, (int)v);
+    }
+
+    [Fact]
+    public void FromObject_UInt_ReturnsUI4Variant()
+    {
+        VARIANT v = VARIANT.FromObject(456u);
+        Assert.Equal(VARENUM.VT_UI4, v.vt);
+        Assert.Equal(456u, (uint)v);
+    }
+
+    [Fact]
+    public void FromObject_Short_ProducesI4VariantViaImplicitWidening()
+    {
+        // FromObject branches on `is short` but `(VARIANT)shortValue` has no short operator,
+        // so the value widens to int and goes through the int operator → VT_I4.
+        VARIANT v = VARIANT.FromObject((short)7);
+        Assert.Equal(VARENUM.VT_I4, v.vt);
+        Assert.Equal(7, (int)v);
+    }
+
+    [Fact]
+    public void FromObject_Bool_ReturnsBoolVariant()
+    {
+        VARIANT v = VARIANT.FromObject(true);
+        Assert.Equal(VARENUM.VT_BOOL, v.vt);
+        Assert.True((bool)v);
+    }
+
+    [Fact]
+    public void FromObject_Double_ReturnsR8Variant()
+    {
+        VARIANT v = VARIANT.FromObject(2.5);
+        Assert.Equal(VARENUM.VT_R8, v.vt);
+    }
+
+    [Fact]
+    public void ToObject_Decimal_ReturnsDecimal()
+    {
+        VARIANT v = new();
+        v.Anonymous.decVal = new(100.5m);
+        v.vt |= VARENUM.VT_DECIMAL;
+        Assert.Equal(100.5m, v.ToObject());
+    }
+
+    [Fact]
+    public void ToObject_Int_ReturnsInt()
+    {
+        VARIANT v = (VARIANT)42;
+        Assert.Equal(42, v.ToObject());
+    }
+
+    [Fact]
+    public void ToObject_Bool_ReturnsBool()
+    {
+        VARIANT v = (VARIANT)true;
+        Assert.Equal(true, v.ToObject());
+    }
+
+    [Fact]
+    public void ToObject_String_ReturnsString()
+    {
+        VARIANT v = (VARIANT)"abc";
+        Assert.Equal("abc", v.ToObject());
+        v.Dispose();
+    }
+
+    [Fact]
+    public void GetManagedType_AllScalarTypes_ReturnsExpected()
+    {
+        Assert.Equal(typeof(sbyte), VARIANT.GetManagedType(VARENUM.VT_I1));
+        Assert.Equal(typeof(byte), VARIANT.GetManagedType(VARENUM.VT_UI1));
+        Assert.Equal(typeof(short), VARIANT.GetManagedType(VARENUM.VT_I2));
+        Assert.Equal(typeof(ushort), VARIANT.GetManagedType(VARENUM.VT_UI2));
+        Assert.Equal(typeof(long), VARIANT.GetManagedType(VARENUM.VT_I8));
+        Assert.Equal(typeof(ulong), VARIANT.GetManagedType(VARENUM.VT_UI8));
+        Assert.Equal(typeof(float), VARIANT.GetManagedType(VARENUM.VT_R4));
+        Assert.Equal(typeof(double), VARIANT.GetManagedType(VARENUM.VT_R8));
+        Assert.Equal(typeof(int), VARIANT.GetManagedType(VARENUM.VT_ERROR));
+        Assert.Equal(typeof(decimal), VARIANT.GetManagedType(VARENUM.VT_CY));
+        Assert.Equal(typeof(DateTime), VARIANT.GetManagedType(VARENUM.VT_DATE));
+        Assert.Equal(typeof(DateTime), VARIANT.GetManagedType(VARENUM.VT_FILETIME));
+        Assert.Equal(typeof(string), VARIANT.GetManagedType(VARENUM.VT_LPSTR));
+        Assert.Equal(typeof(string), VARIANT.GetManagedType(VARENUM.VT_LPWSTR));
+        Assert.Equal(typeof(VARIANT), VARIANT.GetManagedType(VARENUM.VT_VARIANT));
+        Assert.Equal(typeof(Guid), VARIANT.GetManagedType(VARENUM.VT_CLSID));
+        Assert.Equal(typeof(byte[]), VARIANT.GetManagedType(VARENUM.VT_BLOB));
+        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_DISPATCH));
+    }
+
+    [Fact]
+    public void GetManagedType_ArrayTypes_ReturnsArrayType()
+    {
+        Assert.Equal(typeof(byte[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_UI1));
+        Assert.Equal(typeof(short[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_I2));
+        Assert.Equal(typeof(double[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_R8));
+        Assert.Equal(typeof(bool[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BOOL));
+        Assert.Equal(typeof(string[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BSTR));
+        Assert.Equal(typeof(Guid[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_CLSID));
+        Assert.Equal(typeof(decimal[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_DECIMAL));
+        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_DISPATCH));
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantConversionTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantConversionTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
 
 namespace Windows.Win32.System.Variant;


### PR DESCRIPTION
Adds tests covering more of the hand-written madowaku surface.

## New tests

- `HMODULETests` — `GetLaunchingExecutable`, `FromName` (success / unknown), `LoadModule` (success / nonexistent), `GetProcAddress` (success / unknown), `GetDllVersion`, `FromAddress`.
- `StringParameterArrayTests` — null / empty / populated `char**` and `sbyte**` paths, `Dispose` on null.
- `CLSIDTests` — verifies all nine well-known CLSID GUIDs.
- `ComScopeTests` — null construction, all implicit operator paths, `Dispose` on null.
- `SafeArrayScopeTests` — int / string / double indexer round-trips, array-ctor population, unsupported type, `nint` "use ComSafeArrayScope" diagnostic, null SAFEARRAY pointer.
- `VariantConversionTests` — string / double / IDispatch pointer operators, `FromObject` paths (null, string, int, uint, short→widen, bool, double), `ToObject` for decimal/int/bool/string, `GetManagedType` for the full scalar and array tables.

## Coverage (Release, both TFMs)

| Metric | Before | After |
|---|---|---|
| Line | 17.8% | **40.1%** |
| Branch | 20.1% | **42.2%** |
| Method | 30.1% | **60.3%** |

Per-class movements: `HMODULE` 0→93%, `CLSID` 0→100%, `StringParameterArray` 38→100%, `ComScope<T>` 0→62%, `SafeArrayScope<T>` 0→55%, `SAFEARRAY` 0→33%, `VARIANT` 13→28%.