### PR TITLE
Add publish-release skill and a publish-workflow tag guard

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -16,6 +16,7 @@ overlap.
 | [cswin32-interop](./cswin32-interop/SKILL.md) | "add a P/Invoke", "replace `[DllImport]`", "use CsWin32 for X", "what does `PInvoke` vs `PInvokeMadowaku` mean", net472 vs modern .NET CsWin32 gating, the `ComWrappers` polyfill, Touki vs local polyfills | `cswin32-com` |
 | [cswin32-com](./cswin32-com/SKILL.md) | "use `ComScope<T>`", "wire up `IComIID`", "activate a COM object", "manually define an `ICLR*` / `IWbem*` / `IMetaData*` interface", `IID.Get<T>()`, `delegate* unmanaged` vtables, per-struct net472 polyfill | `cswin32-interop` |
 | [performance-testing](./performance-testing/SKILL.md) | "add a benchmark", "run perf tests", "compare allocations", "BenchmarkDotNet", "why is net481 slower/faster" | `cswin32-interop`, `cswin32-com` |
+| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" | &mdash; |
 
 ## Disambiguation
 

--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -88,7 +88,7 @@ watch the workflow, and create the GitHub release.
 
 - [versioning.md](versioning.md) &mdash; establishing the prior version, the
   prerelease channel decision, the `Major.Minor.Patch` bump table, the
-  `AssemblyVersion` gotcha, the exact tag format, and the "no guard" warning.
+  `AssemblyVersion` gotcha, the exact tag format, and the tag-format guard.
 - [release-steps.md](release-steps.md) &mdash; creating and pushing the
   annotated tag, `workflow_dispatch` recovery, the GitHub release notes
   template, and aftercare.

