### PR TITLE
Drive Error / HMODULE / AgileComPointer / ComClassFactory tests toward 100%

### DIFF
--- a/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.ComponentModel;
+
 namespace Windows.Win32.Foundation;
 
 public class ErrorTests
@@ -85,5 +87,84 @@ public class ErrorTests
     public void ThrowIfFailed_Failure_Throws()
     {
         Assert.Throws<FileNotFoundException>(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.ThrowIfFailed());
+    }
+
+    [Fact]
+    public void GetException_FilenameExcededRange_ReturnsPathTooLongException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_FILENAME_EXCED_RANGE.GetException();
+        Assert.IsType<PathTooLongException>(ex);
+    }
+
+    [Fact]
+    public void GetException_InvalidDrive_ReturnsDriveNotFoundException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_INVALID_DRIVE.GetException();
+        Assert.IsType<DriveNotFoundException>(ex);
+    }
+
+    [Fact]
+    public void GetException_OperationAborted_ReturnsOperationCanceledException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_OPERATION_ABORTED.GetException();
+        Assert.IsType<OperationCanceledException>(ex);
+    }
+
+    [Fact]
+    public void GetException_Cancelled_ReturnsOperationCanceledException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_CANCELLED.GetException();
+        Assert.IsType<OperationCanceledException>(ex);
+    }
+
+    [Fact]
+    public void GetException_NetworkAccessDenied_ReturnsUnauthorizedAccessException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_NETWORK_ACCESS_DENIED.GetException();
+        Assert.IsType<UnauthorizedAccessException>(ex);
+    }
+
+    [Fact]
+    public void GetException_NotReady_ReturnsWin32Exception()
+    {
+        Exception ex = WIN32_ERROR.ERROR_NOT_READY.GetException();
+        Assert.IsType<Win32Exception>(ex);
+    }
+
+    [Fact]
+    public void GetException_FileExists_ReturnsWin32Exception()
+    {
+        Exception ex = WIN32_ERROR.ERROR_FILE_EXISTS.GetException();
+        Assert.IsType<Win32Exception>(ex);
+    }
+
+    [Fact]
+    public void GetException_AlreadyExists_ReturnsWin32Exception()
+    {
+        Exception ex = WIN32_ERROR.ERROR_ALREADY_EXISTS.GetException();
+        Assert.IsType<Win32Exception>(ex);
+    }
+
+    [Fact]
+    public void GetException_NotSupportedInAppContainer_ReturnsNotSupportedException()
+    {
+        Exception ex = WIN32_ERROR.ERROR_NOT_SUPPORTED_IN_APPCONTAINER.GetException();
+        Assert.IsType<NotSupportedException>(ex);
+    }
+
+    [Fact]
+    public void GetException_UnknownError_ReturnsWin32Exception()
+    {
+        Exception ex = ((WIN32_ERROR)9999).GetException();
+        Assert.IsType<Win32Exception>(ex);
+    }
+
+    [Fact]
+    public void ThrowIfLastErrorNot_LastErrorMatches_DoesNotThrow()
+    {
+        // Read the current last-error so the test doesn't depend on prior state, then assert
+        // ThrowIfLastErrorNot matches it.
+        WIN32_ERROR current = Error.GetLastError();
+        Error.ThrowIfLastErrorNot(current);
     }
 }

--- a/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
@@ -90,7 +90,7 @@ public class ErrorTests
     }
 
     [Fact]
-    public void GetException_FilenameExcededRange_ReturnsPathTooLongException()
+    public void GetException_FilenameExcedRange_ReturnsPathTooLongException()
     {
         Exception ex = WIN32_ERROR.ERROR_FILENAME_EXCED_RANGE.GetException();
         Assert.IsType<PathTooLongException>(ex);

--- a/madowaku.tests/Windows/Win32/System/Com/AgileComPointerTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/AgileComPointerTests.cs
@@ -62,4 +62,41 @@ public class AgileComPointerTests
             agile.Dispose();
         }
     }
