### PR TITLE
Add madowaku.perf project and performance-testing agent docs

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -15,6 +15,7 @@ overlap.
 | ----- | ---------------- | ---------------- |
 | [cswin32-interop](./cswin32-interop/SKILL.md) | "add a P/Invoke", "replace `[DllImport]`", "use CsWin32 for X", "what does `PInvoke` vs `PInvokeMadowaku` mean", net472 vs modern .NET CsWin32 gating, the `ComWrappers` polyfill, Touki vs local polyfills | `cswin32-com` |
 | [cswin32-com](./cswin32-com/SKILL.md) | "use `ComScope<T>`", "wire up `IComIID`", "activate a COM object", "manually define an `ICLR*` / `IWbem*` / `IMetaData*` interface", `IID.Get<T>()`, `delegate* unmanaged` vtables, per-struct net472 polyfill | `cswin32-interop` |
+| [performance-testing](./performance-testing/SKILL.md) | "add a benchmark", "run perf tests", "compare allocations", "BenchmarkDotNet", "why is net481 slower/faster" | `cswin32-interop`, `cswin32-com` |
 
 ## Disambiguation
 

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: performance-testing
+description: Author and run BenchmarkDotNet performance tests in the madowaku.perf project. Use when adding new benchmarks, running existing ones, comparing implementations, or evaluating allocations and memory usage for code in madowaku.
+argument-hint: Describe the API or hot path you want to benchmark and whether you care most about time, allocations, or both.
+---
+
+# Performance testing in madowaku.perf
+
+The [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj) project hosts
+all [BenchmarkDotNet](https://benchmarkdotnet.org/) benchmarks for this repo.
+It multi-targets modern .NET (`$(DotNetCoreVersion)-$(WindowsPlatformVersion)`)
+and `net481`, so you can compare runtime behavior between the two JITs.
+
+This skill is adapted from Touki's performance-testing skill and narrowed to
+madowaku conventions.
+
+## 1. Authoring a benchmark
+
+### File and class layout
+
+- One benchmark class per file, file named after the class.
+- Namespace is always `madowaku.perf`.
+- Class is `public` and has one or more `[Benchmark]` methods.
+- Use the standard repo file header.
+- Follow [AGENTS.md](../../../AGENTS.md) coding rules (explicit types, XML docs,
+  no `var`, collection expressions where applicable).
+
+### Globals already imported
+
+[GlobalUsings.cs](../../../madowaku.perf/GlobalUsings.cs) already provides:
+
+- `BenchmarkDotNet.Attributes`
+- `BenchmarkDotNet.Jobs`
+
+Do not re-import those in each benchmark file.
+
+### Required attributes
+
+Always annotate benchmark classes with `[MemoryDiagnoser]`.
+
+When comparing alternatives, set one method to baseline:
+
+```csharp
+[Benchmark(Baseline = true)]
+public int Current()
+{
+    return _value;
+}
+
+[Benchmark]
+public int Candidate()
+{
+    return _value + 1;
+}
+```
+
+### What benchmark methods must do
+
+- Return a value derived from the measured work (not `void`).
+- Keep setup outside the measured path using `[GlobalSetup]`.
+- Avoid helper indirection between benchmark method and system-under-test
+  unless you intentionally want that overhead measured.
+- For mutating operations, return a digest or sampled value from the mutated
+  data (`buffer[0]`, sum, xor, etc.) so dead-code elimination cannot erase work.
+
+## 2. Running benchmarks
+
+The benchmark entrypoint uses `BenchmarkSwitcher.FromAssembly(...)`, so all
+CLI args after `--` are forwarded to BenchmarkDotNet.
+
+### Target framework is required
+
+Because `madowaku.perf` is multi-targeted, always pass `-f`.
+
+```powershell
+# modern .NET
+ dotnet run -c Release -f net10.0-windows10.0.22000.0 --project madowaku.perf -- --filter *VariantConversionPerf*
+
+# .NET Framework
+ dotnet run -c Release -f net481 --project madowaku.perf -- --filter *VariantConversionPerf*
+```
+
+`-c Release` is mandatory for useful numbers.
+
+### Useful switches
+
+- `--job short`: quick smoke pass while iterating.
+- `--memory`: force memory diagnoser for the run.
+- `--exporters github`: emit GitHub-flavored markdown summary.
+- `--disasm`: inspect generated assembly for codegen investigations.
+
+## 3. Reading memory results
+
+With `[MemoryDiagnoser]`, output includes:
+
+- `Gen0`, `Gen1`, `Gen2`: collections per 1000 ops.
+- `Allocated`: managed bytes per operation.
+
+Guidance:
+
+- `Allocated` should be `-` or `0 B` for allocation-free paths.
+- Use `Ratio` with `Allocated` to avoid trading CPU gains for allocation
+  regressions.
+- Compare both TFMs before claiming an improvement. net481 and modern .NET can
+  differ significantly in JIT behavior.
+
+## 4. Workflow checklist
+
+1. Add `<Name>.cs` under `madowaku.perf/` with `public class <Name>`.
+2. Add `[MemoryDiagnoser]` and a clear baseline benchmark.
+3. Ensure every benchmark returns a value tied to real work.
+4. Build Release:
+
+   ```powershell
+   dotnet build -c Release madowaku.perf/madowaku.perf.csproj
+   ```
+
+5. Smoke-test with short job on both TFMs:
+
+   ```powershell
+   dotnet run -c Release -f net10.0-windows10.0.22000.0 --project madowaku.perf -- --job short --filter *<Name>*
+   dotnet run -c Release -f net481 --project madowaku.perf -- --job short --filter *<Name>*
+   ```
+
+6. Run full benchmark if needed (remove `--job short`).
+7. Capture summary from console or artifacts and include it with perf claims.
+
+## 5. Repo-specific notes
+
+- `madowaku.perf` references both `madowaku` and `madowaku.tests` so test-only
+  fixtures can be reused in benchmark setup.
+- If benchmarking code that only exists under `madowaku/Framework/`, guard
+  references with `#if NETFRAMEWORK`.
+- Keep benchmark data realistic and derived from existing tests where possible
+  (for example, VARIANT conversion cases from `madowaku.tests`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -206,6 +206,10 @@ not a license to skip the conversation.
   See the [`cswin32-interop`](../.agents/skills/cswin32-interop/SKILL.md) and
   [`cswin32-com`](../.agents/skills/cswin32-com/SKILL.md) skills for
   patterns, TFM gating, and the per-struct net472 polyfill recipe.
+- For BenchmarkDotNet setup, authoring rules, and run guidance in
+  `madowaku.perf`, see the
+  [`performance-testing`](../.agents/skills/performance-testing/SKILL.md)
+  skill.
 - Hand-rolled net472 polyfills live under `madowaku/Framework/` and
   declare the BCL namespace they're polyfilling (e.g.
   `Framework/System/Runtime/InteropServices/ComWrappers.cs` &rarr;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,10 @@ not a license to skip the conversation.
   See the [`cswin32-interop`](.agents/skills/cswin32-interop/SKILL.md) and
   [`cswin32-com`](.agents/skills/cswin32-com/SKILL.md) skills for
   patterns, TFM gating, and the per-struct net472 polyfill recipe.
+- For BenchmarkDotNet setup, authoring rules, and run guidance in
+  `madowaku.perf`, see the
+  [`performance-testing`](.agents/skills/performance-testing/SKILL.md)
+  skill.
 - Hand-rolled net472 polyfills live under `madowaku/Framework/` and
   declare the BCL namespace they're polyfilling (e.g.
   `Framework/System/Runtime/InteropServices/ComWrappers.cs` &rarr;

--- a/madowaku.perf/GlobalUsings.cs
+++ b/madowaku.perf/GlobalUsings.cs
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+global using BenchmarkDotNet.Attributes;
+global using BenchmarkDotNet.Jobs;

--- a/madowaku.perf/Program.cs
+++ b/madowaku.perf/Program.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace madowaku.perf;
+
+internal static class Program
+{
+    private static void Main(string[] args)
+    {
+        BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    }
+}

--- a/madowaku.perf/VariantConversionPerf.cs
+++ b/madowaku.perf/VariantConversionPerf.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.System.Variant;
+
+namespace madowaku.perf;
+
+/// <summary>
+///  Benchmarks core <see cref="VARIANT"/> conversion paths covered by Variant tests.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class VariantConversionPerf
+{
+    private VARIANT _intVariant;
+    private object _boxedInt = null!;
+
+    /// <summary>
+    ///  Initializes benchmark inputs used across all conversion benchmarks.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup()
+    {
+        _intVariant = (VARIANT)42;
+        _boxedInt = 42;
+    }
+
+    /// <summary>
+    ///  Reads an int payload directly through the explicit VARIANT cast operator.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public int ExplicitIntCast()
+    {
+        return (int)_intVariant;
+    }
+
+    /// <summary>
+    ///  Converts through <see cref="VARIANT.ToObject"/> and unboxes to <see cref="int"/>.
+    /// </summary>
+    [Benchmark]
+    public int ToObjectThenUnbox()
+    {
+        object value = _intVariant.ToObject()!;
+        return (int)value;
+    }
+
+    /// <summary>
+    ///  Converts a boxed int through <see cref="VARIANT.FromObject"/> and returns the variant type.
+    /// </summary>
+    [Benchmark]
+    public VARENUM FromObjectInt()
+    {
+        VARIANT value = VARIANT.FromObject(_boxedInt);
+        VARENUM type = value.vt;
+        return type;
+    }
+
+    /// <summary>
+    ///  Converts an int through the explicit variant conversion operator and returns the variant type.
+    /// </summary>
+    [Benchmark]
+    public VARENUM ExplicitVariantInt()
+    {
+        VARIANT value = (VARIANT)42;
+        VARENUM type = value.vt;
+        return type;
+    }
+}

--- a/madowaku.perf/VariantConversionPerf.cs
+++ b/madowaku.perf/VariantConversionPerf.cs
@@ -29,7 +29,7 @@ public class VariantConversionPerf
     /// <summary>
     ///  Reads an int payload directly through the explicit VARIANT cast operator.
     /// </summary>
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public int ExplicitIntCast()
     {
         return (int)_intVariant;

--- a/madowaku.perf/madowaku.perf.csproj
+++ b/madowaku.perf/madowaku.perf.csproj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Targeting 4.8.1 for perf tests to get additional runtime diagnostics support. -->
+    <TargetFrameworks>$(DotNetCoreVersion)-$(WindowsPlatformVersion);net481</TargetFrameworks>
+    <DependencyTargetFramework>$(TargetFramework)</DependencyTargetFramework>
+    <OutputType>Exe</OutputType>
+    <StartupObject>madowaku.perf.Program</StartupObject>
+
+    <!-- Make sure the main project builds against its normal framework target. -->
+    <DependencyTargetFramework Condition="'$(TargetFramework)' == 'net481'">$(DotNetFrameworkVersion)</DependencyTargetFramework>
+
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace />
+
+    <!-- Turn off Microsoft Testing Platform's transitive test-app behavior. -->
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
+    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+
+    <!-- Do not advertise this executable as a test container/server. -->
+    <DisableTestingPlatformServerCapability>true</DisableTestingPlatformServerCapability>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\madowaku.tests\madowaku.tests.csproj" />
+    <ProjectReference Include="..\madowaku\madowaku.csproj" AdditionalProperties="TargetFramework=$(DependencyTargetFramework)" />
+  </ItemGroup>
+
+</Project>

--- a/madowaku.slnx
+++ b/madowaku.slnx
@@ -19,6 +19,9 @@
     <File Path=".github/workflows/dotnet.yml" />
     <File Path=".github/workflows/publish.yml" />
   </Folder>
+  <Project Path="madowaku.perf/madowaku.perf.csproj">
+    <Platform Project="x64" />
+  </Project>
   <Project Path="madowaku.tests/madowaku.tests.csproj" Id="3cc6b747-dfb7-40c7-82ca-ca4d3c0c28a9">
     <Platform Project="x64" />
   </Project>


### PR DESCRIPTION
## Summary
- add a new `madowaku.perf` BenchmarkDotNet project modeled after Touki's perf layout
- add initial `VariantConversionPerf` benchmark using realistic VARIANT conversion scenarios from existing tests
- add a new `.agents/skills/performance-testing/SKILL.md` adapted from Touki and register it in the skills catalog
- add AGENTS cross-reference to the new performance skill and regenerate `.github/copilot-instructions.md`

## Validation
- `dotnet build -c Release madowaku.perf/madowaku.perf.csproj`
- `dotnet test --solution madowaku.slnx -c Release`
- `dotnet run -c Release -f net10.0-windows10.0.22000.0 --project madowaku.perf -- --job short --filter *VariantConversionPerf*`