### PR TITLE
Unify Stdcall function-pointer calls across TFMs

### DIFF
--- a/madowaku/Windows/Win32/Foundation/HMODULE.cs
+++ b/madowaku/Windows/Win32/Foundation/HMODULE.cs
@@ -15,8 +15,6 @@ public unsafe partial struct HMODULE : IHandle<HMODULE>
 {
     private const string DllGetVersionMethodName = "DllGetVersion";
 
-    private delegate HRESULT DllGetVersionProc(DLLVERSIONINFO* version);
-
     HMODULE IHandle<HMODULE>.Handle => this;
     object? IHandle<HMODULE>.Wrapper => null;
 
@@ -111,11 +109,11 @@ public unsafe partial struct HMODULE : IHandle<HMODULE>
         };
 
         // HRESULT Dllgetversionproc(DLLVERSIONINFO* version)
-#if NETFRAMEWORK
-        Marshal.GetDelegateForFunctionPointer<DllGetVersionProc>(proc.Value)(&versionInfo).ThrowOnFailure();
-#else
-        ((delegate* unmanaged<DLLVERSIONINFO*, HRESULT>)proc.Value)(&versionInfo).ThrowOnFailure();
-#endif
+        // DllGetVersion is declared STDAPI (__stdcall). The explicit [Stdcall]
+        // qualifier is convention-correct on x86 and compiles on net472 (Roslyn
+        // emits the legacy IL "unmanaged stdcall" signature encoding, no modopt
+        // polyfill required).
+        ((delegate* unmanaged[Stdcall]<DLLVERSIONINFO*, HRESULT>)proc.Value)(&versionInfo).ThrowOnFailure();
 
         return new Version(
             (int)versionInfo.dwMajorVersion,

--- a/madowaku/Windows/Win32/System/Com/ComClassFactory.cs
+++ b/madowaku/Windows/Win32/System/Com/ComClassFactory.cs
@@ -18,11 +18,6 @@ public sealed unsafe class ComClassFactory : IDisposable
     private readonly bool _unloadModule;
     private readonly IClassFactory* _classFactory;
 
-    private delegate HRESULT DllGetClassObjectProc(
-        Guid* rclsid,
-        Guid* riid,
-        void** ppv);
-
     /// <summary>
     ///  The class ID.
     /// </summary>
@@ -68,18 +63,17 @@ public sealed unsafe class ComClassFactory : IDisposable
         IClassFactory* classFactory;
         Guid iid = IClassFactory.IID_Guid;
 
-#if NETFRAMEWORK
-        // In .NET Framework we need to use the delegate type to call the method.
-        Marshal.GetDelegateForFunctionPointer<DllGetClassObjectProc>(proc.Value)(
+        // DllGetClassObject is declared STDAPI (__stdcall). The explicit [Stdcall]
+        // qualifier is required: it is convention-correct on x86 (where Stdcall and
+        // Cdecl differ in who cleans the stack) and compiles on net472, where the
+        // Roslyn lowering uses the legacy IL "unmanaged stdcall" signature encoding
+        // rather than a CallConvStdcall modopt. An unqualified delegate* unmanaged
+        // would not compile on net472 (CS8889) and would resolve to Cdecl on x86
+        // on modern .NET.
+        ((delegate* unmanaged[Stdcall]<Guid*, Guid*, void**, HRESULT>)proc.Value)(
             &classId,
             &iid,
             (void**)&classFactory).ThrowOnFailure();
-#else
-        ((delegate* unmanaged<Guid*, Guid*, void**, HRESULT>)proc.Value)(
-            &classId,
-            &iid,
-            (void**)&classFactory).ThrowOnFailure();
-#endif
 
         _classFactory = classFactory;
     }


### PR DESCRIPTION
## Summary

Removed the `#if NETFRAMEWORK` split in `ComClassFactory` and `HMODULE.GetDllVersion`. Both call sites now share a single `delegate* unmanaged[Stdcall]<...>` invocation, dropping the private delegate types and the `Marshal.GetDelegateForFunctionPointer` branch.

## Why `[Stdcall]` explicitly

`DllGetClassObject` and `DllGetVersion` are declared `STDAPI` (`__stdcall`). The previous modern-.NET branch used an unqualified `delegate* unmanaged<...>`, which:

1. **Resolves to Cdecl on Windows x86** — caller-cleanup vs. callee-cleanup; on a 32-bit process this would corrupt the stack on return from the export. (Verified empirically: a `[Cdecl]` function pointer against `kernel32!MulDiv` crashes with `0xC0000409` STATUS_STACK_BUFFER_OVERRUN on x86; the `[Stdcall]` form works cleanly.)
2. **Fails to compile against net472** with `CS8889: The target runtime doesn't support extensible or runtime-environment default calling conventions`. That's why the `#if NETFRAMEWORK` existed — but using an explicit `[Stdcall]` qualifier sidesteps the issue entirely.

On net472, `delegate* unmanaged[Stdcall]<...>` is lowered by Roslyn to the legacy ECMA-335 `calli unmanaged stdcall` signature encoding — no `CallConvStdcall` modopt, no polyfill required. Confirmed by disassembly: the IL contains `calli unmanaged stdcall int32(...)` with zero references to `CallConv*` types.

## Test coverage

Existing tests exercise the changed code paths on both `net10.0-windows10.0.22000.0` and `net481`:

- `ComClassFactoryTests.Constructor_Hmodule_KnownExport_ExposesClassId` — loads `ole32.dll` and invokes `DllGetClassObject` via the fixed call site.
- `HMODULETests.GetDllVersion_Shell32_ReturnsVersion` — loads `shell32.dll` and invokes `DllGetVersion` via the fixed call site.

Both pass in Release on both TFMs.

## Notes for reviewers

- No behavior change on x64 (only one unmanaged calling convention exists there).
- Net472 behavior was already going through a `Winapi` (= Stdcall) delegate, so it remains correct; the new path goes through the same calling convention via a direct `calli` instead of delegate marshalling.
- The change removes a `Marshal.GetDelegateForFunctionPointer` call per construction on Framework, which was the slower path.