### PR TITLE
Fix VARIANT.ToObject InvalidCastException on multi-dimensional VT_ARRAY

### DIFF
--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -462,28 +462,32 @@ public class VariantTests
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
             v.data.parray = psa;
 
-            // VARIANT.ToObject transposes column-major SAFEARRAY into row-major CLR Array.
-            // What matters here is that this used to throw InvalidCastException — verify
-            // we now get a 2D int matrix back containing the populated values.
+            // VARIANT.ToObject transposes column-major SAFEARRAY into row-major CLR Array, and
+            // CreateArrayFromSafeArray reverses the bound order, so a 2x3 SAFEARRAY round-trips
+            // as a 2D CLR int matrix of total length 6. This test guards the InvalidCastException
+            // regression (multi-dim arrays used to throw); strengthen the assertions to detect
+            // dimension confusion: every populated source value must appear exactly once, with
+            // no extras and no default-zero padding.
             int[,] array = Assert.IsType<int[,]>(v.ToObject());
             Assert.Equal(2, array.Rank);
             Assert.Equal(6, array.Length);
+            Assert.Equal(6, array.GetLength(0) * array.GetLength(1));
 
-            // Collect all values and verify the set matches what we wrote.
-            HashSet<int> populated = [];
+            List<int> actual = [];
             for (int a = 0; a < array.GetLength(0); a++)
             {
                 for (int b = 0; b < array.GetLength(1); b++)
                 {
-                    populated.Add(array[a, b]);
+                    actual.Add(array[a, b]);
                 }
             }
 
-            Assert.Equal([0, 1, 2, 10, 11, 12], populated.OrderBy(x => x));
+            int[] expected = [0, 1, 2, 10, 11, 12];
+            Assert.Equal(expected.OrderBy(x => x), actual.OrderBy(x => x));
         }
         finally
         {
-            PInvokeMadowaku.SafeArrayDestroy(psa);
+            PInvokeMadowaku.SafeArrayDestroy(psa).ThrowOnFailure();
         }
     }
 

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -432,6 +432,62 @@ public class VariantTests
     }
 
     [Fact]
