### PR TITLE
Convert tests from xUnit to MSTest with method-level parallelism

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ Top-level layout:
 
 - `madowaku/` &mdash; main library (CsWin32 P/Invoke surface, COM helpers,
   net472 polyfills under `madowaku/Framework/`)
-- `madowaku.tests/` &mdash; xUnit v3 tests (uses FluentAssertions; targets
+- `madowaku.tests/` &mdash; MSTest tests (uses AwesomeAssertions; targets
   `net10.0-windows10.0.22000.0` and `net481`)
 - `artifacts/`, `TestResults/` &mdash; build/test output (ignored)
 
@@ -130,9 +130,9 @@ Detailed test conventions live in
 [.github/instructions/tests.instructions.md](instructions/tests.instructions.md)
 (applies to `madowaku.tests/**/*.cs`). Headline rules: place tests in
 `madowaku.tests`; name them `MethodName_StateUnderTest_ExpectedBehavior`;
-use FluentAssertions; xUnit v3 with the Microsoft Testing Platform
-runner; cover edge and negative cases; do not add "Arrange, Act, Assert"
-comments.
+use AwesomeAssertions `.Should()`; MSTest with the Microsoft Testing
+Platform runner and method-level parallelism; cover edge and negative
+cases; do not add "Arrange, Act, Assert" comments.
 
 ## Working with the user on changes
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -4,21 +4,29 @@ applyTo: "madowaku.tests/**/*.cs"
 
 # Test conventions (`madowaku.tests/`)
 
-Path-specific rules for the xUnit v3 test project. The general `AGENTS.md`
+Path-specific rules for the MSTest test project. The general `AGENTS.md`
 rules (coding style, whitespace, file header) still apply.
 
 ## Framework
 
-- xUnit v3 with the **Microsoft Testing Platform** runner
-  (`UseMicrosoftTestingPlatformRunner` is set in the csproj). Run tests
-  with `dotnet test`; do not invoke `vstest` directly.
+- **MSTest** with the **Microsoft Testing Platform** runner
+  (`EnableMSTestRunner` is set in the csproj). Run tests with
+  `dotnet test`; do not invoke `vstest` directly.
+- Tests run with **method-level parallelism**. The assembly-level
+  `[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]`
+  attribute lives in `GlobalUsings.cs`. Do not rely on shared mutable
+  static state between test methods; if a test cannot run in parallel,
+  mark it `[DoNotParallelize]`.
 - Target frameworks: `net10.0-windows10.0.22000.0` and `net481`. All
   tests must build and pass on both.
-- `Xunit` is available via a project-level `<Using>`; `using Xunit;` is
-  unnecessary.
-- `FluentAssertions` is referenced. Either `Assert.*` (xUnit) or
-  `.Should().*` (FluentAssertions) is acceptable; pick one style per
-  file and stay consistent within it.
+- `Microsoft.VisualStudio.TestTools.UnitTesting` is available via a
+  project-level `<Using>`, so `[TestClass]` / `[TestMethod]` need no
+  explicit `using`.
+- **AwesomeAssertions** (a FluentAssertions fork) is globally used via
+  `global using AwesomeAssertions;` in `GlobalUsings.cs`. Assert with
+  `.Should().*` only; do not use MSTest's native `Assert.*`. Use
+  `FluentActions.Invoking(() => ...).Should().Throw<T>()` for exception
+  assertions.
 
 ## Naming and structure
 
@@ -27,8 +35,8 @@ rules (coding style, whitespace, file header) still apply.
 - Mirror the source layout: a test for `madowaku/Windows/Win32/Foo.cs`
   lives at `madowaku.tests/Windows/Win32/FooTests.cs` with namespace
   matching the production type.
-- One `public class FooTests` per type under test. Multiple `[Fact]`s
-  per class is fine.
+- One `[TestClass] public class FooTests` per type under test. Multiple
+  `[TestMethod]`s per class is fine.
 - Do **not** add "Arrange / Act / Assert" comments. The structure should
   be obvious from the code.
 
@@ -55,8 +63,10 @@ rules (coding style, whitespace, file header) still apply.
 
 ## What not to do
 
-- Do not introduce a separate test SDK (MSTest, NUnit) alongside xUnit.
+- Do not introduce a separate test SDK (xUnit, NUnit) alongside MSTest.
+- Do not use MSTest's native `Assert.*`; use AwesomeAssertions
+  `.Should().*` throughout.
 - Do not gate tests on a specific machine, locale, or installed SDK
-  without a clear `[Fact(Skip = "...")]` reason.
+  without a clear `[Ignore("...")]` reason.
 - Do not use `Thread.Sleep` for synchronization; use the appropriate
-  xUnit / `Task`-based primitives.
+  `Task`-based primitives.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -14,7 +14,7 @@ rules (coding style, whitespace, file header) still apply.
   `dotnet test`; do not invoke `vstest` directly.
 - Tests run with **method-level parallelism**. The assembly-level
   `[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]`
-  attribute lives in `GlobalUsings.cs`. Do not rely on shared mutable
+  attribute lives in `AssemblyInfo.cs`. Do not rely on shared mutable
   static state between test methods; if a test cannot run in parallel,
   mark it `[DoNotParallelize]`.
 - Target frameworks: `net10.0-windows10.0.22000.0` and `net481`. All

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,8 +34,8 @@ jobs:
 
         dotnet test --no-build `
           --results-directory "$resultsDir" `
-          --report-xunit-trx `
-          --show-live-output on
+          --report-trx `
+          --output Detailed
     - name: Test release
       run: |
         $resultsDir = Join-Path $PWD.Path 'artifacts/test-results/release'
@@ -43,8 +43,8 @@ jobs:
 
         dotnet test -c Release --no-build `
           --results-directory "$resultsDir" `
-          --report-xunit-trx `
-          --show-live-output on `
+          --report-trx `
+          --output Detailed `
           --coverage `
           --coverage-output-format cobertura `
           --coverage-settings "$PWD/.config/coverage.settings.xml"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Top-level layout:
 
 - `madowaku/` &mdash; main library (CsWin32 P/Invoke surface, COM helpers,
   net472 polyfills under `madowaku/Framework/`)
-- `madowaku.tests/` &mdash; xUnit v3 tests (uses FluentAssertions; targets
+- `madowaku.tests/` &mdash; MSTest tests (uses AwesomeAssertions; targets
   `net10.0-windows10.0.22000.0` and `net481`)
 - `artifacts/`, `TestResults/` &mdash; build/test output (ignored)
 
@@ -129,9 +129,9 @@ Detailed test conventions live in
 [.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md)
 (applies to `madowaku.tests/**/*.cs`). Headline rules: place tests in
 `madowaku.tests`; name them `MethodName_StateUnderTest_ExpectedBehavior`;
-use FluentAssertions; xUnit v3 with the Microsoft Testing Platform
-runner; cover edge and negative cases; do not add "Arrange, Act, Assert"
-comments.
+use AwesomeAssertions `.Should()`; MSTest with the Microsoft Testing
+Platform runner and method-level parallelism; cover edge and negative
+cases; do not add "Arrange, Act, Assert" comments.
 
 ## Working with the user on changes
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,10 +11,10 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.242" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.0" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != '$(DotNetCoreVersion)'">
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />

--- a/madowaku.tests/AssemblyInfo.cs
+++ b/madowaku.tests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Run test methods in parallel within the assembly.
+[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]

--- a/madowaku.tests/GlobalUsings.cs
+++ b/madowaku.tests/GlobalUsings.cs
@@ -2,3 +2,5 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+global using AwesomeAssertions;
+

--- a/madowaku.tests/Windows/Win32/Foundation/BSTRTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/BSTRTests.cs
@@ -4,65 +4,66 @@
 
 namespace Windows.Win32.Foundation;
 
+[TestClass]
 public class BSTRTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_ManagedString_RoundTripsValue()
     {
         using BSTR bstr = new("hello");
-        Assert.False(bstr.IsNull);
-        Assert.Equal("hello", bstr.ToString());
+        bstr.IsNull.Should().BeFalse();
+        bstr.ToString().Should().Be("hello");
     }
 
-    [Fact]
+    [TestMethod]
     public void IsNull_DefaultInstance_ReturnsTrue()
     {
         BSTR bstr = default;
-        Assert.True(bstr.IsNull);
+        bstr.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void ToStringAndFree_ReturnsValueAndFrees()
     {
         BSTR bstr = new("disposable");
         string result = bstr.ToStringAndFree();
-        Assert.Equal("disposable", result);
-        Assert.True(bstr.IsNull);
+        result.Should().Be("disposable");
+        bstr.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_ClearsPointer()
     {
         BSTR bstr = new("clear me");
         bstr.Dispose();
-        Assert.True(bstr.IsNull);
+        bstr.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void TryFormat_DestinationLargeEnough_WritesAllChars()
     {
         using BSTR bstr = new("abc");
         Span<char> buffer = stackalloc char[8];
         bool result = bstr.TryFormat(buffer, out int written, default, null);
-        Assert.True(result);
-        Assert.Equal(3, written);
-        Assert.Equal("abc", buffer[..written].ToString());
+        result.Should().BeTrue();
+        written.Should().Be(3);
+        buffer[..written].ToString().Should().Be("abc");
     }
 
-    [Fact]
+    [TestMethod]
     public void TryFormat_DestinationTooSmall_ReturnsFalse()
     {
         using BSTR bstr = new("abcdef");
         Span<char> buffer = stackalloc char[3];
         bool result = bstr.TryFormat(buffer, out int written, default, null);
-        Assert.False(result);
-        Assert.Equal(0, written);
+        result.Should().BeFalse();
+        written.Should().Be(0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToStringWithFormat_IgnoresFormatAndProvider()
     {
         using BSTR bstr = new("value");
-        Assert.Equal("value", bstr.ToString("X", null));
+        bstr.ToString("X", null).Should().Be("value");
     }
 }

--- a/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
@@ -6,160 +6,161 @@ using System.ComponentModel;
 
 namespace Windows.Win32.Foundation;
 
+[TestClass]
 public class ErrorTests
 {
-    [Fact]
+    [TestMethod]
     public void ToHRESULT_Success_ReturnsZero()
     {
         HRESULT hr = WIN32_ERROR.ERROR_SUCCESS.ToHRESULT();
-        Assert.Equal(0, hr.Value);
+        hr.Value.Should().Be(0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToHRESULT_NonSuccess_SetsFacilityWin32()
     {
         HRESULT hr = WIN32_ERROR.ERROR_ACCESS_DENIED.ToHRESULT();
-        Assert.Equal(unchecked((int)0x80070005), hr.Value);
+        hr.Value.Should().Be(unchecked((int)0x80070005));
     }
 
-    [Fact]
+    [TestMethod]
     public void ErrorToString_Success_StartsWithErrorSuccess()
     {
         string text = WIN32_ERROR.ERROR_SUCCESS.ErrorToString();
-        Assert.StartsWith("ERROR_SUCCESS", text);
+        text.Should().StartWith("ERROR_SUCCESS");
     }
 
-    [Fact]
+    [TestMethod]
     public void ErrorToString_KnownError_IncludesEnumName()
     {
         string text = WIN32_ERROR.ERROR_FILE_NOT_FOUND.ErrorToString();
-        Assert.Contains("ERROR_FILE_NOT_FOUND", text);
+        text.Should().Contain("ERROR_FILE_NOT_FOUND");
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_FileNotFound_ReturnsFileNotFoundException()
     {
         Exception ex = WIN32_ERROR.ERROR_FILE_NOT_FOUND.GetException("foo.txt");
-        Assert.IsType<FileNotFoundException>(ex);
+        ex.Should().BeOfType<FileNotFoundException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_PathNotFound_ReturnsDirectoryNotFoundException()
     {
         Exception ex = WIN32_ERROR.ERROR_PATH_NOT_FOUND.GetException();
-        Assert.IsType<DirectoryNotFoundException>(ex);
+        ex.Should().BeOfType<DirectoryNotFoundException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_AccessDenied_ReturnsUnauthorizedAccessException()
     {
         Exception ex = WIN32_ERROR.ERROR_ACCESS_DENIED.GetException();
-        Assert.IsType<UnauthorizedAccessException>(ex);
+        ex.Should().BeOfType<UnauthorizedAccessException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_InvalidParameter_ReturnsArgumentException()
     {
         Exception ex = WIN32_ERROR.ERROR_INVALID_PARAMETER.GetException();
-        Assert.IsType<ArgumentException>(ex);
+        ex.Should().BeOfType<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_NotSupported_ReturnsNotSupportedException()
     {
         Exception ex = WIN32_ERROR.ERROR_NOT_SUPPORTED.GetException();
-        Assert.IsType<NotSupportedException>(ex);
+        ex.Should().BeOfType<NotSupportedException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void Throw_AlwaysThrows()
     {
-        Assert.Throws<FileNotFoundException>(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.Throw());
+        FluentActions.Invoking(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.Throw()).Should().Throw<FileNotFoundException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void ThrowIfFailed_Success_DoesNotThrow()
     {
         WIN32_ERROR.ERROR_SUCCESS.ThrowIfFailed();
     }
 
-    [Fact]
+    [TestMethod]
     public void ThrowIfFailed_Failure_Throws()
     {
-        Assert.Throws<FileNotFoundException>(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.ThrowIfFailed());
+        FluentActions.Invoking(() => WIN32_ERROR.ERROR_FILE_NOT_FOUND.ThrowIfFailed()).Should().Throw<FileNotFoundException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_FilenameExcedRange_ReturnsPathTooLongException()
     {
         Exception ex = WIN32_ERROR.ERROR_FILENAME_EXCED_RANGE.GetException();
-        Assert.IsType<PathTooLongException>(ex);
+        ex.Should().BeOfType<PathTooLongException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_InvalidDrive_ReturnsDriveNotFoundException()
     {
         Exception ex = WIN32_ERROR.ERROR_INVALID_DRIVE.GetException();
-        Assert.IsType<DriveNotFoundException>(ex);
+        ex.Should().BeOfType<DriveNotFoundException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_OperationAborted_ReturnsOperationCanceledException()
     {
         Exception ex = WIN32_ERROR.ERROR_OPERATION_ABORTED.GetException();
-        Assert.IsType<OperationCanceledException>(ex);
+        ex.Should().BeOfType<OperationCanceledException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_Cancelled_ReturnsOperationCanceledException()
     {
         Exception ex = WIN32_ERROR.ERROR_CANCELLED.GetException();
-        Assert.IsType<OperationCanceledException>(ex);
+        ex.Should().BeOfType<OperationCanceledException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_NetworkAccessDenied_ReturnsUnauthorizedAccessException()
     {
         Exception ex = WIN32_ERROR.ERROR_NETWORK_ACCESS_DENIED.GetException();
-        Assert.IsType<UnauthorizedAccessException>(ex);
+        ex.Should().BeOfType<UnauthorizedAccessException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_NotReady_ReturnsWin32Exception()
     {
         Exception ex = WIN32_ERROR.ERROR_NOT_READY.GetException();
-        Assert.IsType<Win32Exception>(ex);
+        ex.Should().BeOfType<Win32Exception>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_FileExists_ReturnsWin32Exception()
     {
         Exception ex = WIN32_ERROR.ERROR_FILE_EXISTS.GetException();
-        Assert.IsType<Win32Exception>(ex);
+        ex.Should().BeOfType<Win32Exception>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_AlreadyExists_ReturnsWin32Exception()
     {
         Exception ex = WIN32_ERROR.ERROR_ALREADY_EXISTS.GetException();
-        Assert.IsType<Win32Exception>(ex);
+        ex.Should().BeOfType<Win32Exception>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_NotSupportedInAppContainer_ReturnsNotSupportedException()
     {
         Exception ex = WIN32_ERROR.ERROR_NOT_SUPPORTED_IN_APPCONTAINER.GetException();
-        Assert.IsType<NotSupportedException>(ex);
+        ex.Should().BeOfType<NotSupportedException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetException_UnknownError_ReturnsWin32Exception()
     {
         Exception ex = ((WIN32_ERROR)9999).GetException();
-        Assert.IsType<Win32Exception>(ex);
+        ex.Should().BeOfType<Win32Exception>();
     }
 
-    [Fact]
+    [TestMethod]
     public void ThrowIfLastErrorNot_LastErrorMatches_DoesNotThrow()
     {
         // Read the current last-error so the test doesn't depend on prior state, then assert

--- a/madowaku.tests/Windows/Win32/Foundation/FILETIMETests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/FILETIMETests.cs
@@ -4,23 +4,24 @@
 
 namespace Windows.Win32.Foundation;
 
+[TestClass]
 public class FILETIMETests
 {
-    [Fact]
+    [TestMethod]
     public void ExplicitCast_DateTimeRoundTrip_PreservesValue()
     {
         DateTime original = new DateTime(2025, 5, 11, 13, 45, 30, DateTimeKind.Utc).ToLocalTime();
         FILETIME ft = (FILETIME)original;
         DateTime roundTripped = (DateTime)ft;
-        Assert.Equal(original, roundTripped);
+        roundTripped.Should().Be(original);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitCast_FromDateTime_PopulatesLowAndHighParts()
     {
         DateTime value = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime();
         FILETIME ft = (FILETIME)value;
         long combined = ((long)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
-        Assert.Equal(value.ToFileTime(), combined);
+        combined.Should().Be(value.ToFileTime());
     }
 }

--- a/madowaku.tests/Windows/Win32/Foundation/HMODULETests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HMODULETests.cs
@@ -6,37 +6,38 @@ using System.ComponentModel;
 
 namespace Windows.Win32.Foundation;
 
+[TestClass]
 public class HMODULETests
 {
-    [Fact]
+    [TestMethod]
     public void GetLaunchingExecutable_ReturnsNonNullModule()
     {
         HMODULE module = HMODULE.GetLaunchingExecutable();
-        Assert.False(module.IsNull);
+        module.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void FromName_KnownSystemDll_ReturnsLoadedModule()
     {
         // kernel32 is always loaded in any Windows process.
         HMODULE module = HMODULE.FromName("kernel32.dll");
-        Assert.False(module.IsNull);
+        module.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void FromName_UnknownModule_ReturnsNullHandle()
     {
         HMODULE module = HMODULE.FromName("definitely-not-a-real-module.dll");
-        Assert.True(module.IsNull);
+        module.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void LoadModule_KnownSystemDll_ReturnsModule()
     {
         HMODULE module = HMODULE.LoadModule("shell32.dll");
         try
         {
-            Assert.False(module.IsNull);
+            module.IsNull.Should().BeFalse();
         }
         finally
         {
@@ -44,45 +45,43 @@ public class HMODULETests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void LoadModule_NonexistentPath_ThrowsWin32Exception()
     {
-        Win32Exception ex = Assert.Throws<Win32Exception>(
-            () => HMODULE.LoadModule("madowaku-no-such-file.dll"));
+        Win32Exception ex = FluentActions.Invoking(() => HMODULE.LoadModule("madowaku-no-such-file.dll"))
+            .Should().Throw<Win32Exception>().Which;
 
         // ERROR_MOD_NOT_FOUND = 126, ERROR_FILE_NOT_FOUND = 2, ERROR_PATH_NOT_FOUND = 3
-        Assert.True(
-            ex.NativeErrorCode is 126 or 2 or 3,
-            $"Unexpected NativeErrorCode {ex.NativeErrorCode}");
+        ex.NativeErrorCode.Should().BeOneOf(126, 2, 3);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetProcAddress_KnownExport_ReturnsNonNullAddress()
     {
         HMODULE module = HMODULE.FromName("kernel32.dll");
         FARPROC proc = module.GetProcAddress("GetCurrentProcessId");
-        Assert.False(proc.IsNull);
+        proc.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetProcAddress_UnknownExport_ThrowsWin32Exception()
     {
         HMODULE module = HMODULE.FromName("kernel32.dll");
-        Win32Exception ex = Assert.Throws<Win32Exception>(
-            () => module.GetProcAddress("MadowakuNoSuchExport"));
+        Win32Exception ex = FluentActions.Invoking(() => module.GetProcAddress("MadowakuNoSuchExport"))
+            .Should().Throw<Win32Exception>().Which;
 
         // ERROR_PROC_NOT_FOUND = 127
-        Assert.Equal(127, ex.NativeErrorCode);
+        ex.NativeErrorCode.Should().Be(127);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDllVersion_Shell32_ReturnsVersion()
     {
         HMODULE module = HMODULE.LoadModule("shell32.dll");
         try
         {
             Version version = module.GetDllVersion();
-            Assert.True(version.Major >= 5);
+            version.Major.Should().BeGreaterThanOrEqualTo(5);
         }
         finally
         {
@@ -90,12 +89,12 @@ public class HMODULETests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void FromAddress_AddressInsideKernel32_ReturnsKernel32()
     {
         HMODULE kernel32 = HMODULE.FromName("kernel32.dll");
         FARPROC proc = kernel32.GetProcAddress("GetCurrentProcessId");
         HMODULE byAddress = HMODULE.FromAddress(proc.Value);
-        Assert.Equal(kernel32, byAddress);
+        byAddress.Should().Be(kernel32);
     }
 }

--- a/madowaku.tests/Windows/Win32/Foundation/HRESULTTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HRESULTTests.cs
@@ -6,58 +6,59 @@ using Windows.Win32.System.Diagnostics.Debug;
 
 namespace Windows.Win32.Foundation;
 
+[TestClass]
 public class HRESULTTests
 {
-    [Fact]
+    [TestMethod]
     public void Code_ReturnsLowSixteenBits()
     {
         HRESULT hr = (HRESULT)unchecked((int)0x80070005);
-        Assert.Equal(0x0005, hr.Code);
+        hr.Code.Should().Be(0x0005);
     }
 
-    [Fact]
+    [TestMethod]
     public void Facility_ReturnsExpectedFacility()
     {
         HRESULT hr = (HRESULT)unchecked((int)0x80070005);
-        Assert.Equal(FACILITY_CODE.FACILITY_WIN32, hr.Facility);
+        hr.Facility.Should().Be(FACILITY_CODE.FACILITY_WIN32);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitCastFromWin32Error_Success_ReturnsZero()
     {
         HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_SUCCESS;
-        Assert.Equal(0, hr.Value);
+        hr.Value.Should().Be(0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitCastFromWin32Error_NonZero_SetsFacilityWin32AndSeverityBit()
     {
         HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND;
-        Assert.Equal(unchecked((int)0x80070002), hr.Value);
-        Assert.Equal(FACILITY_CODE.FACILITY_WIN32, hr.Facility);
-        Assert.Equal((int)WIN32_ERROR.ERROR_FILE_NOT_FOUND, hr.Code);
+        hr.Value.Should().Be(unchecked((int)0x80070002));
+        hr.Facility.Should().Be(FACILITY_CODE.FACILITY_WIN32);
+        hr.Code.Should().Be((int)WIN32_ERROR.ERROR_FILE_NOT_FOUND);
     }
 
-    [Fact]
+    [TestMethod]
     public void ImplicitCastToException_FailingHResult_ReturnsException()
     {
         Exception ex = HRESULT.COR_E_ARGUMENT;
-        Assert.NotNull(ex);
+        ex.Should().NotBeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void ToStringWithDescription_Win32Facility_ContainsErrorName()
     {
         HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND;
         string text = hr.ToStringWithDescription();
-        Assert.Contains("0x80070002", text);
-        Assert.Contains("ERROR_FILE_NOT_FOUND", text);
+        text.Should().Contain("0x80070002");
+        text.Should().Contain("ERROR_FILE_NOT_FOUND");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToStringWithDescription_NonWin32Facility_ContainsHexValue()
     {
         string text = HRESULT.COR_E_OBJECTDISPOSED.ToStringWithDescription();
-        Assert.Contains("0x80131622", text);
+        text.Should().Contain("0x80131622");
     }
 }

--- a/madowaku.tests/Windows/Win32/Foundation/StringParameterArrayTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/StringParameterArrayTests.cs
@@ -4,57 +4,58 @@
 
 namespace Windows.Win32.Foundation;
 
+[TestClass]
 public class StringParameterArrayTests
 {
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_NullArray_ProducesNullPointer()
     {
         using StringParameterArray array = new(null);
         char** ptr = array;
-        Assert.True(ptr is null);
+        (ptr is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_EmptyArray_ProducesNullPointer()
     {
         using StringParameterArray array = new([]);
         char** ptr = array;
-        Assert.True(ptr is null);
+        (ptr is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_PopulatedArray_PointersPointToPinnedStrings()
     {
         string[] values = ["alpha", "beta", "gamma"];
         using StringParameterArray array = new(values);
         char** ptr = array;
-        Assert.False(ptr is null);
+        (ptr is null).Should().BeFalse();
 
         for (int i = 0; i < values.Length; i++)
         {
             string actual = new(ptr[i]);
-            Assert.Equal(values[i], actual);
+            actual.Should().Be(values[i]);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_SbyteDoublePointer_NonNullForPopulated()
     {
         string[] values = ["x"];
         using StringParameterArray array = new(values);
         sbyte** ptr = array;
-        Assert.False(ptr is null);
+        (ptr is null).Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_SbyteDoublePointer_NullForEmpty()
     {
         using StringParameterArray array = new(null);
         sbyte** ptr = array;
-        Assert.True(ptr is null);
+        (ptr is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_NullArray_DoesNotThrow()
     {
         StringParameterArray array = new(null);

--- a/madowaku.tests/Windows/Win32/System/Com/AgileComPointerTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/AgileComPointerTests.cs
@@ -6,9 +6,10 @@ using Windows.Win32.Foundation;
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class AgileComPointerTests
 {
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_RegistersInterface_AndGetInterfaceReturnsScope()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
@@ -18,7 +19,7 @@ public class AgileComPointerTests
         try
         {
             using ComScope<IUnknown> scope = agile.GetInterface();
-            Assert.False(scope.IsNull);
+            scope.IsNull.Should().BeFalse();
         }
         finally
         {
@@ -26,7 +27,7 @@ public class AgileComPointerTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void TryGetInterface_ReturnsSuccess()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
@@ -36,8 +37,8 @@ public class AgileComPointerTests
         try
         {
             using ComScope<IUnknown> scope = agile.TryGetInterface(out HRESULT hr);
-            Assert.True(hr.Succeeded);
-            Assert.False(scope.IsNull);
+            hr.Succeeded.Should().BeTrue();
+            scope.IsNull.Should().BeFalse();
         }
         finally
         {
@@ -45,7 +46,7 @@ public class AgileComPointerTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Equals_SamePointer_ReturnsTrue()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
@@ -55,7 +56,7 @@ public class AgileComPointerTests
         AgileComPointer<IUnknown> agile = new(ptr, takeOwnership: false);
         try
         {
-            Assert.True(agile.Equals(ptr));
+            agile.Equals(ptr).Should().BeTrue();
         }
         finally
         {
@@ -63,7 +64,7 @@ public class AgileComPointerTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void GetInterface_Generic_RequeriesAsSameInterface_Succeeds()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
@@ -73,7 +74,7 @@ public class AgileComPointerTests
         try
         {
             using ComScope<IUnknown> scope = agile.GetInterface<IUnknown>();
-            Assert.False(scope.IsNull);
+            scope.IsNull.Should().BeFalse();
         }
         finally
         {
@@ -81,7 +82,7 @@ public class AgileComPointerTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void TryGetInterface_Generic_RequeriesAsSameInterface_Succeeds()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
@@ -91,8 +92,8 @@ public class AgileComPointerTests
         try
         {
             using ComScope<IUnknown> scope = agile.TryGetInterface<IUnknown>(out HRESULT hr);
-            Assert.True(hr.Succeeded);
-            Assert.False(scope.IsNull);
+            hr.Succeeded.Should().BeTrue();
+            scope.IsNull.Should().BeFalse();
         }
         finally
         {

--- a/madowaku.tests/Windows/Win32/System/Com/CLSIDTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/CLSIDTests.cs
@@ -4,59 +4,60 @@
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class CLSIDTests
 {
-    [Fact]
+    [TestMethod]
     public void StdGlobalInterfaceTable_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("00000323-0000-0000-c000-000000000046"), CLSID.StdGlobalInterfaceTable);
+        CLSID.StdGlobalInterfaceTable.Should().Be(new Guid("00000323-0000-0000-c000-000000000046"));
     }
 
-    [Fact]
+    [TestMethod]
     public void FileOpenDialog_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("dc1c5a9c-e88a-4dde-a5a1-60f82a20aef7"), CLSID.FileOpenDialog);
+        CLSID.FileOpenDialog.Should().Be(new Guid("dc1c5a9c-e88a-4dde-a5a1-60f82a20aef7"));
     }
 
-    [Fact]
+    [TestMethod]
     public void FileSaveDialog_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("c0b4e2f3-ba21-4773-8dba-335ec946eb8b"), CLSID.FileSaveDialog);
+        CLSID.FileSaveDialog.Should().Be(new Guid("c0b4e2f3-ba21-4773-8dba-335ec946eb8b"));
     }
 
-    [Fact]
+    [TestMethod]
     public void AutoComplete_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("00bb2763-6a77-11d0-a535-00c04fd7d062"), CLSID.AutoComplete);
+        CLSID.AutoComplete.Should().Be(new Guid("00bb2763-6a77-11d0-a535-00c04fd7d062"));
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropHelper_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("4657278a-411b-11d2-839a-00c04fd918d0"), CLSID.DragDropHelper);
+        CLSID.DragDropHelper.Should().Be(new Guid("4657278a-411b-11d2-839a-00c04fd918d0"));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetupConfiguration_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("177f0c4a-1cd3-4de7-a32c-71dbbb9fa36d"), CLSID.SetupConfiguration);
+        CLSID.SetupConfiguration.Should().Be(new Guid("177f0c4a-1cd3-4de7-a32c-71dbbb9fa36d"));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetupConfiguration2_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("42843719-db4c-46c2-8e7c-64f1816efd5b"), CLSID.SetupConfiguration2);
+        CLSID.SetupConfiguration2.Should().Be(new Guid("42843719-db4c-46c2-8e7c-64f1816efd5b"));
     }
 
-    [Fact]
+    [TestMethod]
     public void StdComponentCategoriesManager_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("0002e005-0000-0000-c000-000000000046"), CLSID.StdComponentCategoriesManager);
+        CLSID.StdComponentCategoriesManager.Should().Be(new Guid("0002e005-0000-0000-c000-000000000046"));
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowsMediaPlayer_HasExpectedGuid()
     {
-        Assert.Equal(new Guid("6bf52a52-394a-11d3-b153-00c04f79faa6"), CLSID.WindowsMediaPlayer);
+        CLSID.WindowsMediaPlayer.Should().Be(new Guid("6bf52a52-394a-11d3-b153-00c04f79faa6"));
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/ComClassFactoryTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComClassFactoryTests.cs
@@ -7,58 +7,58 @@ using Windows.Win32.Foundation;
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class ComClassFactoryTests
 {
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_RegisteredClsid_CreateInstance_ReturnsInterface()
     {
         // StdGlobalInterfaceTable is always registered.
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
         using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
-        Assert.False(unknown.IsNull);
+        unknown.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void TryCreateInstance_ReturnsSuccess()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
         using ComScope<IUnknown> unknown = factory.TryCreateInstance<IUnknown>(out HRESULT hr);
-        Assert.True(hr.Succeeded);
-        Assert.False(unknown.IsNull);
+        hr.Succeeded.Should().BeTrue();
+        unknown.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ComScope_QueryInterface_ToIUnknown_Succeeds()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
         using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
         using ComScope<IUnknown> requeried = unknown.QueryInterface<IUnknown>();
-        Assert.False(requeried.IsNull);
+        requeried.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ComScope_TryQueryInterface_ToIUnknown_Succeeds()
     {
         using ComClassFactory factory = new(CLSID.StdGlobalInterfaceTable);
         using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
         using ComScope<IUnknown> requeried = unknown.TryQueryInterface<IUnknown>(out HRESULT hr);
-        Assert.True(hr.Succeeded);
-        Assert.False(requeried.IsNull);
+        hr.Succeeded.Should().BeTrue();
+        requeried.IsNull.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_FilePath_NonexistentDll_ThrowsWin32Exception()
     {
-        Win32Exception ex = Assert.Throws<Win32Exception>(
-            () => new ComClassFactory("madowaku-no-such-dll.dll", CLSID.FileOpenDialog));
+        Win32Exception ex = FluentActions.Invoking(
+            () => new ComClassFactory("madowaku-no-such-dll.dll", CLSID.FileOpenDialog))
+            .Should().Throw<Win32Exception>().Which;
 
         // ERROR_MOD_NOT_FOUND = 126, ERROR_FILE_NOT_FOUND = 2, ERROR_PATH_NOT_FOUND = 3
-        Assert.True(
-            ex.NativeErrorCode is 126 or 2 or 3,
-            $"Unexpected NativeErrorCode {ex.NativeErrorCode}");
+        ex.NativeErrorCode.Should().BeOneOf(126, 2, 3);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_Hmodule_KnownExport_ExposesClassId()
     {
         // Explicitly load ole32.dll so the test isn't order-/environment-dependent.
@@ -67,10 +67,10 @@ public class ComClassFactoryTests
         try
         {
             using ComClassFactory factory = new(ole32, CLSID.StdGlobalInterfaceTable);
-            Assert.Equal(CLSID.StdGlobalInterfaceTable, factory.ClassId);
+            factory.ClassId.Should().Be(CLSID.StdGlobalInterfaceTable);
 
             using ComScope<IUnknown> unknown = factory.CreateInstance<IUnknown>();
-            Assert.False(unknown.IsNull);
+            unknown.IsNull.Should().BeFalse();
         }
         finally
         {

--- a/madowaku.tests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
@@ -6,47 +6,48 @@ using Windows.Win32.System.Variant;
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class ComSafeArrayScopeTests
 {
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_NullSafearrayPointer_IsNullTrue()
     {
         using ComSafeArrayScope<IUnknown> scope = new((SAFEARRAY*)null);
-        Assert.True(scope.IsNull);
+        scope.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_WrongVarType_Throws()
     {
         using SafeArrayScope<int> source = new(1);
         SAFEARRAY* ptr = source.Value;
-        Assert.Throws<ArgumentException>(() => new ComSafeArrayScope<IUnknown>(ptr));
+        FluentActions.Invoking(() => new ComSafeArrayScope<IUnknown>(ptr)).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_VT_UNKNOWN_Array_Wraps()
     {
         // Build a 1-element VT_UNKNOWN SAFEARRAY manually and wrap it.
         SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
         SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
-        Assert.False(array is null);
+        (array is null).Should().BeFalse();
 
         using ComSafeArrayScope<IUnknown> scope = new(array);
-        Assert.False(scope.IsNull);
-        Assert.Equal(1, scope.Length);
-        Assert.False(scope.IsEmpty);
+        scope.IsNull.Should().BeFalse();
+        scope.Length.Should().Be(1);
+        scope.IsEmpty.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Length_NonEmptyArray_ReturnsCElements()
     {
         SAFEARRAYBOUND bound = new() { cElements = 3, lLbound = 0 };
         SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
         using ComSafeArrayScope<IUnknown> scope = new(array);
-        Assert.Equal(3, scope.Length);
+        scope.Length.Should().Be(3);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Indexer_NullEntry_ReturnsNullComScope()
     {
         SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
@@ -55,17 +56,17 @@ public class ComSafeArrayScopeTests
 
         // Default entry is null; the indexer should return a ComScope wrapping null.
         using ComScope<IUnknown> entry = scope[0];
-        Assert.True(entry.IsNull);
+        entry.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_SafearrayDoublePointer_DereferencesToSafearrayPointer()
     {
         SAFEARRAYBOUND bound = new() { cElements = 1, lLbound = 0 };
         SAFEARRAY* array = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bound);
         using ComSafeArrayScope<IUnknown> scope = new(array);
         SAFEARRAY** pp = scope;
-        Assert.False(pp is null);
-        Assert.True(*pp == scope.Value);
+        (pp is null).Should().BeFalse();
+        (*pp == scope.Value).Should().BeTrue();
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
@@ -4,56 +4,57 @@
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class ComScopeTests
 {
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_NullPointer_IsNullTrue()
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
-        Assert.True(scope.IsNull);
-        Assert.True(scope.Pointer is null);
+        scope.IsNull.Should().BeTrue();
+        (scope.Pointer is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_VoidNull_IsNullTrue()
     {
         using ComScope<IUnknown> scope = new((void*)null);
-        Assert.True(scope.IsNull);
+        scope.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_TStar_NullPointer_ReturnsNull()
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
         IUnknown* p = scope;
-        Assert.True(p is null);
+        (p is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_VoidStar_NullPointer_ReturnsNull()
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
         void* p = scope;
-        Assert.True(p is null);
+        (p is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_Nint_NullPointer_ReturnsZero()
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
         nint p = scope;
-        Assert.Equal(0, p);
+        p.Should().Be((nint)0);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_TStarStar_NonNull()
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
         IUnknown** pp = scope;
-        Assert.False(pp is null);
+        (pp is null).Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Dispose_NullPointer_DoesNotThrow()
     {
         ComScope<IUnknown> scope = new((IUnknown*)null);

--- a/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/SafeArrayScopeTests.cs
@@ -6,76 +6,78 @@ using Windows.Win32.System.Variant;
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class SafeArrayScopeTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_IntSize_CreatesSafeArray()
     {
         using SafeArrayScope<int> array = new(3);
-        unsafe { Assert.False(array.Value is null); }
+        unsafe { (array.Value is null).Should().BeFalse(); }
     }
 
-    [Fact]
+    [TestMethod]
     public void Indexer_Int_RoundTripsValues()
     {
         using SafeArrayScope<int> array = new(3);
         array[0] = 10;
         array[1] = 20;
         array[2] = 30;
-        Assert.Equal(10, array[0]);
-        Assert.Equal(20, array[1]);
-        Assert.Equal(30, array[2]);
+        array[0].Should().Be(10);
+        array[1].Should().Be(20);
+        array[2].Should().Be(30);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_FromIntArray_PopulatesValues()
     {
         using SafeArrayScope<int> array = new([1, 2, 3, 4]);
-        Assert.Equal(1, array[0]);
-        Assert.Equal(4, array[3]);
+        array[0].Should().Be(1);
+        array[3].Should().Be(4);
     }
 
-    [Fact]
+    [TestMethod]
     public void Indexer_String_RoundTripsValues()
     {
         using SafeArrayScope<string> array = new(2);
         array[0] = "alpha";
         array[1] = "beta";
-        Assert.Equal("alpha", array[0]);
-        Assert.Equal("beta", array[1]);
+        array[0].Should().Be("alpha");
+        array[1].Should().Be("beta");
     }
 
-    [Fact]
+    [TestMethod]
     public void Indexer_Double_RoundTripsValues()
     {
         using SafeArrayScope<double> array = new(2);
         array[0] = 1.5;
         array[1] = 2.5;
-        Assert.Equal(1.5, array[0]);
-        Assert.Equal(2.5, array[1]);
+        array[0].Should().Be(1.5);
+        array[1].Should().Be(2.5);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_UnsupportedType_Throws()
     {
-        Assert.Throws<ArgumentException>(() => new SafeArrayScope<byte>(1));
+        FluentActions.Invoking(() => new SafeArrayScope<byte>(1)).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NintType_ThrowsWithComSafeArrayScopeMessage()
     {
-        ArgumentException ex = Assert.Throws<ArgumentException>(() => new SafeArrayScope<nint>(1));
-        Assert.Contains("ComSafeArrayScope", ex.Message);
+        ArgumentException ex = FluentActions.Invoking(() => new SafeArrayScope<nint>(1))
+            .Should().Throw<ArgumentException>().Which;
+        ex.Message.Should().Contain("ComSafeArrayScope");
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_NullSafearrayPointer_ValueIsNull()
     {
         using SafeArrayScope<int> array = new((SAFEARRAY*)null);
-        Assert.True(array.Value is null);
+        (array.Value is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_WrapVT_I4_Succeeds()
     {
         using SafeArrayScope<int> source = new(2);
@@ -84,115 +86,115 @@ public class SafeArrayScopeTests
 
         // Wrap the existing VT_I4 SAFEARRAY in a new scope — must not throw.
         SafeArrayScope<int> wrapped = new(source.Value);
-        Assert.Equal(7, wrapped[0]);
-        Assert.Equal(8, wrapped[1]);
+        wrapped[0].Should().Be(7);
+        wrapped[1].Should().Be(8);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_TypeMismatch_ForInt_Throws()
     {
         // VT_BSTR SAFEARRAY wrapped as SafeArrayScope<int> must throw.
         using SafeArrayScope<string> source = new(1);
         SAFEARRAY* ptr = source.Value;
-        ArgumentException ex = Assert.Throws<ArgumentException>(
-            () => new SafeArrayScope<int>(ptr));
-        Assert.Contains("VarType=", ex.Message);
+        ArgumentException ex = FluentActions.Invoking(() => new SafeArrayScope<int>(ptr))
+            .Should().Throw<ArgumentException>().Which;
+        ex.Message.Should().Contain("VarType=");
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_TypeMismatch_ForString_Throws()
     {
         using SafeArrayScope<int> source = new(1);
         SAFEARRAY* ptr = source.Value;
-        Assert.Throws<ArgumentException>(() => new SafeArrayScope<string>(ptr));
+        FluentActions.Invoking(() => new SafeArrayScope<string>(ptr)).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_TypeMismatch_ForDouble_Throws()
     {
         using SafeArrayScope<int> source = new(1);
         SAFEARRAY* ptr = source.Value;
-        Assert.Throws<ArgumentException>(() => new SafeArrayScope<double>(ptr));
+        FluentActions.Invoking(() => new SafeArrayScope<double>(ptr)).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void Length_ReturnsElementCount()
     {
         using SafeArrayScope<int> array = new(5);
-        Assert.Equal(5, array.Length);
+        array.Length.Should().Be(5);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEmpty_LengthZero_ReturnsTrue()
     {
         using SafeArrayScope<int> array = new(0);
-        Assert.True(array.IsEmpty);
+        array.IsEmpty.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEmpty_NonEmpty_ReturnsFalse()
     {
         using SafeArrayScope<int> array = new(1);
-        Assert.False(array.IsEmpty);
+        array.IsEmpty.Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void IsNull_DefaultConstructed_ReturnsTrue()
     {
         using SafeArrayScope<int> array = new((SAFEARRAY*)null);
-        Assert.True(array.IsNull);
+        array.IsNull.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_SafearrayStar_NonNull()
     {
         using SafeArrayScope<int> array = new(2);
         SAFEARRAY* ptr = array;
-        Assert.False(ptr is null);
+        (ptr is null).Should().BeFalse();
     }
 
-    [Fact]
+    [TestMethod]
     public void ImplicitOperator_Nint_NonZero()
     {
         using SafeArrayScope<int> array = new(2);
         nint value = array;
-        Assert.NotEqual(0, value);
+        value.Should().NotBe(0);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ExplicitOperator_Variant_HasArrayFlag()
     {
         using SafeArrayScope<int> array = new(2);
         VARIANT v = (VARIANT)array;
-        Assert.Equal(VARENUM.VT_ARRAY, v.vt & VARENUM.VT_ARRAY);
-        Assert.Equal(VARENUM.VT_I4, v.vt & VARENUM.VT_TYPEMASK);
+        (v.vt & VARENUM.VT_ARRAY).Should().Be(VARENUM.VT_ARRAY);
+        (v.vt & VARENUM.VT_TYPEMASK).Should().Be(VARENUM.VT_I4);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Constructor_ObjectType_VariantSafearray_Roundtrips()
     {
         using SafeArrayScope<object> array = new(2);
         array[0] = 42;
         array[1] = "hi";
-        Assert.Equal(42, array[0]);
-        Assert.Equal("hi", array[1]);
+        array[0].Should().Be(42);
+        array[1].Should().Be("hi");
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_VoidDoublePointer_DereferencesToSafearrayPointer()
     {
         using SafeArrayScope<int> array = new(2);
         void** pp = array;
-        Assert.False(pp is null);
-        Assert.True(*pp == array.Value);
+        (pp is null).Should().BeFalse();
+        (*pp == array.Value).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ImplicitOperator_SafearrayDoublePointer_DereferencesToSafearrayPointer()
     {
         using SafeArrayScope<int> array = new(2);
         SAFEARRAY** pp = array;
-        Assert.False(pp is null);
-        Assert.True(*pp == array.Value);
+        (pp is null).Should().BeFalse();
+        (*pp == array.Value).Should().BeTrue();
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Com/SafeArrayTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/SafeArrayTests.cs
@@ -6,54 +6,55 @@ using Windows.Win32.System.Variant;
 
 namespace Windows.Win32.System.Com;
 
+[TestClass]
 public class SafeArrayTests
 {
-    [Fact]
+    [TestMethod]
     public unsafe void VarType_IntArray_ReturnsVT_I4()
     {
         using SafeArrayScope<int> array = new(2);
-        Assert.Equal(VARENUM.VT_I4, array.Value->VarType);
+        array.Value->VarType.Should().Be(VARENUM.VT_I4);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void VarType_StringArray_ReturnsVT_BSTR()
     {
         using SafeArrayScope<string> array = new(1);
-        Assert.Equal(VARENUM.VT_BSTR, array.Value->VarType);
+        array.Value->VarType.Should().Be(VARENUM.VT_BSTR);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void VarType_DoubleArray_ReturnsVT_R8()
     {
         using SafeArrayScope<double> array = new(1);
-        Assert.Equal(VARENUM.VT_R8, array.Value->VarType);
+        array.Value->VarType.Should().Be(VARENUM.VT_R8);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void VarType_ObjectArray_ReturnsVT_VARIANT()
     {
         using SafeArrayScope<object> array = new(1);
-        Assert.Equal(VARENUM.VT_VARIANT, array.Value->VarType);
+        array.Value->VarType.Should().Be(VARENUM.VT_VARIANT);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void GetBounds_OneDimensionalArray_ReturnsExpectedBound()
     {
         using SafeArrayScope<int> array = new(5);
         SAFEARRAYBOUND bound = array.Value->GetBounds();
-        Assert.Equal(5u, bound.cElements);
-        Assert.Equal(0, bound.lLbound);
+        bound.cElements.Should().Be(5u);
+        bound.lLbound.Should().Be(0);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void GetValue_OneDimensional_ReadsBackInOrder()
     {
         using SafeArrayScope<int> array = new([10, 20, 30]);
         Span<int> indices0 = [0];
         Span<int> indices1 = [1];
         Span<int> indices2 = [2];
-        Assert.Equal(10, array.Value->GetValue<int>(indices0));
-        Assert.Equal(20, array.Value->GetValue<int>(indices1));
-        Assert.Equal(30, array.Value->GetValue<int>(indices2));
+        array.Value->GetValue<int>(indices0).Should().Be(10);
+        array.Value->GetValue<int>(indices1).Should().Be(20);
+        array.Value->GetValue<int>(indices2).Should().Be(30);
     }
 }

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -12,6 +12,7 @@ using SafeArrayTypeMismatchException = System.Runtime.InteropServices.SafeArrayT
 
 namespace Windows.Win32.System.Variant;
 
+[TestClass]
 public partial class VariantTests
 {
     private static VARIANT MakeScalar<T>(VARENUM type, T value) where T : unmanaged
@@ -21,49 +22,49 @@ public partial class VariantTests
         return v;
     }
 
-    [Fact]
+    [TestMethod]
     public void EmptyVariant_HasExpectedProperties()
     {
         VARIANT v = VARIANT.Empty;
-        Assert.True(v.IsEmpty);
-        Assert.Equal(VARENUM.VT_EMPTY, v.vt);
-        Assert.Equal(VARENUM.VT_EMPTY, v.Type);
-        Assert.False(v.Byref);
-        Assert.Null(v.GetManagedType());
+        v.IsEmpty.Should().BeTrue();
+        v.vt.Should().Be(VARENUM.VT_EMPTY);
+        v.Type.Should().Be(VARENUM.VT_EMPTY);
+        v.Byref.Should().BeFalse();
+        v.GetManagedType().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void IntConversion_RoundTrip()
     {
         int value = 42;
         VARIANT v = (VARIANT)value;
-        Assert.Equal(VARENUM.VT_I4, v.vt);
-        Assert.Equal(value, (int)v);
-        Assert.Equal(typeof(int), v.GetManagedType());
+        v.vt.Should().Be(VARENUM.VT_I4);
+        ((int)v).Should().Be(value);
+        v.GetManagedType().Should().Be(typeof(int));
     }
 
-    [Fact]
+    [TestMethod]
     public void UIntConversion_RoundTrip()
     {
         uint value = 123u;
         VARIANT v = (VARIANT)value;
-        Assert.Equal(VARENUM.VT_UI4, v.vt);
-        Assert.Equal(value, (uint)v);
-        Assert.Equal(typeof(uint), v.GetManagedType());
+        v.vt.Should().Be(VARENUM.VT_UI4);
+        ((uint)v).Should().Be(value);
+        v.GetManagedType().Should().Be(typeof(uint));
     }
 
-    [Fact]
+    [TestMethod]
     public void BoolConversion_RoundTrip()
     {
         VARIANT vTrue = (VARIANT)true;
         VARIANT vFalse = (VARIANT)false;
-        Assert.Equal(VARENUM.VT_BOOL, vTrue.vt);
-        Assert.True((bool)vTrue);
-        Assert.False((bool)vFalse);
-        Assert.Equal(typeof(bool), vTrue.GetManagedType());
+        vTrue.vt.Should().Be(VARENUM.VT_BOOL);
+        ((bool)vTrue).Should().BeTrue();
+        ((bool)vFalse).Should().BeFalse();
+        vTrue.GetManagedType().Should().Be(typeof(bool));
     }
 
-    [Fact]
+    [TestMethod]
     public void DecimalConversion_RoundTrip()
     {
         decimal value = 123.45m;
@@ -72,129 +73,131 @@ public partial class VariantTests
         v.Anonymous.decVal = new(value);
         v.vt |= VARENUM.VT_DECIMAL;
 
-        Assert.Equal(value, v.ToObject());
-        Assert.Equal(typeof(decimal), v.GetManagedType());
+        // BeApproximately with zero tolerance compares decimal value scale-insensitively
+        // (the round-trip can change the decimal's scale on some target frameworks).
+        v.ToObject().Should().BeOfType<decimal>().Which.Should().BeApproximately(value, 0m);
+        v.GetManagedType().Should().Be(typeof(decimal));
     }
 
-    [Fact]
+    [TestMethod]
     public void StringConversion_RoundTrip()
     {
         string s = "hello";
         using BSTR bstr = new(s);
         VARIANT v = (VARIANT)bstr;
-        Assert.Equal(VARENUM.VT_BSTR, v.vt);
-        Assert.Equal(s, (string)v);
-        Assert.Equal(typeof(string), v.GetManagedType());
+        v.vt.Should().Be(VARENUM.VT_BSTR);
+        ((string)v).Should().Be(s);
+        v.GetManagedType().Should().Be(typeof(string));
     }
 
-    [Fact]
+    [TestMethod]
     public void StringExplicitCast_RoundTrip()
     {
         VARIANT v = (VARIANT)"hello";
-        Assert.Equal(VARENUM.VT_BSTR, v.vt);
-        Assert.Equal("hello", (string)v);
+        v.vt.Should().Be(VARENUM.VT_BSTR);
+        ((string)v).Should().Be("hello");
         v.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void DoubleExplicitCast_ProducesR8Variant()
     {
         VARIANT v = (VARIANT)3.14;
-        Assert.Equal(VARENUM.VT_R8, v.vt);
-        Assert.Equal(3.14, v.data.dblVal);
+        v.vt.Should().Be(VARENUM.VT_R8);
+        v.data.dblVal.Should().Be(3.14);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void IDispatchPointer_NullRoundTrip()
     {
         VARIANT v = (VARIANT)(IDispatch*)null;
-        Assert.Equal(VARENUM.VT_DISPATCH, v.vt);
-        Assert.True((IDispatch*)v is null);
+        v.vt.Should().Be(VARENUM.VT_DISPATCH);
+        ((IDispatch*)v is null).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void InvalidIDispatchCast_Throws()
     {
         VARIANT v = VARIANT.Empty;
-        Assert.Throws<InvalidCastException>(() => { IDispatch* _ = (IDispatch*)v; });
+        FluentActions.Invoking(() => { IDispatch* _ = (IDispatch*)v; }).Should().Throw<InvalidCastException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void InvalidCast_Throws()
     {
         VARIANT v = VARIANT.Empty;
-        Assert.Throws<InvalidCastException>(() => (int)v);
-        Assert.Throws<InvalidCastException>(() => (uint)v);
-        Assert.Throws<InvalidCastException>(() => (bool)v);
-        Assert.Throws<InvalidCastException>(() => (decimal)v);
-        Assert.Throws<InvalidCastException>(() => (string)v);
+        FluentActions.Invoking(() => (int)v).Should().Throw<InvalidCastException>();
+        FluentActions.Invoking(() => (uint)v).Should().Throw<InvalidCastException>();
+        FluentActions.Invoking(() => (bool)v).Should().Throw<InvalidCastException>();
+        FluentActions.Invoking(() => (decimal)v).Should().Throw<InvalidCastException>();
+        FluentActions.Invoking(() => (string)v).Should().Throw<InvalidCastException>();
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_Null_ReturnsEmpty()
     {
         VARIANT v = VARIANT.FromObject(null);
-        Assert.True(v.IsEmpty);
+        v.IsEmpty.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_String_ReturnsBstrVariant()
     {
         VARIANT v = VARIANT.FromObject("text");
-        Assert.Equal(VARENUM.VT_BSTR, v.vt);
-        Assert.Equal("text", (string)v);
+        v.vt.Should().Be(VARENUM.VT_BSTR);
+        ((string)v).Should().Be("text");
         v.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_Int_ReturnsI4Variant()
     {
         VARIANT v = VARIANT.FromObject(123);
-        Assert.Equal(VARENUM.VT_I4, v.vt);
-        Assert.Equal(123, (int)v);
+        v.vt.Should().Be(VARENUM.VT_I4);
+        ((int)v).Should().Be(123);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_UInt_ReturnsUI4Variant()
     {
         VARIANT v = VARIANT.FromObject(456u);
-        Assert.Equal(VARENUM.VT_UI4, v.vt);
-        Assert.Equal(456u, (uint)v);
+        v.vt.Should().Be(VARENUM.VT_UI4);
+        ((uint)v).Should().Be(456u);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_Short_ProducesI4VariantViaImplicitWidening()
     {
         // FromObject branches on `is short` but `(VARIANT)shortValue` has no short operator,
         // so the value widens to int and goes through the int operator → VT_I4.
         VARIANT v = VARIANT.FromObject((short)7);
-        Assert.Equal(VARENUM.VT_I4, v.vt);
-        Assert.Equal(7, (int)v);
+        v.vt.Should().Be(VARENUM.VT_I4);
+        ((int)v).Should().Be(7);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_Bool_ReturnsBoolVariant()
     {
         VARIANT v = VARIANT.FromObject(true);
-        Assert.Equal(VARENUM.VT_BOOL, v.vt);
-        Assert.True((bool)v);
+        v.vt.Should().Be(VARENUM.VT_BOOL);
+        ((bool)v).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_Double_ReturnsR8Variant()
     {
         VARIANT v = VARIANT.FromObject(2.5);
-        Assert.Equal(VARENUM.VT_R8, v.vt);
+        v.vt.Should().Be(VARENUM.VT_R8);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromObject_ViaMarshal_DateTime_ProducesDateOrR8Variant()
     {
         VARIANT v = VARIANT.FromObject(new DateTime(2025, 6, 1));
         try
         {
             // Marshal returns either VT_DATE or VT_R8 depending on the platform; either is acceptable.
-            Assert.True(v.vt is VARENUM.VT_DATE or VARENUM.VT_R8);
+            v.vt.Should().BeOneOf(VARENUM.VT_DATE, VARENUM.VT_R8);
         }
         finally
         {
@@ -202,178 +205,178 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_Decimal_ReturnsDecimal()
     {
         VARIANT v = new();
         v.Anonymous.decVal = new(100.5m);
         v.vt |= VARENUM.VT_DECIMAL;
-        Assert.Equal(100.5m, v.ToObject());
+        v.ToObject().Should().BeOfType<decimal>().Which.Should().BeApproximately(100.5m, 0m);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_Int_ReturnsInt()
     {
         VARIANT v = (VARIANT)42;
-        Assert.Equal(42, v.ToObject());
+        v.ToObject().Should().Be(42);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_Bool_ReturnsBool()
     {
         VARIANT v = (VARIANT)true;
-        Assert.Equal(true, v.ToObject());
+        v.ToObject().Should().Be(true);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_String_ReturnsString()
     {
         VARIANT v = (VARIANT)"abc";
-        Assert.Equal("abc", v.ToObject());
+        v.ToObject().Should().Be("abc");
         v.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_NULL_ReturnsDBNull()
     {
         VARIANT v = new() { vt = VARENUM.VT_NULL };
-        Assert.Equal(Convert.DBNull, v.ToObject());
+        v.ToObject().Should().Be(Convert.DBNull);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_EMPTY_ReturnsNull()
     {
         VARIANT v = VARIANT.Empty;
-        Assert.Null(v.ToObject());
+        v.ToObject().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_I1_ReturnsSbyte()
     {
         VARIANT v = MakeScalar(VARENUM.VT_I1, (sbyte)-5);
-        Assert.Equal((sbyte)-5, v.ToObject());
+        v.ToObject().Should().Be((sbyte)-5);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_UI1_ReturnsByte()
     {
         VARIANT v = MakeScalar(VARENUM.VT_UI1, (byte)200);
-        Assert.Equal((byte)200, v.ToObject());
+        v.ToObject().Should().Be((byte)200);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_I2_ReturnsShort()
     {
         VARIANT v = MakeScalar(VARENUM.VT_I2, (short)-1000);
-        Assert.Equal((short)-1000, v.ToObject());
+        v.ToObject().Should().Be((short)-1000);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_UI2_ReturnsUshort()
     {
         VARIANT v = MakeScalar(VARENUM.VT_UI2, (ushort)50000);
-        Assert.Equal((ushort)50000, v.ToObject());
+        v.ToObject().Should().Be((ushort)50000);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_I8_ReturnsLong()
     {
         VARIANT v = MakeScalar(VARENUM.VT_I8, -1234567890123L);
-        Assert.Equal(-1234567890123L, v.ToObject());
+        v.ToObject().Should().Be(-1234567890123L);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_UI8_ReturnsUlong()
     {
         VARIANT v = MakeScalar(VARENUM.VT_UI8, 9876543210123UL);
-        Assert.Equal(9876543210123UL, v.ToObject());
+        v.ToObject().Should().Be(9876543210123UL);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_R4_ReturnsFloat()
     {
         VARIANT v = MakeScalar(VARENUM.VT_R4, 1.5f);
-        Assert.Equal(1.5f, v.ToObject());
+        v.ToObject().Should().Be(1.5f);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_R8_ReturnsDouble()
     {
         VARIANT v = MakeScalar(VARENUM.VT_R8, 2.25);
-        Assert.Equal(2.25, v.ToObject());
+        v.ToObject().Should().Be(2.25);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_UINT_ReturnsUint()
     {
         VARIANT v = MakeScalar(VARENUM.VT_UINT, 42u);
-        Assert.Equal(42u, v.ToObject());
+        v.ToObject().Should().Be(42u);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_INT_ReturnsInt()
     {
         VARIANT v = MakeScalar(VARENUM.VT_INT, 7);
-        Assert.Equal(7, v.ToObject());
+        v.ToObject().Should().Be(7);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_ERROR_ReturnsInt()
     {
         VARIANT v = MakeScalar(VARENUM.VT_ERROR, unchecked((int)0x80004005));
-        Assert.Equal(unchecked((int)0x80004005), v.ToObject());
+        v.ToObject().Should().Be(unchecked((int)0x80004005));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_DATE_ReturnsDateTime()
     {
         DateTime expected = new(2024, 3, 15);
         VARIANT v = MakeScalar(VARENUM.VT_DATE, expected.ToOADate());
-        Assert.Equal(expected, v.ToObject());
+        v.ToObject().Should().Be(expected);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_CY_ReturnsDecimal()
     {
         // OACurrency stores value * 10000 as Int64.
         VARIANT v = MakeScalar(VARENUM.VT_CY, 12345L);
-        Assert.Equal(1.2345m, v.ToObject());
+        v.ToObject().Should().Be(1.2345m);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_VT_VOID_ReturnsNull()
     {
         VARIANT v = new() { vt = VARENUM.VT_VOID };
-        Assert.Null(v.ToObject());
+        v.ToObject().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void ToObject_Invalid_HighVtBits_Throws()
     {
         VARIANT v = new() { vt = (VARENUM)0xFF };
-        Assert.Throws<InvalidCastException>(() => v.ToObject());
+        FluentActions.Invoking(() => v.ToObject()).Should().Throw<InvalidCastException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_CLSID_ReturnsGuid()
     {
         Guid expected = new("12345678-1234-1234-1234-1234567890ab");
         VARIANT v = new() { vt = VARENUM.VT_CLSID };
         v.data.puuid = &expected;
-        Assert.Equal(expected, v.ToObject());
+        v.ToObject().Should().Be(expected);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_FILETIME_ReturnsDateTime()
     {
         DateTime expected = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc).ToLocalTime();
         FILETIME ft = (FILETIME)expected;
         VARIANT v = new() { vt = VARENUM.VT_FILETIME };
         Unsafe.As<VARIANT._Anonymous_e__Union._Anonymous_e__Struct._Anonymous_e__Union, FILETIME>(ref v.data) = ft;
-        Assert.Equal(expected, v.ToObject());
+        v.ToObject().Should().Be(expected);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_LPSTR_ReturnsString()
     {
         nint ansi = global::System.Runtime.InteropServices.Marshal.StringToCoTaskMemAnsi("ascii-text");
@@ -381,7 +384,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_LPSTR };
             v.data.pcVal = new PSTR((byte*)ansi);
-            Assert.Equal("ascii-text", v.ToObject());
+            v.ToObject().Should().Be("ascii-text");
         }
         finally
         {
@@ -389,15 +392,15 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_VARIANT_NotByref_ThrowsArgument()
     {
         VARIANT v = new() { vt = VARENUM.VT_VARIANT };
         // Falling through the switch with no byref bit set yields the "Unsupported VARENUM" path.
-        Assert.Throws<ArgumentException>(() => v.ToObject());
+        FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_ARRAY_VT_I4_ReturnsIntArray()
     {
         using SafeArrayScope<int> source = new([10, 20, 30]);
@@ -405,11 +408,11 @@ public partial class VariantTests
         VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
         v.data.parray = source.Value;
 
-        int[] array = Assert.IsType<int[]>(v.ToObject());
-        Assert.Equal([10, 20, 30], array);
+        int[] array = v.ToObject().Should().BeOfType<int[]>().Subject;
+        array.Should().Equal(10, 20, 30);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_ARRAY_VT_R8_ReturnsDoubleArray()
     {
         using SafeArrayScope<double> source = new([1.5, 2.5]);
@@ -417,11 +420,11 @@ public partial class VariantTests
         VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_R8 };
         v.data.parray = source.Value;
 
-        double[] array = Assert.IsType<double[]>(v.ToObject());
-        Assert.Equal([1.5, 2.5], array);
+        double[] array = v.ToObject().Should().BeOfType<double[]>().Subject;
+        array.Should().Equal(1.5, 2.5);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_ARRAY_VT_BSTR_ReturnsStringArray()
     {
         using SafeArrayScope<string> source = new(["alpha", "beta"]);
@@ -429,20 +432,20 @@ public partial class VariantTests
         VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_BSTR };
         v.data.parray = source.Value;
 
-        string[] array = Assert.IsType<string[]>(v.ToObject());
-        Assert.Equal(["alpha", "beta"], array);
+        string[] array = v.ToObject().Should().BeOfType<string[]>().Subject;
+        array.Should().Equal("alpha", "beta");
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_ARRAY_NullSafearray_ReturnsNull()
     {
         VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
         v.data.parray = null;
 
-        Assert.Null(v.ToObject());
+        v.ToObject().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_ARRAY_2D_VT_I4_TransposesAndReturnsIntMatrix()
     {
         // 2x3 SAFEARRAY of VT_I4. Native SAFEARRAYs are column-major; CLR arrays are row-major,
@@ -452,7 +455,7 @@ public partial class VariantTests
         bounds[1] = new SAFEARRAYBOUND { cElements = 3, lLbound = 0 };
 
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_I4, 2, bounds);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
 
         try
         {
@@ -479,10 +482,10 @@ public partial class VariantTests
             // regression (multi-dim arrays used to throw); strengthen the assertions to detect
             // dimension confusion: every populated source value must appear exactly once, with
             // no extras and no default-zero padding.
-            int[,] array = Assert.IsType<int[,]>(v.ToObject());
-            Assert.Equal(2, array.Rank);
-            Assert.Equal(6, array.Length);
-            Assert.Equal(6, array.GetLength(0) * array.GetLength(1));
+            int[,] array = v.ToObject().Should().BeOfType<int[,]>().Subject;
+            array.Rank.Should().Be(2);
+            array.Length.Should().Be(6);
+            (array.GetLength(0) * array.GetLength(1)).Should().Be(6);
 
             List<int> actual = [];
             for (int a = 0; a < array.GetLength(0); a++)
@@ -494,7 +497,7 @@ public partial class VariantTests
             }
 
             int[] expected = [0, 1, 2, 10, 11, 12];
-            Assert.Equal(expected.OrderBy(x => x), actual.OrderBy(x => x));
+            actual.OrderBy(x => x).Should().Equal(expected.OrderBy(x => x));
         }
         finally
         {
@@ -502,205 +505,205 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void Byref_BoolByRef_ReturnsTrue()
     {
         VARIANT_BOOL b = VARIANT_BOOL.VARIANT_TRUE;
         VARIANT v = new() { vt = VARENUM.VT_BOOL | VARENUM.VT_BYREF };
         v.data.pboolVal = &b;
-        Assert.True(v.Byref);
+        v.Byref.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_BOOL_BYREF_ReturnsBool()
     {
         VARIANT_BOOL b = VARIANT_BOOL.VARIANT_TRUE;
         VARIANT v = new() { vt = VARENUM.VT_BOOL | VARENUM.VT_BYREF };
         v.data.pboolVal = &b;
-        Assert.Equal(true, v.ToObject());
+        v.ToObject().Should().Be(true);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_I4_BYREF_ReturnsInt()
     {
         int value = 1234;
         VARIANT v = new() { vt = VARENUM.VT_I4 | VARENUM.VT_BYREF };
         v.data.pintVal = &value;
-        Assert.Equal(1234, v.ToObject());
+        v.ToObject().Should().Be(1234);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_R8_BYREF_ReturnsDouble()
     {
         double value = 3.5;
         VARIANT v = new() { vt = VARENUM.VT_R8 | VARENUM.VT_BYREF };
         v.data.pdblVal = &value;
-        Assert.Equal(3.5, v.ToObject());
+        v.ToObject().Should().Be(3.5);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_VARIANT_BYREF_ReturnsNestedObject()
     {
         VARIANT inner = (VARIANT)42;
         VARIANT outer = new() { vt = VARENUM.VT_VARIANT | VARENUM.VT_BYREF };
         outer.data.pvarVal = &inner;
-        Assert.Equal(42, outer.ToObject());
+        outer.ToObject().Should().Be(42);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_EMPTY_BYREF_NullData_ReturnsZero()
     {
         VARIANT v = new() { vt = VARENUM.VT_EMPTY | VARENUM.VT_BYREF };
         // No data assigned — byref data pointer is null. Should yield 0 (uint/ulong),
         // not throw, per the VT_EMPTY|VT_BYREF special case.
         object? result = v.ToObject();
-        Assert.NotNull(result);
-        Assert.True(result is uint u && u == 0 || result is ulong ul && ul == 0);
+        result.Should().NotBeNull();
+        (result is uint u && u == 0 || result is ulong ul && ul == 0).Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_FromInstance_ReturnsBackingType()
     {
         VARIANT v = (VARIANT)123;
-        Assert.Equal(typeof(int), v.GetManagedType());
+        v.GetManagedType().Should().Be(typeof(int));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_FromEmptyInstance_ReturnsNull()
     {
-        Assert.Null(VARIANT.Empty.GetManagedType());
+        VARIANT.Empty.GetManagedType().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_Static_ReturnsExpectedTypes()
     {
-        Assert.Equal(typeof(int), VARIANT.GetManagedType(VARENUM.VT_I4));
-        Assert.Equal(typeof(uint), VARIANT.GetManagedType(VARENUM.VT_UI4));
-        Assert.Equal(typeof(bool), VARIANT.GetManagedType(VARENUM.VT_BOOL));
-        Assert.Equal(typeof(string), VARIANT.GetManagedType(VARENUM.VT_BSTR));
-        Assert.Equal(typeof(decimal), VARIANT.GetManagedType(VARENUM.VT_DECIMAL));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_UNKNOWN));
-        Assert.Equal(typeof(int[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_I4));
-        Assert.Null(VARIANT.GetManagedType((VARENUM)0xFFFF));
+        VARIANT.GetManagedType(VARENUM.VT_I4).Should().Be(typeof(int));
+        VARIANT.GetManagedType(VARENUM.VT_UI4).Should().Be(typeof(uint));
+        VARIANT.GetManagedType(VARENUM.VT_BOOL).Should().Be(typeof(bool));
+        VARIANT.GetManagedType(VARENUM.VT_BSTR).Should().Be(typeof(string));
+        VARIANT.GetManagedType(VARENUM.VT_DECIMAL).Should().Be(typeof(decimal));
+        VARIANT.GetManagedType(VARENUM.VT_UNKNOWN).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_I4).Should().Be(typeof(int[]));
+        VARIANT.GetManagedType((VARENUM)0xFFFF).Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_AllScalarTypes_ReturnsExpected()
     {
-        Assert.Equal(typeof(sbyte), VARIANT.GetManagedType(VARENUM.VT_I1));
-        Assert.Equal(typeof(byte), VARIANT.GetManagedType(VARENUM.VT_UI1));
-        Assert.Equal(typeof(short), VARIANT.GetManagedType(VARENUM.VT_I2));
-        Assert.Equal(typeof(ushort), VARIANT.GetManagedType(VARENUM.VT_UI2));
-        Assert.Equal(typeof(int), VARIANT.GetManagedType(VARENUM.VT_INT));
-        Assert.Equal(typeof(uint), VARIANT.GetManagedType(VARENUM.VT_UINT));
-        Assert.Equal(typeof(long), VARIANT.GetManagedType(VARENUM.VT_I8));
-        Assert.Equal(typeof(ulong), VARIANT.GetManagedType(VARENUM.VT_UI8));
-        Assert.Equal(typeof(float), VARIANT.GetManagedType(VARENUM.VT_R4));
-        Assert.Equal(typeof(double), VARIANT.GetManagedType(VARENUM.VT_R8));
-        Assert.Equal(typeof(int), VARIANT.GetManagedType(VARENUM.VT_ERROR));
-        Assert.Equal(typeof(decimal), VARIANT.GetManagedType(VARENUM.VT_CY));
-        Assert.Equal(typeof(DateTime), VARIANT.GetManagedType(VARENUM.VT_DATE));
-        Assert.Equal(typeof(DateTime), VARIANT.GetManagedType(VARENUM.VT_FILETIME));
-        Assert.Equal(typeof(string), VARIANT.GetManagedType(VARENUM.VT_LPSTR));
-        Assert.Equal(typeof(string), VARIANT.GetManagedType(VARENUM.VT_LPWSTR));
-        Assert.Equal(typeof(VARIANT), VARIANT.GetManagedType(VARENUM.VT_VARIANT));
-        Assert.Equal(typeof(Guid), VARIANT.GetManagedType(VARENUM.VT_CLSID));
-        Assert.Equal(typeof(byte[]), VARIANT.GetManagedType(VARENUM.VT_BLOB));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_DISPATCH));
+        VARIANT.GetManagedType(VARENUM.VT_I1).Should().Be(typeof(sbyte));
+        VARIANT.GetManagedType(VARENUM.VT_UI1).Should().Be(typeof(byte));
+        VARIANT.GetManagedType(VARENUM.VT_I2).Should().Be(typeof(short));
+        VARIANT.GetManagedType(VARENUM.VT_UI2).Should().Be(typeof(ushort));
+        VARIANT.GetManagedType(VARENUM.VT_INT).Should().Be(typeof(int));
+        VARIANT.GetManagedType(VARENUM.VT_UINT).Should().Be(typeof(uint));
+        VARIANT.GetManagedType(VARENUM.VT_I8).Should().Be(typeof(long));
+        VARIANT.GetManagedType(VARENUM.VT_UI8).Should().Be(typeof(ulong));
+        VARIANT.GetManagedType(VARENUM.VT_R4).Should().Be(typeof(float));
+        VARIANT.GetManagedType(VARENUM.VT_R8).Should().Be(typeof(double));
+        VARIANT.GetManagedType(VARENUM.VT_ERROR).Should().Be(typeof(int));
+        VARIANT.GetManagedType(VARENUM.VT_CY).Should().Be(typeof(decimal));
+        VARIANT.GetManagedType(VARENUM.VT_DATE).Should().Be(typeof(DateTime));
+        VARIANT.GetManagedType(VARENUM.VT_FILETIME).Should().Be(typeof(DateTime));
+        VARIANT.GetManagedType(VARENUM.VT_LPSTR).Should().Be(typeof(string));
+        VARIANT.GetManagedType(VARENUM.VT_LPWSTR).Should().Be(typeof(string));
+        VARIANT.GetManagedType(VARENUM.VT_VARIANT).Should().Be(typeof(VARIANT));
+        VARIANT.GetManagedType(VARENUM.VT_CLSID).Should().Be(typeof(Guid));
+        VARIANT.GetManagedType(VARENUM.VT_BLOB).Should().Be(typeof(byte[]));
+        VARIANT.GetManagedType(VARENUM.VT_DISPATCH).Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_ArrayTypes_ReturnsArrayType()
     {
-        Assert.Equal(typeof(byte[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_UI1));
-        Assert.Equal(typeof(short[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_I2));
-        Assert.Equal(typeof(uint[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_UI4));
-        Assert.Equal(typeof(int[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_ERROR));
-        Assert.Equal(typeof(double[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_R8));
-        Assert.Equal(typeof(bool[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BOOL));
-        Assert.Equal(typeof(string[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BSTR));
-        Assert.Equal(typeof(Guid[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_CLSID));
-        Assert.Equal(typeof(decimal[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_DECIMAL));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_DISPATCH));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_UI1).Should().Be(typeof(byte[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_I2).Should().Be(typeof(short[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_UI4).Should().Be(typeof(uint[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_ERROR).Should().Be(typeof(int[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_R8).Should().Be(typeof(double[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BOOL).Should().Be(typeof(bool[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BSTR).Should().Be(typeof(string[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_CLSID).Should().Be(typeof(Guid[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_DECIMAL).Should().Be(typeof(decimal[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_DISPATCH).Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_StaticSpecialCases_ReturnExpectedTypes()
     {
-        Assert.Equal(typeof(Stream), VARIANT.GetManagedType(VARENUM.VT_STREAM));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_CF));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_STREAMED_OBJECT));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_STORAGE));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_STORED_OBJECT));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_VERSIONED_STREAM));
+        VARIANT.GetManagedType(VARENUM.VT_STREAM).Should().Be(typeof(Stream));
+        VARIANT.GetManagedType(VARENUM.VT_CF).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_STREAMED_OBJECT).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_STORAGE).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_STORED_OBJECT).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_VERSIONED_STREAM).Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_VectorTypes_ReturnExpectedArrayTypes()
     {
-        Assert.Equal(typeof(sbyte[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_I1));
-        Assert.Equal(typeof(ushort[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UI2));
-        Assert.Equal(typeof(long[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_I8));
-        Assert.Equal(typeof(ulong[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UI8));
-        Assert.Equal(typeof(int[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_INT));
-        Assert.Equal(typeof(uint[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UINT));
-        Assert.Equal(typeof(float[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_R4));
-        Assert.Equal(typeof(decimal[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_CY));
-        Assert.Equal(typeof(DateTime[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_DATE));
-        Assert.Equal(typeof(DateTime[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_FILETIME));
-        Assert.Equal(typeof(string[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_LPSTR));
-        Assert.Equal(typeof(string[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_LPWSTR));
-        Assert.Equal(typeof(VARIANT[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_VARIANT));
-        Assert.Equal(typeof(Stream[]), VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_STREAM));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UNKNOWN));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_DISPATCH));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_I1).Should().Be(typeof(sbyte[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UI2).Should().Be(typeof(ushort[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_I8).Should().Be(typeof(long[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UI8).Should().Be(typeof(ulong[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_INT).Should().Be(typeof(int[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UINT).Should().Be(typeof(uint[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_R4).Should().Be(typeof(float[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_CY).Should().Be(typeof(decimal[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_DATE).Should().Be(typeof(DateTime[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_FILETIME).Should().Be(typeof(DateTime[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_LPSTR).Should().Be(typeof(string[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_LPWSTR).Should().Be(typeof(string[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_VARIANT).Should().Be(typeof(VARIANT[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_STREAM).Should().Be(typeof(Stream[]));
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_UNKNOWN).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_VECTOR | VARENUM.VT_DISPATCH).Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void GetManagedType_ArraySpecialCases_ReturnExpectedTypes()
     {
-        Assert.Equal(typeof(Stream[]), VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STREAM));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BLOB));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_CF));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STREAMED_OBJECT));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STORAGE));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STORED_OBJECT));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_VERSIONED_STREAM));
-        Assert.Null(VARIANT.GetManagedType(VARENUM.VT_VOID));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STREAM).Should().Be(typeof(Stream[]));
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_BLOB).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_CF).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STREAMED_OBJECT).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STORAGE).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_STORED_OBJECT).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_ARRAY | VARENUM.VT_VERSIONED_STREAM).Should().BeNull();
+        VARIANT.GetManagedType(VARENUM.VT_VOID).Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public void ByrefProperty_ReflectsVtFlag()
     {
         VARIANT v = (VARIANT)1;
-        Assert.False(v.Byref);
+        v.Byref.Should().BeFalse();
         v.vt |= VARENUM.VT_BYREF;
-        Assert.True(v.Byref);
+        v.Byref.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_ClearsVariant()
     {
         VARIANT v = (VARIANT)123;
         v.Dispose();
-        Assert.True(v.IsEmpty);
-        Assert.Equal(VARENUM.VT_EMPTY, v.vt);
+        v.IsEmpty.Should().BeTrue();
+        v.vt.Should().Be(VARENUM.VT_EMPTY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_ClearsVariant()
     {
         VARIANT v = (VARIANT)456;
         v.Clear();
-        Assert.True(v.IsEmpty);
-        Assert.Equal(VARENUM.VT_EMPTY, v.vt);
+        v.IsEmpty.Should().BeTrue();
+        v.vt.Should().Be(VARENUM.VT_EMPTY);
     }
 
     private static unsafe SAFEARRAY* CreateSafeArray<T>(VARENUM vt, T[] values) where T : unmanaged
     {
         SAFEARRAYBOUND bound = new() { cElements = (uint)values.Length, lLbound = 0 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(vt, 1, &bound);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
         for (int i = 0; i < values.Length; i++)
         {
             T value = values[i];
@@ -716,7 +719,7 @@ public partial class VariantTests
     {
         SAFEARRAYBOUND bounds = new() { cElements = (uint)values.Length, lLbound = 5 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(safeArrayType, 1, &bounds);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
 
         try
         {
@@ -729,9 +732,9 @@ public partial class VariantTests
 
             VARIANT variant = new() { vt = VARENUM.VT_ARRAY | variantType };
             variant.data.parray = psa;
-            Array result = Assert.IsAssignableFrom<Array>(variant.ToObject());
-            Assert.Equal(5, result.GetLowerBound(0));
-            Assert.Equal(values.Length, result.Length);
+            Array result = variant.ToObject().Should().BeAssignableTo<Array>().Subject;
+            result.GetLowerBound(0).Should().Be(5);
+            result.Length.Should().Be(values.Length);
             return result;
         }
         finally
@@ -768,25 +771,25 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_NonEmptyBstr_ClearsAndFreesString()
     {
         VARIANT v = (VARIANT)"some-text";
-        Assert.False(v.IsEmpty);
+        v.IsEmpty.Should().BeFalse();
         v.Clear();
-        Assert.True(v.IsEmpty);
-        Assert.Equal(VARENUM.VT_EMPTY, v.vt);
+        v.IsEmpty.Should().BeTrue();
+        v.vt.Should().Be(VARENUM.VT_EMPTY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_AlreadyEmpty_NoOps()
     {
         VARIANT v = VARIANT.Empty;
         v.Clear();
-        Assert.True(v.IsEmpty);
+        v.IsEmpty.Should().BeTrue();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void StringCast_VT_LPWSTR_ReturnsString()
     {
         nint wide = InteropMarshal.StringToCoTaskMemUni("wide-text");
@@ -794,7 +797,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_LPWSTR };
             v.data.pcVal = new PSTR((byte*)wide);
-            Assert.Equal("wide-text", (string)v);
+            ((string)v).Should().Be("wide-text");
         }
         finally
         {
@@ -802,7 +805,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_LPWSTR_ReturnsString()
     {
         nint wide = InteropMarshal.StringToCoTaskMemUni("wide-obj");
@@ -810,7 +813,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_LPWSTR };
             v.data.pcVal = new PSTR((byte*)wide);
-            Assert.Equal("wide-obj", v.ToObject());
+            v.ToObject().Should().Be("wide-obj");
         }
         finally
         {
@@ -818,22 +821,22 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_HRESULT_ReturnsInt()
     {
         VARIANT v = MakeScalar(VARENUM.VT_HRESULT, unchecked((int)0x80070005));
-        Assert.Equal(unchecked((int)0x80070005), v.ToObject());
+        v.ToObject().Should().Be(unchecked((int)0x80070005));
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_UNKNOWN_NullPointer_ReturnsNull()
     {
         VARIANT v = new() { vt = VARENUM.VT_UNKNOWN };
         v.data.punkVal = null;
-        Assert.Null(v.ToObject());
+        v.ToObject().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_UNKNOWN_NonNullPointer_ReturnsComObject()
     {
         object source = new();
@@ -842,7 +845,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_UNKNOWN };
             v.data.punkVal = (IUnknown*)unknown;
-            Assert.NotNull(v.ToObject());
+            v.ToObject().Should().NotBeNull();
         }
         finally
         {
@@ -850,24 +853,24 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_DECIMAL_BYREF_ReturnsDecimal()
     {
         DECIMAL value = new(42.125m);
         VARIANT v = new() { vt = VARENUM.VT_DECIMAL | VARENUM.VT_BYREF };
         v.data.byref = &value;
-        Assert.Equal(42.125m, v.ToObject());
+        v.ToObject().Should().Be(42.125m);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_DISPATCH_NullPointer_ReturnsNull()
     {
         VARIANT v = new() { vt = VARENUM.VT_DISPATCH };
         v.data.pdispVal = null;
-        Assert.Null(v.ToObject());
+        v.ToObject().Should().BeNull();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_VARIANT_BYREF_NestedByref_Throws()
     {
         VARIANT innerByref = new() { vt = VARENUM.VT_I4 | VARENUM.VT_BYREF };
@@ -875,53 +878,53 @@ public partial class VariantTests
         innerByref.data.pintVal = &value;
         VARIANT outer = new() { vt = VARENUM.VT_VARIANT | VARENUM.VT_BYREF };
         outer.data.pvarVal = &innerByref;
-        Assert.Throws<InvalidOleVariantTypeException>(() => outer.ToObject());
+        FluentActions.Invoking(() => outer.ToObject()).Should().Throw<InvalidOleVariantTypeException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_CLSID_Byref_Throws()
     {
         Guid g = Guid.NewGuid();
         Guid* pg = &g;
         VARIANT v = new() { vt = VARENUM.VT_CLSID | VARENUM.VT_BYREF };
         v.data.byref = &pg;
-        Assert.Throws<ArgumentException>(() => v.ToObject());
+        FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_FILETIME_Byref_Throws()
     {
         FILETIME ft = default;
         VARIANT v = new() { vt = VARENUM.VT_FILETIME | VARENUM.VT_BYREF };
         v.data.byref = &ft;
-        Assert.Throws<ArgumentException>(() => v.ToObject());
+        FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_RECORD_NullRecInfo_Throws()
     {
         VARIANT v = new() { vt = VARENUM.VT_RECORD };
-        Assert.Throws<ArgumentException>(() => v.ToObject());
+        FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Byref_NullData_NonEmpty_Throws()
     {
         VARIANT v = new() { vt = VARENUM.VT_I4 | VARENUM.VT_BYREF };
         v.data.pintVal = null;
-        Assert.Throws<ArgumentException>(() => v.ToObject());
+        FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_VT_NULL_BYREF_NullData_ReturnsDBNull()
     {
         VARIANT v = new() { vt = VARENUM.VT_NULL | VARENUM.VT_BYREF };
-        Assert.Equal(Convert.DBNull, v.ToObject());
+        v.ToObject().Should().Be(Convert.DBNull);
     }
 
     // ===== ToArray (VT_ARRAY) coverage =====
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_I1_ReturnsSbyteArray()
     {
         sbyte[] values = [-1, 2, -3];
@@ -930,7 +933,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I1 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<sbyte[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<sbyte[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -938,7 +941,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_UI1_ReturnsByteArray()
     {
         byte[] values = [1, 2, 3];
@@ -947,7 +950,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UI1 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<byte[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<byte[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -955,7 +958,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_I2_ReturnsShortArray()
     {
         short[] values = [-1, 2];
@@ -964,7 +967,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I2 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<short[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<short[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -972,7 +975,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_UI2_ReturnsUshortArray()
     {
         ushort[] values = [1, 2];
@@ -981,7 +984,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UI2 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<ushort[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<ushort[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -989,7 +992,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_UI4_ReturnsUintArray()
     {
         uint[] values = [1u, 2u];
@@ -998,7 +1001,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UI4 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<uint[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<uint[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1006,7 +1009,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_I8_ReturnsLongArray()
     {
         long[] values = [-1L, 2L];
@@ -1015,7 +1018,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I8 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<long[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<long[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1023,7 +1026,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_UI8_ReturnsUlongArray()
     {
         ulong[] values = [1UL, 2UL];
@@ -1032,7 +1035,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UI8 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<ulong[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<ulong[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1040,7 +1043,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_R4_ReturnsFloatArray()
     {
         float[] values = [1.5f, 2.5f];
@@ -1049,7 +1052,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_R4 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<float[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<float[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1057,7 +1060,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_BOOL_ReturnsBoolArray()
     {
         VARIANT_BOOL[] values = [VARIANT_BOOL.VARIANT_TRUE, VARIANT_BOOL.VARIANT_FALSE];
@@ -1067,7 +1070,7 @@ public partial class VariantTests
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_BOOL };
             v.data.parray = psa;
             bool[] expected = [true, false];
-            Assert.Equal(expected, Assert.IsType<bool[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<bool[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1075,7 +1078,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_DATE_ReturnsDateTimeArray()
     {
         DateTime d1 = new(2024, 1, 1);
@@ -1087,7 +1090,7 @@ public partial class VariantTests
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_DATE };
             v.data.parray = psa;
             DateTime[] expected = [d1, d2];
-            Assert.Equal(expected, Assert.IsType<DateTime[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<DateTime[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1095,7 +1098,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_CY_ReturnsDecimalArray()
     {
         long[] values = [12345L, 67890L];
@@ -1105,7 +1108,7 @@ public partial class VariantTests
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_CY };
             v.data.parray = psa;
             decimal[] expected = [1.2345m, 6.789m];
-            Assert.Equal(expected, Assert.IsType<decimal[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<decimal[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1113,7 +1116,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_DECIMAL_ReturnsDecimalArray()
     {
         // Regression guard: VARIANT.ToObject used to short-circuit on `Type == VT_DECIMAL`
@@ -1126,7 +1129,7 @@ public partial class VariantTests
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_DECIMAL };
             v.data.parray = psa;
             decimal[] expected = [1.5m, 2.5m];
-            Assert.Equal(expected, Assert.IsType<decimal[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<decimal[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1134,7 +1137,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_VARIANT_ReturnsObjectArray()
     {
 #if NETFRAMEWORK
@@ -1147,7 +1150,7 @@ public partial class VariantTests
         PInvokeMadowaku.SafeArrayPutElement(source481.Value, &idx481, &inner481).ThrowOnFailure();
         VARIANT v481 = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_VARIANT };
         v481.data.parray = source481.Value;
-        Assert.Throws<ArgumentException>(() => v481.ToObject());
+        FluentActions.Invoking(() => v481.ToObject()).Should().Throw<ArgumentException>();
 #else
         using SafeArrayScope<object> source = new(2);
         VARIANT one = (VARIANT)1;
@@ -1159,13 +1162,13 @@ public partial class VariantTests
 
         VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_VARIANT };
         v.data.parray = source.Value;
-        object?[] array = Assert.IsType<object?[]>(v.ToObject());
+        object?[] array = v.ToObject().Should().BeOfType<object?[]>().Subject;
         object?[] expected = [1, 2];
-        Assert.Equal(expected, array);
+        array.Should().Equal(expected);
 #endif
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_RECORD_MismatchedSafeArray_ThrowsArgumentException()
     {
         // Constructing a true VT_RECORD SAFEARRAY requires an IRecordInfo, which is impractical
@@ -1178,7 +1181,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_RECORD };
             v.data.parray = psa;
-            Assert.Throws<ArgumentException>(() => v.ToObject());
+            FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
         }
         finally
         {
@@ -1186,12 +1189,12 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_NonZeroLowerBound_PreservesBounds()
     {
         SAFEARRAYBOUND bound = new() { cElements = 3, lLbound = 5 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_I4, 1, &bound);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
 
         try
         {
@@ -1204,13 +1207,13 @@ public partial class VariantTests
 
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
             v.data.parray = psa;
-            Array array = Assert.IsAssignableFrom<Array>(v.ToObject());
-            Assert.Equal(1, array.Rank);
-            Assert.Equal(5, array.GetLowerBound(0));
-            Assert.Equal(3, array.Length);
-            Assert.Equal(0, array.GetValue(5));
-            Assert.Equal(10, array.GetValue(6));
-            Assert.Equal(20, array.GetValue(7));
+            Array array = v.ToObject().Should().BeAssignableTo<Array>().Subject;
+            array.Rank.Should().Be(1);
+            array.GetLowerBound(0).Should().Be(5);
+            array.Length.Should().Be(3);
+            array.GetValue(5).Should().Be(0);
+            array.GetValue(6).Should().Be(10);
+            array.GetValue(7).Should().Be(20);
         }
         finally
         {
@@ -1221,39 +1224,39 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_NonZeroLowerBound_VariousScalarTypes_RoundTrip()
     {
         Array i1 = ConvertNonZeroLowerBoundArray(VARENUM.VT_I1, VARENUM.VT_I1, (sbyte[])[-1, 2]);
-        Assert.Equal((sbyte)-1, i1.GetValue(5));
-        Assert.Equal((sbyte)2, i1.GetValue(6));
+        i1.GetValue(5).Should().Be((sbyte)-1);
+        i1.GetValue(6).Should().Be((sbyte)2);
 
         Array ui1 = ConvertNonZeroLowerBoundArray(VARENUM.VT_UI1, VARENUM.VT_UI1, (byte[])[1, 2]);
-        Assert.Equal((byte)1, ui1.GetValue(5));
-        Assert.Equal((byte)2, ui1.GetValue(6));
+        ui1.GetValue(5).Should().Be((byte)1);
+        ui1.GetValue(6).Should().Be((byte)2);
 
         Array i2 = ConvertNonZeroLowerBoundArray(VARENUM.VT_I2, VARENUM.VT_I2, (short[])[-2, 3]);
-        Assert.Equal((short)-2, i2.GetValue(5));
-        Assert.Equal((short)3, i2.GetValue(6));
+        i2.GetValue(5).Should().Be((short)-2);
+        i2.GetValue(6).Should().Be((short)3);
 
         Array ui2 = ConvertNonZeroLowerBoundArray(VARENUM.VT_UI2, VARENUM.VT_UI2, (ushort[])[2, 4]);
-        Assert.Equal((ushort)2, ui2.GetValue(5));
-        Assert.Equal((ushort)4, ui2.GetValue(6));
+        ui2.GetValue(5).Should().Be((ushort)2);
+        ui2.GetValue(6).Should().Be((ushort)4);
 
         Array i8 = ConvertNonZeroLowerBoundArray(VARENUM.VT_I8, VARENUM.VT_I8, (long[])[-3, 6]);
-        Assert.Equal(-3L, i8.GetValue(5));
-        Assert.Equal(6L, i8.GetValue(6));
+        i8.GetValue(5).Should().Be(-3L);
+        i8.GetValue(6).Should().Be(6L);
 
         Array ui8 = ConvertNonZeroLowerBoundArray(VARENUM.VT_UI8, VARENUM.VT_UI8, (ulong[])[3, 6]);
-        Assert.Equal(3UL, ui8.GetValue(5));
-        Assert.Equal(6UL, ui8.GetValue(6));
+        ui8.GetValue(5).Should().Be(3UL);
+        ui8.GetValue(6).Should().Be(6UL);
 
         Array r4 = ConvertNonZeroLowerBoundArray(VARENUM.VT_R4, VARENUM.VT_R4, (float[])[1.25f, 2.5f]);
-        Assert.Equal(1.25f, r4.GetValue(5));
-        Assert.Equal(2.5f, r4.GetValue(6));
+        r4.GetValue(5).Should().Be(1.25f);
+        r4.GetValue(6).Should().Be(2.5f);
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_NonZeroLowerBound_VT_DATE_BehaviorByTfm()
     {
         DateTime d1 = new(2024, 1, 1);
@@ -1261,15 +1264,16 @@ public partial class VariantTests
         double[] values = [d1.ToOADate(), d2.ToOADate()];
 
 #if NETFRAMEWORK
-        Assert.Throws<ArgumentException>(() => ConvertNonZeroLowerBoundArray(VARENUM.VT_DATE, VARENUM.VT_DATE, values));
+        FluentActions.Invoking(() => ConvertNonZeroLowerBoundArray(VARENUM.VT_DATE, VARENUM.VT_DATE, values))
+            .Should().Throw<ArgumentException>();
 #else
         Array dateArray = ConvertNonZeroLowerBoundArray(VARENUM.VT_DATE, VARENUM.VT_DATE, values);
-        Assert.Equal(d1, dateArray.GetValue(5));
-        Assert.Equal(d2, dateArray.GetValue(6));
+        dateArray.GetValue(5).Should().Be(d1);
+        dateArray.GetValue(6).Should().Be(d2);
 #endif
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_TypeMismatch_Throws()
     {
         double[] values = [1.0];
@@ -1278,7 +1282,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
             v.data.parray = psa;
-            Assert.Throws<SafeArrayTypeMismatchException>(() => v.ToObject());
+            FluentActions.Invoking(() => v.ToObject()).Should().Throw<SafeArrayTypeMismatchException>();
         }
         finally
         {
@@ -1286,7 +1290,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_EMPTY_ThrowsInvalidOleVariantTypeException()
     {
         int[] values = [1];
@@ -1295,7 +1299,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_EMPTY };
             v.data.parray = psa;
-            Assert.Throws<InvalidOleVariantTypeException>(() => v.ToObject());
+            FluentActions.Invoking(() => v.ToObject()).Should().Throw<InvalidOleVariantTypeException>();
         }
         finally
         {
@@ -1303,18 +1307,18 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_UNKNOWN_EmptySafeArray_ReturnsEmptyObjectArray()
     {
         SAFEARRAYBOUND bounds = new() { cElements = 0, lLbound = 0 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UNKNOWN, 1, &bounds);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
 
         try
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UNKNOWN };
             v.data.parray = psa;
-            Assert.Empty(Assert.IsType<object?[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<object?[]>().Which.Should().BeEmpty();
         }
         finally
         {
@@ -1325,18 +1329,18 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_DISPATCH_EmptySafeArray_ReturnsEmptyObjectArray()
     {
         SAFEARRAYBOUND bounds = new() { cElements = 0, lLbound = 0 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_DISPATCH, 1, &bounds);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
 
         try
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_DISPATCH };
             v.data.parray = psa;
-            Assert.Empty(Assert.IsType<object?[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<object?[]>().Which.Should().BeEmpty();
         }
         finally
         {
@@ -1347,7 +1351,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_INT_From_VT_I4_SafeArray_Succeeds()
     {
         int[] values = [7, 8];
@@ -1356,7 +1360,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_INT };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<int[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<int[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1364,7 +1368,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_I4_From_VT_INT_SafeArray_Succeeds()
     {
         int[] values = [9, 10];
@@ -1373,7 +1377,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_I4 };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<int[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<int[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1381,7 +1385,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_VT_UINT_From_VT_UI4_SafeArray_Succeeds()
     {
         uint[] values = [11u, 12u];
@@ -1390,7 +1394,7 @@ public partial class VariantTests
         {
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UINT };
             v.data.parray = psa;
-            Assert.Equal(values, Assert.IsType<uint[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<uint[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1398,7 +1402,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_2D_VT_BSTR_TransposesStrings()
     {
         SAFEARRAYBOUND* bounds = stackalloc SAFEARRAYBOUND[2];
@@ -1422,8 +1426,8 @@ public partial class VariantTests
 
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_BSTR };
             v.data.parray = psa;
-            string[,] array = Assert.IsType<string[,]>(v.ToObject());
-            Assert.Equal(4, array.Length);
+            string[,] array = v.ToObject().Should().BeOfType<string[,]>().Subject;
+            array.Length.Should().Be(4);
             List<string> items = [];
             for (int a = 0; a < array.GetLength(0); a++)
             {
@@ -1434,7 +1438,7 @@ public partial class VariantTests
             }
 
             string[] expected = ["0,0", "0,1", "1,0", "1,1"];
-            Assert.Equal(expected, items.OrderBy(x => x));
+            items.OrderBy(x => x).Should().Equal(expected);
         }
         finally
         {
@@ -1442,7 +1446,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_3D_VT_R8_Transposes()
     {
         SAFEARRAYBOUND* bounds = stackalloc SAFEARRAYBOUND[3];
@@ -1470,8 +1474,8 @@ public partial class VariantTests
 
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_R8 };
             v.data.parray = psa;
-            double[,,] array = Assert.IsType<double[,,]>(v.ToObject());
-            Assert.Equal(8, array.Length);
+            double[,,] array = v.ToObject().Should().BeOfType<double[,,]>().Subject;
+            array.Length.Should().Be(8);
 
             // Validate that every populated source value appears exactly once in the CLR array.
             // SAFEARRAYs are column-major and CLR arrays are row-major, so VARIANT.ToObject
@@ -1492,7 +1496,7 @@ public partial class VariantTests
             }
 
             double[] expected = [0, 1, 10, 11, 100, 101, 110, 111];
-            Assert.Equal(expected.OrderBy(x => x), actual.OrderBy(x => x));
+            actual.OrderBy(x => x).Should().Equal(expected.OrderBy(x => x));
         }
         finally
         {
@@ -1500,14 +1504,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Array_2D_VT_UINT_Transposes()
     {
         SAFEARRAYBOUND* bounds = stackalloc SAFEARRAYBOUND[2];
         bounds[0] = new SAFEARRAYBOUND { cElements = 2, lLbound = 0 };
         bounds[1] = new SAFEARRAYBOUND { cElements = 2, lLbound = 0 };
         SAFEARRAY* psa = PInvokeMadowaku.SafeArrayCreate(VARENUM.VT_UI4, 2, bounds);
-        Assert.False(psa is null);
+        (psa is null).Should().BeFalse();
 
         try
         {
@@ -1526,7 +1530,7 @@ public partial class VariantTests
 
             VARIANT v = new() { vt = VARENUM.VT_ARRAY | VARENUM.VT_UINT };
             v.data.parray = psa;
-            uint[,] array = Assert.IsType<uint[,]>(v.ToObject());
+            uint[,] array = v.ToObject().Should().BeOfType<uint[,]>().Subject;
 
             uint[] expected = [0u, 1u, 10u, 11u];
             List<uint> actual = [];
@@ -1538,7 +1542,7 @@ public partial class VariantTests
                 }
             }
 
-            Assert.Equal(expected.OrderBy(x => x), actual.OrderBy(x => x));
+            actual.OrderBy(x => x).Should().Equal(expected.OrderBy(x => x));
         }
         finally
         {
@@ -1551,14 +1555,14 @@ public partial class VariantTests
 
     // ===== ToVector (VT_VECTOR) coverage =====
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_I1_ReturnsSbyteArray()
     {
         sbyte[] values = [-1, 2];
         VARIANT v = MakeVector(VARENUM.VT_I1, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<sbyte[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<sbyte[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1566,14 +1570,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_UI1_ReturnsByteArray()
     {
         byte[] values = [1, 2, 3];
         VARIANT v = MakeVector(VARENUM.VT_UI1, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<byte[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<byte[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1581,14 +1585,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_I2_ReturnsShortArray()
     {
         short[] values = [-1, 2];
         VARIANT v = MakeVector(VARENUM.VT_I2, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<short[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<short[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1596,14 +1600,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_UI2_ReturnsUshortArray()
     {
         ushort[] values = [1, 2];
         VARIANT v = MakeVector(VARENUM.VT_UI2, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<ushort[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<ushort[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1611,14 +1615,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_I4_ReturnsIntArray()
     {
         int[] values = [1, 2, 3];
         VARIANT v = MakeVector(VARENUM.VT_I4, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<int[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<int[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1626,14 +1630,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_INT_ReturnsIntArray()
     {
         int[] values = [4, 5];
         VARIANT v = MakeVector(VARENUM.VT_INT, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<int[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<int[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1641,14 +1645,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_UI4_ReturnsUintArray()
     {
         uint[] values = [1u, 2u];
         VARIANT v = MakeVector(VARENUM.VT_UI4, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<uint[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<uint[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1656,14 +1660,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_UINT_ReturnsUintArray()
     {
         uint[] values = [3u, 4u];
         VARIANT v = MakeVector(VARENUM.VT_UINT, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<uint[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<uint[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1671,14 +1675,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_ERROR_ReturnsUintArray()
     {
         uint[] values = [5u];
         VARIANT v = MakeVector(VARENUM.VT_ERROR, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<uint[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<uint[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1686,14 +1690,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_I8_ReturnsLongArray()
     {
         long[] values = [1L, 2L];
         VARIANT v = MakeVector(VARENUM.VT_I8, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<long[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<long[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1701,14 +1705,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_UI8_ReturnsUlongArray()
     {
         ulong[] values = [1UL, 2UL];
         VARIANT v = MakeVector(VARENUM.VT_UI8, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<ulong[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<ulong[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1716,14 +1720,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_R4_ReturnsFloatArray()
     {
         float[] values = [1.5f, 2.5f];
         VARIANT v = MakeVector(VARENUM.VT_R4, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<float[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<float[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1731,14 +1735,14 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_R8_ReturnsDoubleArray()
     {
         double[] values = [1.5, 2.5];
         VARIANT v = MakeVector(VARENUM.VT_R8, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<double[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<double[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1746,7 +1750,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_BOOL_ReturnsBoolArray()
     {
         VARIANT_BOOL[] values = [VARIANT_BOOL.VARIANT_TRUE, VARIANT_BOOL.VARIANT_FALSE];
@@ -1754,7 +1758,7 @@ public partial class VariantTests
         try
         {
             bool[] expected = [true, false];
-            Assert.Equal(expected, Assert.IsType<bool[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<bool[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1762,7 +1766,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_CY_ReturnsDecimalArray()
     {
         long[] values = [12345L];
@@ -1770,7 +1774,7 @@ public partial class VariantTests
         try
         {
             decimal[] expected = [1.2345m];
-            Assert.Equal(expected, Assert.IsType<decimal[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<decimal[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1778,7 +1782,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_DATE_ReturnsDateTimeArray()
     {
         DateTime d = new(2024, 1, 1);
@@ -1787,7 +1791,7 @@ public partial class VariantTests
         try
         {
             DateTime[] expected = [d];
-            Assert.Equal(expected, Assert.IsType<DateTime[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<DateTime[]>().Which.Should().Equal(expected);
         }
         finally
         {
@@ -1795,7 +1799,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_FILETIME_ReturnsDateTimeArray()
     {
         DateTime expected = new DateTime(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc).ToLocalTime();
@@ -1805,7 +1809,7 @@ public partial class VariantTests
         try
         {
             DateTime[] expectedArray = [expected];
-            Assert.Equal(expectedArray, Assert.IsType<DateTime[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<DateTime[]>().Which.Should().Equal(expectedArray);
         }
         finally
         {
@@ -1813,7 +1817,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_CLSID_ReturnsGuidArray()
     {
         Guid g1 = Guid.NewGuid();
@@ -1822,7 +1826,7 @@ public partial class VariantTests
         VARIANT v = MakeVector(VARENUM.VT_CLSID, values);
         try
         {
-            Assert.Equal(values, Assert.IsType<Guid[]>(v.ToObject()));
+            v.ToObject().Should().BeOfType<Guid[]>().Which.Should().Equal(values);
         }
         finally
         {
@@ -1830,7 +1834,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_BSTR_ReturnsStringArray()
     {
         BSTR b1 = new("alpha");
@@ -1841,9 +1845,9 @@ public partial class VariantTests
             VARIANT v = MakeVector(VARENUM.VT_BSTR, values);
             try
             {
-                string?[] array = Assert.IsType<string?[]>(v.ToObject());
+                string?[] array = v.ToObject().Should().BeOfType<string?[]>().Subject;
                 string?[] expected = ["alpha", "beta"];
-                Assert.Equal(expected, array);
+                array.Should().Equal(expected);
             }
             finally
             {
@@ -1857,7 +1861,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_LPWSTR_ReturnsStringArray()
     {
         nint s1 = InteropMarshal.StringToCoTaskMemUni("one");
@@ -1868,9 +1872,9 @@ public partial class VariantTests
             VARIANT v = MakeVector(VARENUM.VT_LPWSTR, values);
             try
             {
-                string?[] array = Assert.IsType<string?[]>(v.ToObject());
+                string?[] array = v.ToObject().Should().BeOfType<string?[]>().Subject;
                 string?[] expected = ["one", "two"];
-                Assert.Equal(expected, array);
+                array.Should().Equal(expected);
             }
             finally
             {
@@ -1884,7 +1888,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_LPSTR_ReturnsStringArray()
     {
         nint s1 = InteropMarshal.StringToCoTaskMemAnsi("one");
@@ -1895,9 +1899,9 @@ public partial class VariantTests
             VARIANT v = MakeVector(VARENUM.VT_LPSTR, values);
             try
             {
-                string?[] array = Assert.IsType<string?[]>(v.ToObject());
+                string?[] array = v.ToObject().Should().BeOfType<string?[]>().Subject;
                 string?[] expected = ["one", "two"];
-                Assert.Equal(expected, array);
+                array.Should().Equal(expected);
             }
             finally
             {
@@ -1911,7 +1915,7 @@ public partial class VariantTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_VT_VARIANT_ReturnsObjectArray()
     {
 #if NETFRAMEWORK
@@ -1922,7 +1926,7 @@ public partial class VariantTests
         VARIANT v481 = MakeVector(VARENUM.VT_VARIANT, inners481);
         try
         {
-            Assert.Throws<ArgumentException>(() => v481.ToObject());
+            FluentActions.Invoking(() => v481.ToObject()).Should().Throw<ArgumentException>();
         }
         finally
         {
@@ -1933,9 +1937,9 @@ public partial class VariantTests
         VARIANT v = MakeVector(VARENUM.VT_VARIANT, inners);
         try
         {
-            object?[] array = Assert.IsType<object?[]>(v.ToObject());
+            object?[] array = v.ToObject().Should().BeOfType<object?[]>().Subject;
             object?[] expected = [1, 2];
-            Assert.Equal(expected, array);
+            array.Should().Equal(expected);
         }
         finally
         {
@@ -1944,14 +1948,14 @@ public partial class VariantTests
 #endif
     }
 
-    [Fact]
+    [TestMethod]
     public unsafe void ToObject_Vector_UnsupportedType_Throws()
     {
         int[] values = [0];
         VARIANT v = MakeVector(VARENUM.VT_CF, values);
         try
         {
-            Assert.Throws<ArgumentException>(() => v.ToObject());
+            FluentActions.Invoking(() => v.ToObject()).Should().Throw<ArgumentException>();
         }
         finally
         {

--- a/madowaku.tests/madowaku.tests.csproj
+++ b/madowaku.tests/madowaku.tests.csproj
@@ -18,11 +18,12 @@
 
     <!-- Use the Microsoft Testing Platform -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
-    <PackageReference Include="xunit.v3"/>
+    <PackageReference Include="MSTest" />
     <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 
@@ -31,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Xunit" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Migrate `madowaku.tests` from xUnit v3 to **MSTest 4.2.3** running on the Microsoft Testing Platform, with assertions via **AwesomeAssertions 9.4.0**.

## Changes

- **Packages** (`Directory.Packages.props`): add `MSTest` 4.2.3 and `AwesomeAssertions` 9.4.0; bump `Microsoft.Testing.Extensions.CodeCoverage` to 18.7.0 to satisfy MSTest's transitive minimum (was NU1605).
- **Test project** (`madowaku.tests.csproj`): enable the MSTest runner; add the `Microsoft.VisualStudio.TestTools.UnitTesting` using.
- **Parallelism**: `[assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]` in a new `AssemblyInfo.cs`.
- **Tests**: convert all `[Fact]` tests to `[TestClass]`/`[TestMethod]` with `.Should()` assertions throughout; exceptions via `FluentActions.Invoking(...).Should().Throw<T>()`.
- **Decimal round-trips**: use `BeApproximately(value, 0m)` for `VT_DECIMAL` so the comparison is scale-insensitive (net10's round-trip changes the decimal's scale, which AwesomeAssertions' scale-sensitive `Be` would reject).
- **Docs**: update `AGENTS.md`, `tests.instructions.md`, and regenerate the `copilot-instructions.md` mirror.

## Validation

`dotnet test -c Release` — **492/492 passing** on both `net10.0-windows10.0.22000.0` and `net481`.