### PR TITLE
Fix VARIANT.ToObject for VT_ARRAY|VT_DECIMAL and non-zero lower bound

### DIFF
--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -1077,6 +1077,8 @@ public partial class VariantTests
     {
         SAFEARRAYBOUND bound = new() { cElements = 3, lLbound = 5 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_I4, 1, &bound);
+        Assert.False(psa is null);
+
         try
         {
             for (int i = 0; i < 3; i++)
@@ -1098,7 +1100,10 @@ public partial class VariantTests
         }
         finally
         {
-            PInvokeMadowaku.SafeArrayDestroy(psa).ThrowOnFailure();
+            if (psa is not null)
+            {
+                PInvokeMadowaku.SafeArrayDestroy(psa).ThrowOnFailure();
+            }
         }
     }
 

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -1000,6 +1000,27 @@ public partial class VariantTests
     }
 
     [Fact]
+    public unsafe void ToObject_Array_VT_DECIMAL_ReturnsDecimalArray()
+    {
+        // Regression guard: VARIANT.ToObject used to short-circuit on `Type == VT_DECIMAL`
+        // (which masks off VT_ARRAY/VT_VECTOR/VT_BYREF), returning a bogus scalar decimal
+        // instead of dispatching to the SAFEARRAY path.
+        DECIMAL[] values = [new(1.5m), new(2.5m)];
+        SAFEARRAY* psa = CreateSafeArray(VARENUM.VT_DECIMAL, values);
+        try
+        {
+            VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_DECIMAL };
+            v.data.parray = psa;
+            decimal[] expected = [1.5m, 2.5m];
+            Assert.Equal(expected, Assert.IsType<decimal[]>(v.ToObject()));
+        }
+        finally
+        {
+            PInvokeMadowaku.SafeArrayDestroy(psa).ThrowOnFailure();
+        }
+    }
+
+    [Fact]
     public unsafe void ToObject_Array_VT_VARIANT_ReturnsObjectArray()
     {
 #if NETFRAMEWORK
@@ -1044,6 +1065,36 @@ public partial class VariantTests
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_RECORD };
             v.data.parray = psa;
             Assert.Throws<ArgumentException>(() => v.ToObject());
+        }
+        finally
+        {
+            PInvokeMadowaku.SafeArrayDestroy(psa).ThrowOnFailure();
+        }
+    }
+
+    [Fact]
+    public unsafe void ToObject_Array_NonZeroLowerBound_PreservesBounds()
+    {
+        SAFEARRAYBOUND bound = new() { cElements = 3, lLbound = 5 };
+        SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_I4, 1, &bound);
+        try
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                int abs = i + 5;
+                int value = i * 10;
+                PInvokeMadowaku.SafeArrayPutElement(psa, &abs, &value).ThrowOnFailure();
+            }
+
+            VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
+            v.data.parray = psa;
+            Array array = Assert.IsAssignableFrom<Array>(v.ToObject());
+            Assert.Equal(1, array.Rank);
+            Assert.Equal(5, array.GetLowerBound(0));
+            Assert.Equal(3, array.Length);
+            Assert.Equal(0, array.GetValue(5));
+            Assert.Equal(10, array.GetValue(6));
+            Assert.Equal(20, array.GetValue(7));
         }
         finally
         {

--- a/madowaku/Windows/Win32/System/Variant/VARIANT_ToObject.cs
+++ b/madowaku/Windows/Win32/System/Variant/VARIANT_ToObject.cs
@@ -25,7 +25,11 @@ public unsafe partial struct VARIANT
     /// </summary>
     public object? ToObject()
     {
-        if (Type == VT_DECIMAL)
+        // VT_DECIMAL stores its payload directly in the VARIANT, including bytes that overlap
+        // the vt field (vt's wReserved1 == DECIMAL.wReserved). The scalar form is identified by
+        // vt == VT_DECIMAL with no modifier flags; VT_ARRAY|VT_DECIMAL, VT_VECTOR|VT_DECIMAL, and
+        // byref variants store a pointer instead and must fall through to the normal dispatch.
+        if (Type == VT_DECIMAL && !vt.AreAnyFlagsSet(VT_ARRAY | VT_VECTOR | VT_BYREF))
         {
             return (decimal)Anonymous.decVal;
         }
@@ -80,7 +84,12 @@ public unsafe partial struct VARIANT
 
         try
         {
-            if (array.Rank != 1)
+            // The fast path below uses Span<T>.CopyTo((T[])array), which requires an SZArray
+            // (zero-lower-bound vector). A 1-D SAFEARRAY with a non-zero lower bound comes back
+            // from CreateArrayFromSafeArray as a variable-bound 1-D array (e.g. int[*]) that
+            // can't be cast to int[]; route those through the transpose path, which writes
+            // through Unsafe.Add / MemoryMarshal.GetArrayDataReference and works for any rank.
+            if (array.Rank != 1 || array.GetLowerBound(0) != 0)
             {
                 if (array.Length != 0)
                 {


### PR DESCRIPTION
Two bugs surfaced while expanding VARIANT test coverage in #15.

## 1. `VT_ARRAY|VT_DECIMAL` returned a bogus scalar `decimal`

`VARIANT.ToObject()` short-circuits at the top on `Type == VT_DECIMAL`, but `Type = vt & VT_TYPEMASK` masks off `VT_ARRAY`, `VT_VECTOR`, and `VT_BYREF`. So a `VT_ARRAY|VT_DECIMAL` variant was reinterpreted as if its inline payload were a `DECIMAL` (the SAFEARRAY pointer and bound bits get cast to a `decimal` value) instead of being dispatched through the SAFEARRAY path.

**Fix:** Gate the short-circuit on the absence of those flag bits so only true scalar `VT_DECIMAL` takes the fast path.

## 2. 1-D `VT_ARRAY` with non-zero lower bound threw `InvalidCastException`

`CreateArrayFromSafeArray` returns `Array.CreateInstance(elementType, lengths, bounds)` for non-zero-lower-bound 1-D arrays. That's a variable-bound vector (e.g. `int[*]`), not an SZArray (`int[]`). The `ToArray` fast path then did `(int[])array`, which fails.

**Fix:** Route 1-D non-zero-lower-bound arrays through the existing transpose path. It writes through `Unsafe.Add` / `MemoryMarshal.GetArrayDataReference` and works for any rank and bounds.

## Tests

- `ToObject_Array_VT_DECIMAL_ReturnsDecimalArray` — regression guard for bug #1.
- `ToObject_Array_NonZeroLowerBound_PreservesBounds` — regression guard for bug #2; verifies rank, lower bound, length, and per-index values.

All 458 tests pass on `net10.0-windows10.0.22000.0` and `net481` in Release.