--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: publish-release
+description: Publish a new version of the `KlutzyNinja.Madowaku` NuGet package by cutting a release tag. Use when asked to "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", or "tag and publish". Walks through choosing the right `Major.Minor.Patch` bump, deciding whether to stay in `alpha` / `beta` / `rc` / stable, composing the `v*` tag, pushing it, and creating the matching GitHub release. Flags when an `AssemblyVersion`-changing Major bump is required (binary breaking changes vs additive/bugfix work).
+argument-hint: 'Describe the release you want to cut (channel and/or version bump) if known.'
+---
+
+# Publish a release
+
+This repo ships a single NuGet package from one tag stream:
+
+| Package | Tag prefix | Workflow |
+| ------- | ---------- | -------- |
+| `KlutzyNinja.Madowaku` | `v` (e.g. `v0.1.0-alpha.4`) | [.github/workflows/publish.yml](../../../.github/workflows/publish.yml) |
+
+[MinVer](https://github.com/adamralph/minver) derives every version artifact
+(`Version`, `PackageVersion`, `AssemblyVersion`, `FileVersion`,
+`InformationalVersion`) from the tag at HEAD. **The tag *is* the version.**
+MinVer is referenced directly in
+[madowaku/madowaku.csproj](../../../madowaku/madowaku.csproj) with
+`<MinVerTagPrefix>v</MinVerTagPrefix>`; there is no `Directory.Build.targets`
+and no per-project override (only one package ships).
+
+The publish workflow fires when a `v*.*.*` tag is pushed.
+[publish.yml](../../../.github/workflows/publish.yml) validates the tag against
+a SemVer-with-`v`-prefix regex (and rejects non-tag refs) as its first step, so
+a malformed tag such as `v.0.1.0-alpha.3` fails fast before any pack/push. The
+`v*.*.*` trigger glob is *not* the guard &mdash; it matches the stray dot too;
+the validation step is what stops a typo. See the "Tag-format guard" section in
+[versioning.md](versioning.md).
+
+**Approval scope.** "Publish a release" authorizes preparing the tag and
+release notes. It does **not** authorize the tag push. The
+**Approval checkpoint** below is the gate. See
+[AGENTS.md](../../../AGENTS.md) &sect; "Working with the user on changes" for
+the canonical rule.
+
+## Steps overview
+
+1. **Inspect repo state** (below).
+2. Establish the prior version &mdash; see [versioning.md](versioning.md).
+3. Decide the prerelease channel (alpha / beta / rc / stable) &mdash; [versioning.md](versioning.md).
+4. Decide `Major.Minor.Patch` and check the `AssemblyVersion` gotcha &mdash; [versioning.md](versioning.md).
+5. Compose and validate the tag &mdash; [versioning.md](versioning.md).
+6. **Approval checkpoint** (below) &mdash; stop and wait for an explicit publish verb.
+7. Create and push the tag, then watch the workflow &mdash; see [release-steps.md](release-steps.md).
+8. Create the GitHub release from the notes template &mdash; [release-steps.md](release-steps.md).
+9. Aftercare &mdash; [release-steps.md](release-steps.md).
+
+## 1. Inspect repo state
+
+Read-only checks:
+
+- `git remote -v` &mdash; confirm `origin` points at `JeremyKuhne/madowaku`
+  (the push target).
+- `git rev-parse --abbrev-ref HEAD` &mdash; must be `main` or a release branch.
+  Refuse to tag from an arbitrary feature branch unless the user explicitly
+  says so.
+- `git status --porcelain` &mdash; must be clean. If dirty, stop and ask.
+- `git log origin/main..HEAD` and `git log HEAD..origin/main` &mdash; must both
+  be empty. The tag must point at the published `origin/main` tip (or whatever
+  the user confirmed in the previous bullet).
+
+There is only one package, so no "which package" prompt is needed. Then work
+through steps 2&ndash;5 in [versioning.md](versioning.md) to land on a
+validated tag.
+
+## Approval checkpoint
+
+**Stop here.** Show the user:
+
+- The chosen tag (e.g. `v0.1.0-alpha.4`).
+- The prior tag and what bumped (e.g. "alpha.3 &rarr; alpha.4, no Major/Minor
+  change").
+- The commit the tag will point at (`git rev-parse HEAD`, short SHA + subject).
+- A short summary of the changes since the prior tag
+  (`git log --oneline <prior-tag>..HEAD`).
+- The expected published `AssemblyVersion` before/after.
+
+Wait for an explicit publishing verb (`tag`, `push the tag`, `ship it`,
+`publish`). Do **not** infer approval from the original "publish a release"
+request &mdash; that authorized the *preparation*, not the push. See
+[AGENTS.md](../../../AGENTS.md).
+
+After approval, follow [release-steps.md](release-steps.md) to push the tag,
+watch the workflow, and create the GitHub release.
+
+## Sub-pages
+
+- [versioning.md](versioning.md) &mdash; establishing the prior version, the
+  prerelease channel decision, the `Major.Minor.Patch` bump table, the
+  `AssemblyVersion` gotcha, the exact tag format, and the "no guard" warning.
+- [release-steps.md](release-steps.md) &mdash; creating and pushing the
+  annotated tag, `workflow_dispatch` recovery, the GitHub release notes
+  template, and aftercare.
+
+## Cross-references
+
+- [AGENTS.md](../../../AGENTS.md) &sect; "Working with the user on changes"
+  &mdash; the publish-boundary rule governing the approval checkpoint.
+- [madowaku/madowaku.csproj](../../../madowaku/madowaku.csproj) &mdash; MinVer
+  wiring and package metadata.
+- [.github/workflows/publish.yml](../../../.github/workflows/publish.yml)
+  &mdash; the publish pipeline itself.

--- a/.agents/skills/publish-release/release-steps.md
+++ b/.agents/skills/publish-release/release-steps.md
@@ -1,0 +1,129 @@
+# Tag, publish, and aftercare
+
+Detail for the [publish-release](SKILL.md) skill. These steps run **only after**
+the approval checkpoint in the core has passed.
+
+## 1. Create and push the tag
+
+Use an annotated tag with a short message:
+
+```pwsh
+git tag -a v0.1.0-alpha.4 -m "v0.1.0-alpha.4"
+git push origin v0.1.0-alpha.4
+```
+
+Do **not** use lightweight tags &mdash; annotated tags carry the tagger and
+date that show up in GitHub releases.
+
+Pushing the tag triggers the publish workflow. Watch the run:
+
+- <https://github.com/JeremyKuhne/madowaku/actions/workflows/publish.yml>
+
+The workflow restores, builds Release, packs, and pushes every `.nupkg` it
+finds in `./artifacts` to nuget.org with
+`dotnet nuget push --skip-duplicate` using the `NUGET_API_KEY` repo secret
+(an API key, not OIDC). Only `KlutzyNinja.Madowaku` packs &mdash; the test and
+perf projects set `<IsPackable>false</IsPackable>`, so they produce no package.
+
+> **The tag format is guarded.** [publish.yml](../../../.github/workflows/publish.yml)
+> validates the tag against the SemVer-with-`v`-prefix regex (and rejects
+> non-tag refs) before packing, so a malformed tag like `v.0.1.0-alpha.3`
+> fails fast instead of silently publishing a MinVer height fallback. Still
+> confirm the published version on nuget.org matches what you intended &mdash;
+> the guard catches *malformed*, not *wrong-but-well-formed*. See the
+> "Tag-format guard" section in [versioning.md](versioning.md).
+
+If the workflow fails, treat it like any CI failure: do **not** delete and
+re-push the tag without explicit user approval &mdash; that's destructive and
+the nuget.org publish is irreversible. Fix forward with the next tag in the
+stream.
+
+### Re-running the publish for an existing tag (`workflow_dispatch`)
+
+If a transient failure (NuGet outage, network blip) leaves a tag pushed but
+not published, [publish.yml](../../../.github/workflows/publish.yml) also
+accepts a manual `workflow_dispatch`. This workflow takes **no inputs** &mdash;
+instead, in the Actions UI choose **Run workflow** and select the **tag** ref
+(not a branch) from the ref dropdown. The job checks out that exact ref with
+`fetch-depth: 0`, so MinVer derives the intended version from the tag.
+
+Select the **tag**, not `main` or a branch: dispatching against a branch makes
+MinVer compute a `*.<height>` fallback and would publish a wrong version.
+
+## 2. Create the GitHub release
+
+Once the workflow has succeeded and the package is visible on nuget.org,
+create the matching GitHub release. This is what users actually read.
+
+Find the prior release first (the GitHub `get_latest_release` tool or
+`gh release view`) so the new notes can reference it. Then create via
+`gh release create` (preferred when `gh` is available and authenticated):
+
+```pwsh
+# Drop the --prerelease flag for a stable release.
+gh release create v0.1.0-alpha.4 `
+  --title "v0.1.0-alpha.4" `
+  --notes-file release-notes.md `
+  --prerelease
+```
+
+If `gh` is not available or not authenticated, use the GitHub web UI
+(Releases &rarr; Draft a new release &rarr; choose the existing tag), or the
+GitHub MCP tools.
+
+### Release notes template
+
+````markdown
+## Changes
+
+<!-- One-sentence headline of the most important change. -->
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+### Breaking changes
+<!-- Only present on Major bumps. AssemblyVersion changed from
+     0.0.0.0 -> 1.0.0.0; consumers must rebuild. -->
+- ...
+
+## Compatibility
+
+- Targets: `net10.0-windows10.0.22000.0`, `net10.0`, `net472`.
+- AssemblyVersion: `<old>` -> `<new>` (note **changed** or **unchanged**).
+
+## Install
+
+```bash
+dotnet add package KlutzyNinja.Madowaku --version 0.1.0-alpha.4
+```
+
+**Full changelog:** <https://github.com/JeremyKuhne/madowaku/compare/v0.1.0-alpha.2...v0.1.0-alpha.4>
+````
+
+Notes on the template:
+
+- Use the `--prerelease` flag iff the SemVer has a prerelease label. GitHub
+  displays prereleases differently (the "latest" indicator stays on the most
+  recent stable). Skipping `--prerelease` on an alpha is a real bug.
+- For the `compare/<prior>...<new>` link, use the prior **well-formed** tag.
+  Because `v.0.1.0-alpha.3` is malformed, a compare against the alpha.2 tag is
+  the meaningful diff until a clean tag exists in the stream.
+
+## 3. Aftercare
+
+- This package is not dog-fooded by another project in the repo &mdash; the
+  test and perf projects reference it by project reference, and
+  [Directory.Packages.props](../../../Directory.Packages.props) pins
+  *dependencies* (Touki, CsWin32, etc.), not `KlutzyNinja.Madowaku` itself. So
+  there is no consumer version to bump after a release.
+- If you bumped `Major` (binary break), make sure the release notes call out
+  the `AssemblyVersion` move (`0.0.0.0` &rarr; `1.0.0.0`) so downstream
+  binders know to rebuild.
+- The README's NuGet badge tracks nuget.org automatically; no manual edit is
+  needed after publishing.

--- a/.agents/skills/publish-release/versioning.md
+++ b/.agents/skills/publish-release/versioning.md
@@ -1,0 +1,168 @@
+# Choosing the version and composing the tag
+
+Detail for the [publish-release](SKILL.md) skill. Covers establishing the prior
+version, the prerelease channel decision, the `Major.Minor.Patch` bump, the
+`AssemblyVersion` gotcha, the exact tag format, and the missing-guard warning.
+
+## 1. Establish the prior version
+
+List the most recent five tags on the `v` prefix:
+
+```pwsh
+git tag --list 'v*' --sort=-creatordate | Select-Object -First 5
+```
+
+Cross-check against nuget.org so you don't accidentally re-publish a version
+that's already live (publishing is idempotent thanks to `--skip-duplicate`,
+but choosing a duplicate is almost always a mistake):
+
+- <https://www.nuget.org/packages/KlutzyNinja.Madowaku>
+
+Record the prior version (e.g. `0.1.0-alpha.3`).
+
+> **Watch the tag list for the historical `v.` typo.** The most recent tag in
+> this repo at the time of writing is `v.0.1.0-alpha.3` &mdash; note the stray
+> `.` after `v`. MinVer (prefix `v`) cannot parse it, so it is **silently
+> ignored** for versioning. When establishing the prior version, take the
+> newest tag that is *well-formed* (here `v0.1.0-alpha.2`), not merely the
+> newest tag. See the "No guard" warning in section 4.
+
+## 2. Decide the prerelease channel (alpha / beta / rc / stable)
+
+Before picking numbers, decide what *kind* of release this is. **Always
+prompt** the user with the current state explicit:
+
+> "The last well-formed release was an **alpha** (`v0.1.0-alpha.2`). Should
+> this also be an alpha release, or are you promoting to beta / rc / stable?"
+
+Use `vscode_askQuestions` with these options (mark the matching-prior option
+as `recommended: true`):
+
+- `Stay in alpha` &mdash; bug fixes / additive work during early development.
+- `Promote to beta` &mdash; feature-complete for the upcoming Minor; only
+  stabilization work expected.
+- `Promote to rc` &mdash; release candidate; only blocker bug fixes.
+- `Promote to stable` &mdash; drop the prerelease label entirely.
+- `Use a different label` &mdash; free-form.
+
+Channel rules of thumb:
+
+- Don't *skip* channels casually. `alpha` &rarr; `beta` &rarr; `rc` &rarr;
+  `stable` is the normal path. Going `alpha` &rarr; `stable` is allowed but
+  should be deliberate.
+- Once you ship a stable `Major.Minor.Patch`, the next prerelease must
+  bump *something* (`0.1.0` &rarr; `0.1.1-alpha.1` or `0.2.0-alpha.1`); you
+  cannot ship `0.1.0-alpha.2` after `0.1.0` stable.
+- Do **not** mix channels backwards (no going from `beta` back to `alpha`
+  for the same Major.Minor.Patch). If a beta turned out to need more
+  churn, bump the underlying version: `0.2.0-beta.3` &rarr; `0.3.0-alpha.1`.
+
+## 3. Decide `Major.Minor.Patch`
+
+Apply [SemVer 2.0.0](https://semver.org) rules. The package is currently
+pre-1.0, so the rules below describe the **target stable** semantics; while
+the prior tag is itself a prerelease, the same bump table applies to the
+underlying `Major.Minor.Patch` portion.
+
+| Change shipped since the last tag | Bump |
+| --- | --- |
+| Binary breaking change to public API of `madowaku.dll` (removed/renamed type or member, signature change, return-type change, base-type change, broken inheritance, removed `[Obsolete]`'d API) | **Major** |
+| Behavioral break that compiles but changes observable runtime contract (different exception type, different default, different ordering, different threading guarantee) | **Major** unless the user explicitly accepts shipping it as Minor with a release-note callout |
+| Net-new public API, new overload, new optional parameter, new public type, new TFM | **Minor** |
+| Bug fix only, no new public surface, no observable contract change for non-buggy callers | **Patch** |
+| Internal-only refactor, perf, doc, comment, build, CI | **Patch** (or no release at all) |
+
+For pre-1.0, the user may treat **Major** and **Minor** as both "Minor"
+during alpha/beta. That is fine; just confirm the call out loud:
+
+> "This change adds a public type but you're still in 0.1.x alpha &mdash; bump
+> to 0.2.0-alpha.1 (treating it as Minor) or stay at 0.1.0-alpha.4?"
+
+### When `AssemblyVersion` changes &mdash; and why it matters
+
+MinVer's defaults (used as-is in this repo, no overrides) produce:
+
+- `Version` / `PackageVersion` / `InformationalVersion` = full SemVer
+  (e.g. `0.1.0-alpha.4`).
+- `FileVersion` = `Major.Minor.Patch.0` (e.g. `0.1.0.0`).
+- **`AssemblyVersion` = `Major.0.0.0`** (e.g. `0.0.0.0` for any `0.x.y`).
+
+Only a **Major** bump changes `AssemblyVersion`. That has real consequences:
+
+- A change in `AssemblyVersion` forces every consumer that has the assembly
+  in their build graph to either rebuild against the new identity or use
+  binding redirects (on .NET Framework). Strong-named assemblies make this
+  stricter, and `madowaku.dll` is strong-named
+  (`klutzyninja.snk`, see [madowaku/madowaku.csproj](../../../madowaku/madowaku.csproj)).
+- A change in `Version`/`FileVersion` *without* `AssemblyVersion` changing
+  is binary-compatible &mdash; consumers can drop the new DLL into an existing
+  bin folder and it just works.
+
+**Therefore:** any binary breaking change *must* bump `Major`, even during
+0.x. Refusing to bump `Major` on a binary break &mdash; to "stay at 0.1.x"
+&mdash; silently keeps `AssemblyVersion = 0.0.0.0` across an incompatible
+boundary, which is a real foot-gun for downstream binders.
+
+When `Major` does bump, also note in the release that `AssemblyVersion`
+moved (`0.0.0.0` &rarr; `1.0.0.0`).
+
+## 4. Compose the tag
+
+Format:
+
+```text
+v<Major>.<Minor>.<Patch>[-<prerelease>]
+```
+
+Prerelease segment uses dot-separated identifiers, e.g. `alpha.4`,
+`beta.2`, `rc.1`. Numeric identifiers are SemVer-sorted as numbers, so
+`alpha.10` correctly sorts above `alpha.9` (no leading zeros).
+
+Examples (good):
+
+- `v0.1.0-alpha.4`
+- `v0.2.0-beta.1`
+- `v0.2.0-rc.1`
+- `v0.2.0`
+- `v1.0.0-rc.1`
+
+Examples (malformed &mdash; do not create):
+
+- `v.0.1.0-alpha.4` &mdash; stray `.` after `v`. This is the exact defect in
+  the existing `v.0.1.0-alpha.3` tag; do not recreate it.
+- `0.1.0-alpha.4` &mdash; missing `v` prefix (MinVer's prefix is `v`).
+- `v0.1.0.alpha.4` &mdash; `.` instead of `-` before prerelease.
+- `v0.1` &mdash; missing patch component (the workflow glob `v*.*.*` requires
+  three dot-separated segments).
+- `v01.02.03` &mdash; leading zeros in numeric identifiers.
+
+A well-formed tag matches this SemVer-with-`v`-prefix shape:
+
+```text
+^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
+```
+
+### Tag-format guard
+
+madowaku's [publish.yml](../../../.github/workflows/publish.yml) runs a
+**Validate tag format** step as the first thing in the publish job, before
+checkout. It rejects the run (fails fast, before any pack/push) when:
+
+- The ref is not a tag (`github.ref` must start with `refs/tags/`) &mdash; this
+  catches a `workflow_dispatch` accidentally launched from `main` or a branch,
+  which would otherwise make MinVer compute a `*.<height>` fallback and publish
+  a wrong version.
+- The tag name does not match the SemVer-with-`v`-prefix regex above.
+
+The trigger glob (`tags: ['v*.*.*']`) is *not* the guard &mdash; `*` matches a
+stray dot, so a typo'd tag such as `v.0.1.0-alpha.3` still starts the workflow.
+The validation step is what actually stops it: that tag fails the regex and the
+job throws before packing.
+
+Even with the guard in place:
+
+- Still triple-check the tag string against the good examples above before
+  pushing &mdash; the guard prevents a *malformed* publish, not a *wrong but
+  well-formed* one (e.g. tagging `v0.2.0` when you meant `v0.1.1`).
+- After the workflow runs, confirm the published version on nuget.org matches
+  the version you intended.

--- a/.agents/skills/publish-release/versioning.md
+++ b/.agents/skills/publish-release/versioning.md
@@ -2,7 +2,7 @@
 
 Detail for the [publish-release](SKILL.md) skill. Covers establishing the prior
 version, the prerelease channel decision, the `Major.Minor.Patch` bump, the
-`AssemblyVersion` gotcha, the exact tag format, and the missing-guard warning.
+`AssemblyVersion` gotcha, the exact tag format, and the tag-format guard.
 
 ## 1. Establish the prior version
 
@@ -25,7 +25,8 @@ Record the prior version (e.g. `0.1.0-alpha.3`).
 > `.` after `v`. MinVer (prefix `v`) cannot parse it, so it is **silently
 > ignored** for versioning. When establishing the prior version, take the
 > newest tag that is *well-formed* (here `v0.1.0-alpha.2`), not merely the
-> newest tag. See the "No guard" warning in section 4.
+> newest tag. The publish workflow now rejects such tags &mdash; see the
+> "Tag-format guard" section in section 4.
 
 ## 2. Decide the prerelease channel (alpha / beta / rc / stable)
 
@@ -35,8 +36,9 @@ prompt** the user with the current state explicit:
 > "The last well-formed release was an **alpha** (`v0.1.0-alpha.2`). Should
 > this also be an alpha release, or are you promoting to beta / rc / stable?"
 
-Use `vscode_askQuestions` with these options (mark the matching-prior option
-as `recommended: true`):
+Present these options (however your agent surface asks the user a multiple-
+choice question), and mark the option matching the prior channel as the
+recommended default:
 
 - `Stay in alpha` &mdash; bug fixes / additive work during early development.
 - `Promote to beta` &mdash; feature-complete for the upcoming Minor; only

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
             throw "Publish must run from a tag ref, got '$($env:REF)'."
         }
         $pattern = '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$'
-        if ($env:TAG -notmatch $pattern) {
+        if ($env:TAG -cnotmatch $pattern) {
             throw "Tag '$($env:TAG)' is not a valid version (expected v<major>.<minor>.<patch>[-prerelease])."
         }
         Write-Host "Tag '$($env:TAG)' is valid."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,20 @@ jobs:
     runs-on: windows-latest
 
     steps:
+    - name: Validate tag format
+      shell: pwsh
+      env:
+        REF: ${{ github.ref }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        if (-not $env:REF.StartsWith('refs/tags/')) {
+            throw "Publish must run from a tag ref, got '$($env:REF)'."
+        }
+        $pattern = '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$'
+        if ($env:TAG -notmatch $pattern) {
+            throw "Tag '$($env:TAG)' is not a valid version (expected v<major>.<minor>.<patch>[-prerelease])."
+        }
+        Write-Host "Tag '$($env:TAG)' is valid."
     - uses: actions/checkout@v5
       with: { fetch-depth: 0 }
     - name: Setup .NET


### PR DESCRIPTION
## Summary

Two related changes for the release process.

### `publish-release` skill (new)

Ports the `publish-release` skill from the touki repo, adapted to madowaku's specifics:

- **One package, one stream** — `KlutzyNinja.Madowaku` on the `v*` tag prefix (touki ships two packages / two streams).
- **MinVer wiring** — referenced directly in [madowaku/madowaku.csproj](madowaku/madowaku.csproj) (`MinVerTagPrefix=v`); no `Directory.Build.targets`.
- **Publish mechanism** — `NUGET_API_KEY` secret + `dotnet nuget push --skip-duplicate` (not OIDC).
- **Recovery** — `workflow_dispatch` takes no inputs; re-run by selecting the **tag ref** in the Actions UI.
- **Targets** — `net10.0-windows10.0.22000.0`, `net10.0`, `net472`.
- Cross-references point at [AGENTS.md](AGENTS.md), the csproj, and the workflow (touki's PR-review skill cross-refs don't exist here).
- Registered in the skills catalog ([.agents/skills/README.md](.agents/skills/README.md)).

Files: [SKILL.md](.agents/skills/publish-release/SKILL.md), [versioning.md](.agents/skills/publish-release/versioning.md), [release-steps.md](.agents/skills/publish-release/release-steps.md).

### Tag-format guard in `publish.yml`

Adds a **Validate tag format** step as the first step of the publish job. The `v*.*.*` trigger glob matched the historical `v.0.1.0-alpha.3` typo (the `*` matches the stray dot), which MinVer then can't parse — silently publishing a height-fallback version. The guard:

- Rejects non-tag refs (`github.ref` must start with `refs/tags/`) — catches a `workflow_dispatch` launched from a branch.
- Rejects tags not matching `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$`.
- Passes ref/tag through `env:` to avoid script injection from ref names.

Verified accept/reject against `v0.1.0-alpha.4`, `v0.2.0`, `v1.0.0-rc.1` (pass) and `v.0.1.0-alpha.3`, `0.1.0-alpha.4`, `v0.1`, `v01.02.03`, branch refs (reject).

## Validation

- `Validate-AgentFiles.ps1` — passed.
- markdownlint-cli2 with the repo config — 0 errors.
- `publish.yml` — no YAML errors.