### PR TITLE
Enable TreatWarningsAsErrors and fix surfaced diagnostics

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,18 @@
     <LangVersion>14</LangVersion>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Surface .editorconfig IDE rules (unused usings, type simplification, etc.) as build diagnostics. -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!--
+      Treat all compiler/analyzer warnings as build errors so style and correctness issues fail fast.
+      Exclude the NuGet audit / deprecation codes (NU1900-NU1904) so an upstream package advisory
+      cannot break CI without a source change. The advisories still appear as warnings in the build
+      log; act on them by upgrading or replacing the package, not by ignoring them.
+    -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
@@ -72,4 +72,44 @@ public class SafeArrayScopeTests
         using SafeArrayScope<int> array = new((SAFEARRAY*)null);
         Assert.True(array.Value is null);
     }
+
+    [Fact]
+    public unsafe void Constructor_WrapVT_I4_Succeeds()
+    {
+        using SafeArrayScope<int> source = new(2);
+        source[0] = 7;
+        source[1] = 8;
+
+        // Wrap the existing VT_I4 SAFEARRAY in a new scope — must not throw.
+        SafeArrayScope<int> wrapped = new(source.Value);
+        Assert.Equal(7, wrapped[0]);
+        Assert.Equal(8, wrapped[1]);
+    }
+
+    [Fact]
+    public unsafe void Constructor_TypeMismatch_ForInt_Throws()
+    {
+        // VT_BSTR SAFEARRAY wrapped as SafeArrayScope<int> must throw.
+        using SafeArrayScope<string> source = new(1);
+        SAFEARRAY* ptr = source.Value;
+        ArgumentException ex = Assert.Throws<ArgumentException>(
+            () => new SafeArrayScope<int>(ptr));
+        Assert.Contains("VarType=", ex.Message);
+    }
+
+    [Fact]
+    public unsafe void Constructor_TypeMismatch_ForString_Throws()
+    {
+        using SafeArrayScope<int> source = new(1);
+        SAFEARRAY* ptr = source.Value;
+        Assert.Throws<ArgumentException>(() => new SafeArrayScope<string>(ptr));
+    }
+
+    [Fact]
+    public unsafe void Constructor_TypeMismatch_ForDouble_Throws()
+    {
+        using SafeArrayScope<int> source = new(1);
+        SAFEARRAY* ptr = source.Value;
+        Assert.Throws<ArgumentException>(() => new SafeArrayScope<double>(ptr));
+    }
 }

--- a/madowaku/GlobalSuppressions.cs
+++ b/madowaku/GlobalSuppressions.cs
@@ -1,5 +1,3 @@
 ﻿// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
-
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.Cache`1.t_localItem")]

--- a/madowaku/Windows/Win32/System/Com/SafeArrayScope.cs
+++ b/madowaku/Windows/Win32/System/Com/SafeArrayScope.cs
@@ -61,7 +61,7 @@ public readonly unsafe ref struct SafeArrayScope<T>
         }
         else if (typeof(T) == typeof(int))
         {
-            if (value->VarType is not VARENUM.VT_I4 or VARENUM.VT_INT)
+            if (value->VarType is not (VARENUM.VT_I4 or VARENUM.VT_INT))
             {
                 throw new ArgumentException($"Wanted SafeArrayScope<{typeof(T)}> but got SAFEARRAY with VarType={value->VarType}");
             }


### PR DESCRIPTION
Adopt touki's pattern (PR touki#113): set `TreatWarningsAsErrors=true` and `EnforceCodeStyleInBuild=true` in `Directory.Build.props` so compiler/analyzer/IDE diagnostics fail the build. Exclude NU1900-NU1904 via `WarningsNotAsErrors` so an upstream NuGet advisory cannot break CI without a source change.

## Diagnostics that surfaced

- **CS9336** (redundant pattern) in `SafeArrayScope`: `is not VT_I4 or VT_INT` parsed as `(is not VT_I4) or (is VT_INT)`, which would have thrown on a valid `VT_INT` SAFEARRAY. Fixed by adding parentheses: `is not (VT_I4 or VT_INT)`. Real bug surfaced by the rule.
- **IDE0076** (invalid `SuppressMessage` target) in `GlobalSuppressions.cs`: drop the stale `Touki.Cache\`1.t_localItem` suppression copied from touki — the target doesn't exist in madowaku.

Release + Debug build clean, 190 tests pass on both TFMs.