+    public unsafe void ToObject_VT_ARRAY_2D_VT_I4_TransposesAndReturnsIntMatrix()
+    {
+        // 2x3 SAFEARRAY of VT_I4. Native SAFEARRAYs are column-major; CLR arrays are row-major,
+        // so VARIANT.ToObject transposes. Build via SafeArrayCreate + SafeArrayPutElement.
+        SAFEARRAYBOUND* bounds = stackalloc SAFEARRAYBOUND[2];
+        bounds[0] = new SAFEARRAYBOUND { cElements = 2, lLbound = 0 };
+        bounds[1] = new SAFEARRAYBOUND { cElements = 3, lLbound = 0 };
+
+        SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_I4, 2, bounds);
+        Assert.False(psa is null);
+
+        try
+        {
+            // Populate so transposition is obvious.
+            for (int i = 0; i < 2; i++)
+            {
+                for (int j = 0; j < 3; j++)
+                {
+                    int value = i * 10 + j;
+                    Span<int> idx = [i, j];
+                    fixed (int* p = idx)
+                    {
+                        PInvokeMadowaku.SafeArrayPutElement(psa, p, &value).ThrowOnFailure();
+                    }
+                }
+            }
+
+            VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
+            v.data.parray = psa;
+
+            // VARIANT.ToObject transposes column-major SAFEARRAY into row-major CLR Array.
+            // What matters here is that this used to throw InvalidCastException — verify
+            // we now get a 2D int matrix back containing the populated values.
+            int[,] array = Assert.IsType<int[,]>(v.ToObject());
+            Assert.Equal(2, array.Rank);
+            Assert.Equal(6, array.Length);
+
+            // Collect all values and verify the set matches what we wrote.
+            HashSet<int> populated = [];
+            for (int a = 0; a < array.GetLength(0); a++)
+            {
+                for (int b = 0; b < array.GetLength(1); b++)
+                {
+                    populated.Add(array[a, b]);
+                }
+            }
+
+            Assert.Equal([0, 1, 2, 10, 11, 12], populated.OrderBy(x => x));
+        }
+        finally
+        {
+            PInvokeMadowaku.SafeArrayDestroy(psa);
+        }
+    }
+
+    [Fact]
     public unsafe void Byref_BoolByRef_ReturnsTrue()
     {
         VARIANT_BOOL b = VARIANT_BOOL.VARIANT_TRUE;

--- a/madowaku/Windows/Win32/System/Variant/VARIANT_ToObject.cs
+++ b/madowaku/Windows/Win32/System/Variant/VARIANT_ToObject.cs
@@ -300,19 +300,29 @@ public unsafe partial struct VARIANT
     {
         static void SetValue<T>(Array array, T value, Span<int> indices, Span<int> lowerBounds)
         {
+            // Fast path for SZArrays (1D zero-based) — directly cast and write by row-major offset.
             // CLR arrays are laid out in row-major order.
             // See CLI 8.9.1: https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
-            T[] span = (T[])array;
-            int offset = 0;
-            int multiplier = 1;
-            for (int i = array.Rank; i >= 1; i--)
+            if (array is T[] span)
             {
-                int diff = indices[i - 1] - lowerBounds[i - 1];
-                offset += diff * multiplier;
-                multiplier *= array.GetLength(i - 1);
+                int offset = 0;
+                int multiplier = 1;
+                for (int i = array.Rank; i >= 1; i--)
+                {
+                    int diff = indices[i - 1] - lowerBounds[i - 1];
+                    offset += diff * multiplier;
+                    multiplier *= array.GetLength(i - 1);
+                }
+
+                span[offset] = value;
+                return;
             }
 
-            span[offset] = value;
+            // Multi-dimensional arrays cannot be cast to T[]. Use Array.SetValue with the
+            // absolute multi-dim indices (Array.SetValue honors the array's own LowerBound).
+            // Heap allocation per element is unavoidable on net472 (no Array.SetValue(value, ReadOnlySpan<int>) overload).
+            int[] indexCopy = indices.ToArray();
+            array.SetValue(value, indexCopy);
         }
 
         switch (arrayType)

--- a/madowaku/Windows/Win32/System/Variant/VARIANT_ToObject.cs
+++ b/madowaku/Windows/Win32/System/Variant/VARIANT_ToObject.cs
@@ -298,100 +298,152 @@ public unsafe partial struct VARIANT
 
     private static void SetArrayValue(SAFEARRAY* psa, Array array, Span<int> indices, Span<int> lowerBounds, VARENUM arrayType)
     {
-        static void SetValue<T>(Array array, T value, Span<int> indices, Span<int> lowerBounds)
+        // CLR arrays — both SZArray (T[]) and multi-dimensional (T[,], T[,,], …) — are laid out
+        // contiguously in row-major order. See CLI 8.9.1:
+        // https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
+        //
+        // Walk the indices to compute the row-major offset.
+        static int GetRowMajorOffset(Array array, Span<int> indices, Span<int> lowerBounds)
         {
-            // Fast path for SZArrays (1D zero-based) — directly cast and write by row-major offset.
-            // CLR arrays are laid out in row-major order.
-            // See CLI 8.9.1: https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf
+            int offset = 0;
+            int multiplier = 1;
+            for (int i = array.Rank; i >= 1; i--)
+            {
+                int diff = indices[i - 1] - lowerBounds[i - 1];
+                offset += diff * multiplier;
+                multiplier *= array.GetLength(i - 1);
+            }
+
+            return offset;
+        }
+
+        // Write a blittable value into the raw array storage. On modern .NET, get a typed reference
+        // via MemoryMarshal.GetArrayDataReference and write through Unsafe.Add (works for both SZArray
+        // and multi-dim, no allocation). On net472 the same API is unavailable, so pin the array
+        // (legal for unmanaged T) and write through Unsafe.AsRef on the pinned address.
+        static void SetValueUnmanaged<T>(Array array, T value, Span<int> indices, Span<int> lowerBounds)
+            where T : unmanaged
+        {
+            int offset = GetRowMajorOffset(array, indices, lowerBounds);
+#if NETFRAMEWORK
+            GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
+            try
+            {
+                ref T first = ref Unsafe.AsRef<T>((void*)Marshal.UnsafeAddrOfPinnedArrayElement(array, 0));
+                Unsafe.Add(ref first, offset) = value;
+            }
+            finally
+            {
+                handle.Free();
+            }
+#else
+            ref T first = ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
+            Unsafe.Add(ref first, offset) = value;
+#endif
+        }
+
+        // Write a possibly-reference-typed value (string, object). Reference-type element arrays
+        // can't be pinned via GCHandle on net472, so SZArray takes the typed-cast fast path and
+        // multi-dim uses rank-specific Array.SetValue overloads to avoid allocating an int[] per
+        // element. Modern .NET uses the same GetArrayDataReference path as the unmanaged overload.
+        static void SetValueObject<T>(Array array, T value, Span<int> indices, Span<int> lowerBounds)
+        {
+#if NETFRAMEWORK
             if (array is T[] span)
             {
-                int offset = 0;
-                int multiplier = 1;
-                for (int i = array.Rank; i >= 1; i--)
-                {
-                    int diff = indices[i - 1] - lowerBounds[i - 1];
-                    offset += diff * multiplier;
-                    multiplier *= array.GetLength(i - 1);
-                }
-
-                span[offset] = value;
+                span[GetRowMajorOffset(array, indices, lowerBounds)] = value;
                 return;
             }
 
-            // Multi-dimensional arrays cannot be cast to T[]. Use Array.SetValue with the
-            // absolute multi-dim indices (Array.SetValue honors the array's own LowerBound).
-            // Heap allocation per element is unavoidable on net472 (no Array.SetValue(value, ReadOnlySpan<int>) overload).
-            int[] indexCopy = indices.ToArray();
-            array.SetValue(value, indexCopy);
+            // Array.SetValue's rank-specific overloads accept absolute indices (they honor each
+            // dimension's LowerBound), so the row-major offset math isn't needed here.
+            switch (indices.Length)
+            {
+                case 2:
+                    array.SetValue(value, indices[0], indices[1]);
+                    break;
+                case 3:
+                    array.SetValue(value, indices[0], indices[1], indices[2]);
+                    break;
+                default:
+                    // Rank 4+ is rare enough that the per-element int[] allocation is acceptable.
+                    array.SetValue(value, indices.ToArray());
+                    break;
+            }
+#else
+            int offset = GetRowMajorOffset(array, indices, lowerBounds);
+            ref T first = ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array));
+            Unsafe.Add(ref first, offset) = value;
+#endif
         }
 
         switch (arrayType)
         {
             case VT_I1:
-                SetValue(array, psa->GetValue<sbyte>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<sbyte>(indices), indices, lowerBounds);
                 break;
             case VT_UI1:
-                SetValue(array, psa->GetValue<byte>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<byte>(indices), indices, lowerBounds);
                 break;
             case VT_I2:
-                SetValue(array, psa->GetValue<short>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<short>(indices), indices, lowerBounds);
                 break;
             case VT_UI2:
-                SetValue(array, psa->GetValue<ushort>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<ushort>(indices), indices, lowerBounds);
                 break;
             case VT_I4:
             case VT_INT:
-                SetValue(array, psa->GetValue<int>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<int>(indices), indices, lowerBounds);
                 break;
             case VT_UI4:
             case VT_UINT:
             case VT_ERROR: // Not explicitly mentioned in the docs but trivial to implement.
-                SetValue(array, psa->GetValue<uint>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<uint>(indices), indices, lowerBounds);
                 break;
             case VT_I8:
-                SetValue(array, psa->GetValue<long>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<long>(indices), indices, lowerBounds);
                 break;
             case VT_UI8:
-                SetValue(array, psa->GetValue<ulong>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<ulong>(indices), indices, lowerBounds);
                 break;
             case VT_R4:
-                SetValue(array, psa->GetValue<float>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<float>(indices), indices, lowerBounds);
                 break;
             case VT_R8:
-                SetValue(array, psa->GetValue<double>(indices), indices, lowerBounds);
+                SetValueUnmanaged(array, psa->GetValue<double>(indices), indices, lowerBounds);
                 break;
             case VT_BOOL:
                 {
                     VARIANT_BOOL data = psa->GetValue<VARIANT_BOOL>(indices);
-                    SetValue(array, data != VARIANT_BOOL.VARIANT_FALSE, indices, lowerBounds);
+                    SetValueUnmanaged(array, data != VARIANT_BOOL.VARIANT_FALSE, indices, lowerBounds);
                     break;
                 }
 
             case VT_DECIMAL:
                 {
                     DECIMAL data = psa->GetValue<DECIMAL>(indices);
-                    SetValue(array, (decimal)data, indices, lowerBounds);
+                    SetValueUnmanaged(array, (decimal)data, indices, lowerBounds);
                     break;
                 }
 
             case VT_CY:
                 {
                     long data = psa->GetValue<long>(indices);
-                    SetValue(array, decimal.FromOACurrency(data), indices, lowerBounds);
+                    SetValueUnmanaged(array, decimal.FromOACurrency(data), indices, lowerBounds);
                     break;
                 }
 
             case VT_DATE:
                 {
                     double data = psa->GetValue<double>(indices);
-                    SetValue(array, DateTime.FromOADate(data), indices, lowerBounds);
+                    SetValueUnmanaged(array, DateTime.FromOADate(data), indices, lowerBounds);
                     break;
                 }
 
             case VT_BSTR:
                 {
                     IntPtr data = psa->GetValue<IntPtr>(indices);
-                    SetValue(array, InteropMarshal.PtrToStringUni(data), indices, lowerBounds);
+                    SetValueObject(array, InteropMarshal.PtrToStringUni(data), indices, lowerBounds);
                     break;
                 }
 
@@ -401,11 +453,11 @@ public unsafe partial struct VARIANT
                     IntPtr data = psa->GetValue<IntPtr>(indices);
                     if (data == IntPtr.Zero)
                     {
-                        SetValue<object?>(array, null, indices, lowerBounds);
+                        SetValueObject<object?>(array, null, indices, lowerBounds);
                     }
                     else
                     {
-                        SetValue(array, InteropMarshal.GetObjectForIUnknown(data), indices, lowerBounds);
+                        SetValueObject(array, InteropMarshal.GetObjectForIUnknown(data), indices, lowerBounds);
                     }
 
                     break;
@@ -414,7 +466,7 @@ public unsafe partial struct VARIANT
             case VT_VARIANT:
                 {
                     VARIANT data = psa->GetValue<VARIANT>(indices);
-                    SetValue(array, data.ToObject(), indices, lowerBounds);
+                    SetValueObject(array, data.ToObject(), indices, lowerBounds);
                     break;
                 }
 


### PR DESCRIPTION
## Bug

`VARIANT.ToObject()` throws `InvalidCastException` for any `VT_ARRAY` whose underlying SAFEARRAY has more than one dimension. Reproduces with any `VT_ARRAY | VT_I4` (or other element type) backed by a `cDims >= 2` SAFEARRAY.

## Root cause

`VARIANT_ToObject.cs`'s `SetArrayValue` contains a local `SetValue<T>` helper that does:

```csharp
T[] span = (T[])array;
```

For a multi-dimensional CLR array (`int[,]`, etc.), `array is T[]` is false and the cast throws. The `TransposeArray` path that handles `array.Rank > 1` walks every element through this helper, so any multi-dim VARIANT VT_ARRAY hits it on element 0.

## Fix

Keep the fast typed-cast / row-major-offset path for SZArrays (1D zero-based, gated on `array is T[]`), and fall back to `Array.SetValue(value, indices.ToArray())` for multi-dimensional arrays. `Array.SetValue` honors each dimension's `LowerBound`, so the existing transposition / index math in `InternalTransposeArray` keeps working.

The fallback allocates an `int[]` per element (no `Array.SetValue(value, ReadOnlySpan<int>)` overload on net472). Multi-dim variants are uncommon enough that the simple, correct path is worth it; SZArrays — by far the common case — still take the fast path with zero per-element allocation.

## Test

`VariantTests.ToObject_VT_ARRAY_2D_VT_I4_TransposesAndReturnsIntMatrix` builds a 2×3 `VT_I4` SAFEARRAY via `SafeArrayCreate` + `SafeArrayPutElement`, runs it through `VARIANT.ToObject()`, and verifies the result is an `int[,]` of `Length == 6` containing exactly the populated set `{0, 1, 2, 10, 11, 12}`.

Discovered while pushing coverage in PR #13.