+
+    [Fact]
+    public unsafe void GetInterface_Generic_RequeriesAsSameInterface_Succeeds()
+    {
+        using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
+        using ComScope<IUnknown> source = factory.CreateInstance<IUnknown>();
+
+        AgileComPointer<IUnknown> agile = new(source.Pointer, takeOwnership: false);
+        try
+        {
+            using ComScope<IUnknown> scope = agile.GetInterface<IUnknown>();
+            Assert.False(scope.IsNull);
+        }
+        finally
+        {
+            agile.Dispose();
+        }
+    }
+
+    [Fact]
+    public unsafe void TryGetInterface_Generic_RequeriesAsSameInterface_Succeeds()
+    {
+        using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
+        using ComScope<IUnknown> source = factory.CreateInstance<IUnknown>();
+
+        AgileComPointer<IUnknown> agile = new(source.Pointer, takeOwnership: false);
+        try
+        {
+            using ComScope<IUnknown> scope = agile.TryGetInterface<IUnknown>(out HRESULT hr);
+            Assert.True(hr.Succeeded);
+            Assert.False(scope.IsNull);
+        }
+        finally
+        {
+            agile.Dispose();
+        }
+    }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/ComClassFactoryTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComClassFactoryTests.cs
@@ -44,4 +44,26 @@ public class ComClassFactoryTests
         Assert.True(hr.Succeeded);
         Assert.False(requeried.IsNull);
     }
+
+    [Fact]
+    public void Constructor_FilePath_NonexistentDll_Throws()
+    {
+        Assert.ThrowsAny<Exception>(
+            () => new ComClassFactory("madowaku-no-such-dll.dll", CLSID.FileOpenDialog));
+    }
+
+    [Fact]
+    public unsafe void Constructor_Hmodule_KnownExport_ExposesClassId()
+    {
+        // Get the module that already provides StdGlobalInterfaceTable's exports.
+        // ole32.dll exports DllGetClassObject and the StdGlobalInterfaceTable CLSID.
+        HMODULE ole32 = HMODULE.FromName("ole32.dll");
+        Assert.False(ole32.IsNull);
+
+        using ComClassFactory factory = new(ole32, CLSID.StdGlobalInterfaceTable);
+        Assert.Equal(CLSID.StdGlobalInterfaceTable, factory.ClassId);
+
+        using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
+        Assert.False(unknown.IsNull);
+    }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/ComClassFactoryTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComClassFactoryTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.ComponentModel;
 using Windows.Win32.Foundation;
 
 namespace Windows.Win32.System.Com;
@@ -46,24 +47,34 @@ public class ComClassFactoryTests
     }
 
     [Fact]
-    public void Constructor_FilePath_NonexistentDll_Throws()
+    public void Constructor_FilePath_NonexistentDll_ThrowsWin32Exception()
     {
-        Assert.ThrowsAny<Exception>(
+        Win32Exception ex = Assert.Throws<Win32Exception>(
             () => new ComClassFactory("madowaku-no-such-dll.dll", CLSID.FileOpenDialog));
+
+        // ERROR_MOD_NOT_FOUND = 126, ERROR_FILE_NOT_FOUND = 2, ERROR_PATH_NOT_FOUND = 3
+        Assert.True(
+            ex.NativeErrorCode is 126 or 2 or 3,
+            $"Unexpected NativeErrorCode {ex.NativeErrorCode}");
     }
 
     [Fact]
     public unsafe void Constructor_Hmodule_KnownExport_ExposesClassId()
     {
-        // Get the module that already provides StdGlobalInterfaceTable's exports.
-        // ole32.dll exports DllGetClassObject and the StdGlobalInterfaceTable CLSID.
-        HMODULE ole32 = HMODULE.FromName("ole32.dll");
-        Assert.False(ole32.IsNull);
+        // Explicitly load ole32.dll so the test isn't order-/environment-dependent.
+        // ole32 exports DllGetClassObject and contains the StdGlobalInterfaceTable CLSID.
+        HMODULE ole32 = HMODULE.LoadModule("ole32.dll");
+        try
+        {
+            using ComClassFactory factory = new(ole32, CLSID.StdGlobalInterfaceTable);
+            Assert.Equal(CLSID.StdGlobalInterfaceTable, factory.ClassId);
 
-        using ComClassFactory factory = new(ole32, CLSID.StdGlobalInterfaceTable);
-        Assert.Equal(CLSID.StdGlobalInterfaceTable, factory.ClassId);
-
-        using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
-        Assert.False(unknown.IsNull);
+            using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
+            Assert.False(unknown.IsNull);
+        }
+        finally
+        {
+            PInvokeMadowaku.FreeLibrary(ole32);
+        }
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.System.Variant;
+
+namespace Windows.Win32.System.Com;
+
+public class ComSafeArrayScopeTests
+{
+    [Fact]
+    public unsafe void Constructor_NullSafearrayPointer_IsNullTrue()
+    {
+        using ComSafeArrayScope<IUnknown> scope = new((SAFEARRAY*)null);
+        Assert.True(scope.IsNull);
+    }
+
+    [Fact]
+    public unsafe void Constructor_WrongVarType_Throws()
+    {
+        using SafeArrayScope<int> source = new(1);
+        SAFEARRAY* ptr = source.Value;
+        Assert.Throws<ArgumentException>(() => new ComSafeArrayScope<IUnknown>(ptr));
+    }
+
+    [Fact]
+    public unsafe void Constructor_VT_UNKNOWN_Array_Wraps()
+    {
+        // Build a 1-element VT_UNKNOWN SAFEARRAY manually and wrap it.
+        SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
+        SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
+        Assert.False(array is null);
+
+        using ComSafeArrayScope<IUnknown> scope = new(array);
+        Assert.False(scope.IsNull);
+        Assert.Equal(1, scope.Length);
+        Assert.False(scope.IsEmpty);
+    }
+
+    [Fact]
+    public unsafe void Length_NonEmptyArray_ReturnsCElements()
+    {
+        SAFEARRAYBOUND bound = new() { cElements = 3, lLbound = 0 };
+        SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
+        using ComSafeArrayScope<IUnknown> scope = new(array);
+        Assert.Equal(3, scope.Length);
+    }
+
+    [Fact]
+    public unsafe void Indexer_NullEntry_ReturnsNullComScope()
+    {
+        SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
+        SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
+        using ComSafeArrayScope<IUnknown> scope = new(array);
+
+        // Default entry is null; the indexer should return a ComScope wrapping null.
+        using ComScope<IUnknown> entry = scope[0];
+        Assert.True(entry.IsNull);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_SafearrayDoublePointer_NonNull()
+    {
+        SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
+        SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
+        using ComSafeArrayScope<IUnknown> scope = new(array);
+        SAFEARRAY** pp = scope;
+        Assert.False(pp is null);
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
@@ -59,12 +59,13 @@ public class ComSafeArrayScopeTests
     }
 
     [Fact]
-    public unsafe void ImplicitOperator_SafearrayDoublePointer_NonNull()
+    public unsafe void ImplicitOperator_SafearrayDoublePointer_DereferencesToSafearrayPointer()
     {
         SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
         SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
         using ComSafeArrayScope<IUnknown> scope = new(array);
         SAFEARRAY** pp = scope;
         Assert.False(pp is null);
+        Assert.True(*pp == scope.Value);
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
@@ -179,18 +179,20 @@ public class SafeArrayScopeTests
     }
 
     [Fact]
-    public unsafe void ImplicitOperator_VoidDoublePointer_NonNull()
+    public unsafe void ImplicitOperator_VoidDoublePointer_DereferencesToSafearrayPointer()
     {
         using SafeArrayScope<int> array = new(2);
         void** pp = array;
         Assert.False(pp is null);
+        Assert.True(*pp == array.Value);
     }
 
     [Fact]
-    public unsafe void ImplicitOperator_SafearrayDoublePointer_NonNull()
+    public unsafe void ImplicitOperator_SafearrayDoublePointer_DereferencesToSafearrayPointer()
     {
         using SafeArrayScope<int> array = new(2);
         SAFEARRAY** pp = array;
         Assert.False(pp is null);
+        Assert.True(*pp == array.Value);
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
@@ -177,4 +177,20 @@ public class SafeArrayScopeTests
         Assert.Equal(42, array[0]);
         Assert.Equal("hi", array[1]);
     }
+
+    [Fact]
+    public unsafe void ImplicitOperator_VoidDoublePointer_NonNull()
+    {
+        using SafeArrayScope<int> array = new(2);
+        void** pp = array;
+        Assert.False(pp is null);
+    }
+
+    [Fact]
+    public unsafe void ImplicitOperator_SafearrayDoublePointer_NonNull()
+    {
+        using SafeArrayScope<int> array = new(2);
+        SAFEARRAY** pp = array;
+        Assert.False(pp is null);
+    }
 }

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -344,6 +344,49 @@ public class VariantTests
     }
 
     [Fact]
+    public unsafe void ToObject_VT_CLSID_ReturnsGuid()
+    {
+        Guid expected = new("12345678-1234-1234-1234-1234567890ab");
+        VARIANT v = new() { vt = VARENUM.VT_CLSID };
+        v.data.puuid = &expected;
+        Assert.Equal(expected, v.ToObject());
+    }
+
+    [Fact]
+    public unsafe void ToObject_VT_FILETIME_ReturnsDateTime()
+    {
+        DateTime expected = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc).ToLocalTime();
+        FILETIME ft = (FILETIME)expected;
+        VARIANT v = new() { vt = VARENUM.VT_FILETIME };
+        Unsafe.As<VARIANT._Anonymous_e__Union._Anonymous_e__Struct._Anonymous_e__Union, FILETIME>(ref v.data) = ft;
+        Assert.Equal(expected, v.ToObject());
+    }
+
+    [Fact]
+    public unsafe void ToObject_VT_LPSTR_ReturnsString()
+    {
+        nint ansi = global::System.Runtime.InteropServices.Marshal.StringToCoTaskMemAnsi("ascii-text");
+        try
+        {
+            VARIANT v = new() { vt = VARENUM.VT_LPSTR };
+            v.data.pcVal = new PSTR((byte*)ansi);
+            Assert.Equal("ascii-text", v.ToObject());
+        }
+        finally
+        {
+            global::System.Runtime.InteropServices.Marshal.FreeCoTaskMem(ansi);
+        }
+    }
+
+    [Fact]
+    public unsafe void ToObject_VT_VARIANT_NotByref_ThrowsInvalidCast()
+    {
+        VARIANT v = new() { vt = VARENUM.VT_VARIANT };
+        // Falling through the switch with no byref bit set yields the "Unsupported VARENUM" path.
+        Assert.Throws<ArgumentException>(() => v.ToObject());
+    }
+
+    [Fact]
     public unsafe void ToObject_VT_ARRAY_VT_I4_ReturnsIntArray()
     {
         using SafeArrayScope<int> source = new([10, 20, 30]);

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -379,7 +379,7 @@ public class VariantTests
     }
 
     [Fact]
-    public unsafe void ToObject_VT_VARIANT_NotByref_ThrowsInvalidCast()
+    public unsafe void ToObject_VT_VARIANT_NotByref_ThrowsArgument()
     {
         VARIANT v = new() { vt = VARENUM.VT_VARIANT };
         // Falling through the switch with no byref bit set yields the "Unsupported VARENUM" path.


### PR DESCRIPTION
Pushes coverage on hand-written types up further.

## New / extended tests

- `ErrorTests` — `GetException` mappings for `ERROR_FILENAME_EXCED_RANGE`, `ERROR_INVALID_DRIVE`, `ERROR_OPERATION_ABORTED`, `ERROR_CANCELLED`, `ERROR_NETWORK_ACCESS_DENIED`, `ERROR_NOT_READY`, `ERROR_FILE_EXISTS`, `ERROR_ALREADY_EXISTS`, `ERROR_NOT_SUPPORTED_IN_APPCONTAINER`, and an unknown code (default `Win32Exception`). Plus `Error.ThrowIfLastErrorNot` happy path.
- `AgileComPointerTests` — generic `GetInterface<TAsInterface>()` and `TryGetInterface<TAsInterface>(out HRESULT)` overloads.
- `ComClassFactoryTests` — `ComClassFactory(HMODULE, Guid)` via `ole32.dll` (exercises `ClassId` and the module-based ctor path) and `ComClassFactory(string, Guid)` failure on a missing dll.
- `ComSafeArrayScopeTests` (new file) — null wrap, type-mismatch throw, VT_UNKNOWN array construction, `Length`, `IsEmpty`, indexer returning a null `ComScope`, and the `SAFEARRAY**` operator. Drives `ComSafeArrayScope<T>` from 0% to 100%.
- `SafeArrayScopeTests` — `void**` and `SAFEARRAY**` implicit-operator cases.
- `VariantTests` — `ToObject` for `VT_CLSID`, `VT_FILETIME`, `VT_LPSTR`, and the non-byref `VT_VARIANT` invalid path.

## Coverage delta (hand-written code, both TFMs)

| Metric | Before | After |
|---|---|---|
| Line | 59.1% | **65.8%** |
| Branch | 53.7% | **58.1%** |
| Method | 78.6% | **88.6%** |

Per-class:
- `Error` 78 → **89%**
- `AgileComPointer<T>` 70.8 → **87.5%**
- `ComClassFactory` 45.4 → **90.9%**
- `ComSafeArrayScope<T>` 0 → **100%**
- `SafeArrayScope<T>` 82.5 → **83.4%**
- `VARIANT` 41.3 → **42.6%**

## Note

A 2D-SAFEARRAY VARIANT round-trip test was attempted but exposed a latent bug in `VARIANT.ToObject`: `SetArrayValue`'s local `SetValue<T>` casts `Array` to `T[]`, which throws `InvalidCastException` for any `T[,]`. Not fixed in this PR — should be a separate change.