### PR TITLE
Vendor agent-skills commons and reconcile local skill catalog

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -11,12 +11,61 @@ overlap.
 
 ## Inventory
 
-| Skill | Trigger phrasing | Cross-references |
-| ----- | ---------------- | ---------------- |
-| [cswin32-interop](./cswin32-interop/SKILL.md) | "add a P/Invoke", "replace `[DllImport]`", "use CsWin32 for X", "what does `PInvoke` vs `PInvokeMadowaku` mean", net472 vs modern .NET CsWin32 gating, the `ComWrappers` polyfill, Touki vs local polyfills | `cswin32-com` |
-| [cswin32-com](./cswin32-com/SKILL.md) | "use `ComScope<T>`", "wire up `IComIID`", "activate a COM object", "manually define an `ICLR*` / `IWbem*` / `IMetaData*` interface", `IID.Get<T>()`, `delegate* unmanaged` vtables, per-struct net472 polyfill | `cswin32-interop` |
-| [performance-testing](./performance-testing/SKILL.md) | "add a benchmark", "run perf tests", "compare allocations", "BenchmarkDotNet", "why is net481 slower/faster" | `cswin32-interop`, `cswin32-com` |
-| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" | &mdash; |
+Each skill is either **born-local** (specific to madowaku; no upstream, no
+provenance) or **vendored** from the shared commons
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) at a
+pinned ref, with a thin repo-specific `overlay.md` beside the pinned core. See
+[the vendoring model](#vendoring-model) below.
+
+### Born-local
+
+| Skill | Trigger phrasing |
+| ----- | ---------------- |
+| [cswin32-interop](./cswin32-interop/SKILL.md) | "add a P/Invoke", "replace `[DllImport]`", "use CsWin32 for X", "`PInvoke` vs `PInvokeMadowaku`", net472 vs modern .NET CsWin32 gating, the `ComWrappers` polyfill |
+| [cswin32-com](./cswin32-com/SKILL.md) | "use `ComScope<T>`", "wire up `IComIID`", "activate a COM object", "manually define an `ICLR*` / `IWbem*` / `IMetaData*` interface", `IID.Get<T>()`, `delegate* unmanaged` vtables, per-struct net472 polyfill |
+| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" |
+
+### Vendored (commons `v0.10.0`, unless noted)
+
+| Skill | Trigger phrasing |
+| ----- | ---------------- |
+| [performance-testing](./performance-testing/SKILL.md) | "add a benchmark", "run perf tests", "compare allocations", "BenchmarkDotNet", "why is net481 slower/faster", "how long / how much memory" |
+| [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | optimize a `net481` / .NET Framework hot path, specialize a generic for primitives, diagnose a Framework micro-benchmark regression |
+| [scratch-buffer-strategy](./scratch-buffer-strategy/SKILL.md) | zeroed `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs `ArrayPool`, "should I rent or stackalloc?", net481/net10 size crossovers |
+| [dotnet-polyfills](./dotnet-polyfills/SKILL.md) | "use a modern .NET API on .NET Framework", PolySharp / `System.Memory` / `Microsoft.Bcl.*`, "which package supplies this type downlevel", "is this already polyfilled" |
+| [il-copy-inspection](./il-copy-inspection/SKILL.md) | "find struct copies", "is this a defensive copy", "check for boxing in IL", "did the compiler emit a copy here" |
+| [security-review](./security-review/SKILL.md) | "do a security review", "check for ReDoS / DoS", "audit untrusted input"; any `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*` use |
+| [code-comprehension](./code-comprehension/SKILL.md) | "review this for readability", "is this too complex", "reduce nesting / cognitive load", reasonable method length / parameter count / nesting depth |
+| [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review before opening a PR, "review my draft", after a reviewer flags issues that should have been caught |
+| [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", publish in-progress work for review |
+| [address-pr-feedback](./address-pr-feedback/SKILL.md) | "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", post-PR follow-up |
+| [manage-skills](./manage-skills/SKILL.md) | "find a skill for X", "build a skill" / "create a skill", "update the skill", reconcile a local skill change against the commons vs a repo overlay |
+| [agent-files-review](./agent-files-review/SKILL.md) | review or validate changes to `AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, "fix the agent-files CI failure" |
+| [engineering-baseline](./engineering-baseline/SKILL.md) | "ensure this repo follows modern engineering best practices", "audit this repository", "bring this repo up to standard" |
+| [github-actions-cost-optimization](./github-actions-cost-optimization/SKILL.md) &mdash; pinned `@85325db` | "reduce CI cost / spend / minutes", optimize GitHub Actions triggers, matrices, runners, caches, artifacts |
+
+## Vendoring model
+
+Skills are authored once as a portable **core** in the commons and shared from
+there. madowaku holds a pinned, provenance-stamped **copy** of each vendored
+core plus a thin repo-specific **overlay**:
+
+- **Vendored core** &mdash; the `SKILL.md` (and its sibling pages) carry
+  `metadata.github-*` provenance (source repo, ref, tree SHA). It is a mirror of
+  upstream; **do not hand-edit it**, or `gh skill update` will flag the drift.
+- **Overlay** &mdash; `overlay.md` beside the core holds madowaku paths, project
+  names, and cross-references to other skills. Its frontmatter records the
+  `core-pin` it was reviewed against.
+- **Born-local** &mdash; `cswin32-com`, `cswin32-interop`, and `publish-release`
+  are specific to madowaku's structure, carry no provenance, and are never
+  upstreamed.
+
+All but one vendored core are pinned to the commons `v0.10.0` tag.
+`github-actions-cost-optimization` postdates that tag, so it is pinned to commit
+`85325db`; re-pin it to a release tag once the commons ships one that includes
+it. The [manage-skills](./manage-skills/SKILL.md) skill drives find / build /
+update, and [agent-files-review](./agent-files-review/SKILL.md) validates the
+resulting files.
 
 ## Disambiguation
 
@@ -35,6 +84,40 @@ Both touch CsWin32. They are mutually exclusive by **surface**:
 If a change adds both a new P/Invoke and a new COM type, run
 `cswin32-interop` first to add the P/Invoke surface, then `cswin32-com`
 for the COM activation and per-struct partial.
+
+### PR and release workflows: `create-pr` vs `address-pr-feedback` vs `publish-release`
+
+- **Open a new PR for in-progress work** &rarr; `create-pr`.
+- **Iterate on an existing PR** (review comments, Copilot feedback, CI fixes)
+  &rarr; `address-pr-feedback`.
+- **Cut a `KlutzyNinja.Madowaku` release tag** (a tag, not a PR) &rarr;
+  `publish-release` (born-local). All three honor the same publish boundary in
+  [AGENTS.md](../../AGENTS.md).
+
+### Performance cluster
+
+- **Measure** (author / run a BenchmarkDotNet benchmark, read results) &rarr;
+  `performance-testing`.
+- **Tune net472/net481 codegen** (specialization, unrolling, BCL delegation)
+  &rarr; `framework-jit-optimization`.
+- **Choose a scratch buffer** (`stackalloc` vs `ArrayPool` vs `BufferScope<T>`)
+  &rarr; `scratch-buffer-strategy`.
+- **Read IL for hidden struct copies or boxing** &rarr; `il-copy-inspection`.
+
+### Skill and agent-file meta: `manage-skills` vs `agent-files-review`
+
+- **Catalog lifecycle** (discover, add, vendor, sync a skill) &rarr;
+  `manage-skills`.
+- **Validate one agent file's syntax and conventions** (frontmatter, mirror,
+  whitespace) &rarr; `agent-files-review`.
+
+### `engineering-baseline` vs `github-actions-cost-optimization`
+
+- **Whole-repo nine-domain audit** (foundation, build, test, publish,
+  versioning, CI, supply chain, governance, agent enablement) &rarr;
+  `engineering-baseline`.
+- **CI runner cost specifically** (minutes, matrices, caches, artifacts) &rarr;
+  `github-actions-cost-optimization`.
 
 ## Maintenance
 

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -1,0 +1,134 @@
+---
+compatibility: Requires git and either a GitHub integration or authenticated gh for remote pull-request operations.
+description: Address feedback on an existing pull request - review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/address-pr-feedback
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: ceb544da854ef7ba911679b8af8bca2631150ef9
+    maturity: canary
+    portability: portable
+    related: create-pr, pre-pr-self-review, agent-files-review
+    requires: none
+    risk: remote-write
+name: address-pr-feedback
+---
+
+# Address PR feedback
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+This skill is the post-PR counterpart to the `create-pr` skill. Both share the
+**same** publish gate: neither `git commit` nor `git push` runs without an
+explicit publishing verb from the user. The difference is what each skill
+authorizes you to *edit*:
+
+- `create-pr` authorizes preparing a new PR from in-progress work -
+  branching, staging, proposing a commit message. The commit and push
+  still wait on approval.
+- This skill authorizes editing files in response to review feedback or
+  CI failures on an existing PR. Same approval gate before commit/push.
+
+Your repo's agent guidance (the "Working with the user on changes" rules in
+`AGENTS.md`) is the source of truth for the commit/push approval rule. Re-read it
+at the start of every invocation; this skill is the decision-point reminder, not
+a replacement.
+
+## Recognizing approval
+
+Carefully read the most recent user message and identify whether it
+contains an explicit publishing verb before you stage, commit, or push.
+Pattern-match the words, do not infer intent.
+
+**Approval** - verbs that authorize publishing the current change:
+`commit`, `push`, `update the PR`, `ship it`, `send it`, `yes push`, or
+direct synonyms when paired with a publishing intent.
+
+**Not approval** - everything else, including these phrasings that
+have repeatedly caused violations:
+
+- "Address the review comments." / "Reply to the comments on the PR." /
+  "Fix the comments / fix the CI failure."
+- "Look at Copilot's feedback / see what they said."
+- "See what you can do about this." / "Try a different approach."
+- "Do the next step" / "finish the rollout" / "go ahead to the next
+  thing" / a bare "go ahead" attached to a task description.
+- A reviewer (human or Copilot) leaving a new comment, or a failing
+  check on the PR.
+
+If you are uncertain whether a phrase is approval, **it is not approval**.
+Stop and ask one short yes/no question.
+
+## Workflow
+
+1. **Fetch the feedback.** Read review comments, PR conversation, and check-run
+   logs via the GitHub PR tools (or `Invoke-RestMethod` against
+   `api.github.com/repos/<owner>/<repo>/pulls/<N>/comments`). With multiple
+   review passes, fetch the **latest** review's comments (filter by the newest
+   review id) so you act on the current round.
+
+   Automated reviewers (e.g. Copilot) post asynchronously - on open, on push, or
+   when requested - a minute or two after the trigger. If one was requested but
+   hasn't posted, say so and act when the user reports comments (or check once);
+   don't poll. Verify their comments per step 2 - they produce confident false
+   positives.
+2. **Plan, and verify each comment.** Don't fix something just because a reviewer
+   (especially a bot) flagged it: confirm the claim against the code, and prove
+   it when checkable (a REPL check, a build, a test) - a fix to a false positive
+   can introduce the bug the reviewer imagined. Classify each:
+   - **Valid** - real issue; fix it.
+   - **Nit** - minor; fix if cheap, else note it.
+   - **Out of scope** - plan a written reply.
+   - **False positive / disagree** - plan a written explanation, not a change.
+3. **Edit files.** Make the code changes. Run the build and any relevant
+   tests. The applicable validation rules are still the `pre-pr-self-review`
+   checklist - a follow-up round needs the same checks as the initial PR.
+4. **Stop. Describe.** Summarize what you changed, why, and what (if
+   anything) you chose not to act on. Do **not** run `git add`, `git
+   commit`, or `git push`.
+5. **Wait** for an explicit publishing verb (see "Recognizing approval"
+   above).
+6. **Only then** stage by path, commit with a message that summarizes the
+   round of changes, and push. The staging/commit/push mechanics are the
+   same as in the `create-pr` skill (its "Commit changes" and "Push the
+   branch" steps).
+7. **Resolve the threads, with explanations.** Replying and resolving are remote
+   actions, so they ride in the same approved publish step as the push; honor
+   explicit scoping ("push and resolve only", "don't re-request") and report
+   what you did. For each comment, reply then resolve:
+   - **Fixed** - one line on what changed (reference the commit or behavior).
+   - **False positive / won't-fix** - the rationale or the evidence. Leave a
+     thread open only to invite a human onto a contested point, and say so.
+   With the PR tool, use its resolve action; with `gh`, resolve via the GraphQL
+   `resolveReviewThread` mutation on the thread node id (not the comment id).
+8. **Re-request review when non-trivial.** After real code changes, request a
+   fresh pass from the same reviewer - also a remote action in the publish step.
+   Skip it for trivial rounds (typo, reword, one-line nit) to avoid an endless
+   trickle, and say which you did.
+
+**When to stop.** Later auto-review passes drift toward nits and false positives.
+Once comments stop being substantive, stop re-requesting, say so, and let the
+user merge.
+
+## When you've already violated the rule
+
+Acknowledge the violation directly without minimizing. Do **not** push a
+follow-up commit to "fix" the situation without explicit approval -
+that compounds the failure. The user decides whether to revert,
+force-push, or leave the commit in place.
+
+## Related
+
+- Your repo's agent guidance (`AGENTS.md`) - the rule itself.
+- The `create-pr` skill - opening the initial PR (same publish gate,
+  different edit scope).
+- The `pre-pr-self-review` skill - the validation checklist that applies
+  to both initial and follow-up rounds.
+- The `agent-files-review` skill - for a CI failure from the *agent-files*
+  workflow specifically; its checklist owns the frontmatter, mirror, and
+  link rules.

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,0 +1,38 @@
+---
+core: address-pr-feedback
+core-pin: v0.10.0
+---
+
+# madowaku overlay - address-pr-feedback
+
+Repository-specific companion to the vendored [address-pr-feedback](SKILL.md)
+skill. The `SKILL.md` is a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in its frontmatter). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **The publish boundary still applies.** "Address the review comments", "fix the
+  comments", and "fix the CI failure" are **edit-only**; they never authorize a
+  commit or push. Make the changes, describe them, and stop - see
+  [AGENTS.md - Working with the user on changes](../../../AGENTS.md#working-with-the-user-on-changes).
+- **Run `dotnet test -c Release` before declaring a fix done.** Release-mode
+  inlining surfaces bugs Debug does not (the `Unsafe.As`-on-a-parameter foot-gun
+  on net481 RyuJIT is a known one).
+- **Do not stack "make CI green" follow-up commits.** Fix, then wait for an
+  explicit publishing verb.
+
+## Cross-references
+
+- [`create-pr`](../create-pr/SKILL.md) - the pre-PR counterpart with the same
+  publish gate.
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - the checklist for the
+  edits you push in a follow-up round.
+
+## Updating
+
+Pull upstream changes with `gh skill update address-pr-feedback` (review the
+diff, re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -1,0 +1,157 @@
+---
+compatibility: Requires the repository's validator and relative-link check; exact commands may be supplied by an overlay.
+description: Review changes to AI-agent customization files (AGENTS.md, .github/copilot-instructions.md, *.instructions.md, *.prompt.md, *.agent.md, SKILL.md, the validator, the CI workflow). Use when asked to review or validate agent-file changes, fix CI failures from the agent-files workflow, or audit a draft of any of these files.
+license: MIT
+metadata:
+    applicability: agent-customization
+    binding: optional-overlay
+    github-path: skills/agent-files-review
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 64a00d548909d8f84fb8ac6f6e3db77deceab270
+    maturity: canary
+    portability: portable
+    related: manage-skills
+    requires: none
+    risk: local-write
+name: agent-files-review
+---
+
+# Agent customization files - review checklist
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Run through every applicable item below before approving a change to an agent
+customization file. Each item below caught a real bug in PR review history.
+
+This skill assumes the repository has adopted the agent-file scaffold: an
+`AGENTS.md` single-source with a generated `.github/copilot-instructions.md`
+mirror, a validator script (conventionally `tools/Validate-AgentFiles.ps1`), a
+relative-link checker (conventionally `tools/Test-AgentFileLinks.ps1`), and a CI
+workflow (conventionally `.github/workflows/agent-files.yml`) running markdownlint
+plus an offline lychee link check. A consuming repo wires the exact paths in its
+overlay.
+
+## 1. AGENTS.md / `.github/copilot-instructions.md`
+
+- The mirror is generated. **Never edit `.github/copilot-instructions.md` by hand.**
+  Edits go in `AGENTS.md`, then regenerate the mirror with the validator's
+  fix mode.
+- Run the validator after any `AGENTS.md` edit. The agent-files CI workflow
+  enforces this; out-of-sync mirrors fail CI.
+- **Relative Markdown links must work in both `AGENTS.md` and the mirror.** The
+  generator rewrites them automatically (`.github/x` → `x`, other paths get
+  `../` prepended). Don't pre-rewrite links by hand. Don't add absolute
+  filesystem paths or `./` prefixes that would defeat the regex.
+- Don't use end-of-line comments in `AGENTS.md` examples or anywhere else; the
+  file itself bans the pattern. Same applies to YAML examples in the README
+  files for `.github/agents/`, `.github/prompts/`, etc. - put `# comment`
+  lines above the field, not after it.
+- Watch for placeholder syntax in code examples (e.g.
+  `<see langword=".."/>`). Use a recognizable ellipsis (`"..."`) or a real
+  example value.
+- Run a grammar pass: singular vs. plural ("extension methods"),
+  "for your needs" not "for your need", etc.
+
+## 2. Per-file frontmatter and naming
+
+The frontmatter and naming rules for each file type - `*.instructions.md`,
+`*.agent.md`, `SKILL.md`, and `*.prompt.md` - live in
+[frontmatter.md](frontmatter.md). Check the entry for the file type you touched.
+
+## 3. Validator and workflow
+
+- The frontmatter parser in the validator script is typically hand-rolled. A
+  hand-rolled parser supports flat scalars, inline lists, and block lists, but
+  **not** nested mappings, multi-line strings, anchors, or flow mappings. If a
+  contributor needs those, switch to a real YAML module (e.g.
+  `powershell-yaml`) rather than extending the regex.
+- The mirror generator preserves `AGENTS.md`'s on-disk line endings (LF or
+  CRLF) so `core.autocrlf=true` doesn't cause spurious diffs on Windows
+  checkouts.
+- The markdownlint config typically disables MD013 (line-length), MD022/MD032
+  (blanks-around), MD033 (inline HTML), MD041 (first-line heading), and keeps
+  MD040 (fenced-code-language), no-trailing-spaces, no-hard-tabs. Don't disable
+  MD040 - adding a `text` language tag is trivial and prevents drift.
+- The CI job typically runs on `ubuntu-latest`. PowerShell is preinstalled
+  there; no `pip` step is needed.
+- A commons repository should validate source `skills/*/SKILL.md`, not only a
+  consumer's `.agents/skills/` directory. Treat a conditional that silently
+  skips a populated source tree as a broken gate.
+- Validate agent frontmatter, plugin/marketplace/MCP manifests, relationship
+  names, and generated catalogs in addition to skill frontmatter. Then install
+  each core alone (plus declared `requires`) and resolve links inside that
+  artifact; a repo-wide link check cannot catch undeclared sibling dependencies.
+
+## 4. Relative Markdown links must resolve in this branch
+
+The CI link check is **offline lychee** - it only follows links that
+resolve to files in the current working tree. A link to a file that exists
+on the canonical repo's `main` but not in your branch will fail.
+
+- **Before opening a PR with agent-file changes, run the link checker.**
+  Without arguments, it scans every Markdown file in CI's lychee scope and
+  reports any relative link whose target doesn't exist on disk. It typically
+  auto-detects the PR base ref: `upstream/main` if a remote literally named
+  `upstream` exists (the fork-PR workflow, where `origin` is your fork and
+  `upstream` is the canonical repo), `origin/main` otherwise (working directly
+  on a clone of the canonical repo). A changed-only mode and an explicit
+  base-ref override are the usual options.
+- **If you cite files added by a different in-flight or just-merged PR,
+  rebase your branch on the canonical `main`** (`upstream/main` from a
+  fork, or `origin/main` from a direct clone) so those files exist
+  locally. A recurring review-round loss comes from exactly this scenario:
+  the branch predated a sister PR that added the referenced source files,
+  so every cross-reference to them failed lychee even though those files
+  existed on the canonical `main`.
+- The lychee check runs against the merged tree on `main` only after a
+  push, so a stale branch can still ship broken links into your PR. Treat
+  rebase-then-link-audit as a single step before pushing any agent-file
+  change that references code added elsewhere.
+- Don't downgrade a real link to backticks just to silence the checker.
+  Either fix the link or rebase. Backtick references work as a last resort
+  when the file truly does not exist in any branch yet.
+
+## 5. Whitespace (applies to every file in scope)
+
+- No trailing whitespace.
+- No whitespace-only lines (a "blank" line must be truly empty).
+- Tabs are forbidden in Markdown bodies.
+- **Files must end with a single newline character** (markdownlint MD047).
+  The validator flags a *missing* trailing newline (it checks the file ends
+  with `\n`, not that there is exactly one); markdownlint enforces the full
+  single-newline rule in CI. New files
+  created via the standard editor tooling get this for free, but
+  hand-edited or copy-pasted content sometimes loses the final `\n`.
+- These rules are enforced both by the validator and by markdownlint.
+
+## How to run the checks locally
+
+**Always run the validator before declaring a review complete or pushing
+agent-file changes.** It catches mirror drift, missing/invalid frontmatter,
+`SKILL.md` naming mistakes, missing trailing newlines, and trailing/empty-line
+whitespace - the same rules CI enforces. Run it in plain mode to validate, and
+in fix mode (`-Fix`) to regenerate the mirror after editing `AGENTS.md`.
+
+The validator does **not** reproduce markdownlint's full rule set. After it
+passes, sanity-check that your Markdown:
+
+- ends with exactly one newline (MD047);
+- has a language tag on every fenced code block, e.g. \`\`\`text or \`\`\`yaml
+  (MD040);
+- doesn't use tabs (no-hard-tabs).
+
+If CI fails after a local validator pass, the failure is almost always
+markdownlint (open the failing job's annotations) or the lychee link check
+(broken relative link - remember the mirror rewrites links, so test
+the form in `AGENTS.md`, not the rewritten copy).
+
+For a commons portfolio, use strict mode and check generated collateral:
+
+```pwsh
+./skills/manage-skills/scripts/Validate-Skills.ps1 ./skills -RequirePortfolioMetadata
+./tools/Update-SkillCatalog.ps1
+Invoke-Pester ./tests
+```

--- a/.agents/skills/agent-files-review/frontmatter.md
+++ b/.agents/skills/agent-files-review/frontmatter.md
@@ -1,0 +1,62 @@
+# Agent-file frontmatter and naming
+
+Per-file-type frontmatter and naming rules for the `agent-files-review`
+checklist. Check the entry for the file type you changed; the operational
+workflow (mirror, links, validator, whitespace) stays in [SKILL.md](SKILL.md).
+
+## `*.instructions.md` (path-specific instructions)
+
+- Frontmatter must include a non-empty `applyTo` glob.
+- Glob is comma-separated, relative to repo root. Quote the value for safety.
+- The validator only checks `applyTo`'s presence and emptiness; it does not
+  verify that the glob actually matches anything. Sanity-check by eye.
+
+## `*.agent.md` (custom agents)
+
+- Frontmatter must include `description`.
+- If `tools` is present, it must be a YAML list. Either form is accepted by
+  the validator:
+
+  ```yaml
+  tools: ['search', 'edit']
+  ```
+
+  ```yaml
+  tools:
+    - search
+    - edit
+  ```
+
+- Use VS Code's current tool names: bare tool-set names (`search`, `read`,
+  `edit`, `web`) or namespaced `<set>/<tool>` members (`read/problems`,
+  `web/fetch`, `search/usages`, `search/changes`). The legacy flat names
+  (`usages`, `problems`, `changes`, `fetch`) still resolve but raise an
+  info-level "renamed" notice in VS Code, so prefer the current form. A bare
+  tool-set name already includes its members (e.g. `search` covers
+  `search/usages` and `search/changes`).
+- The repo's authoring rules forbid end-of-line comments; document optional
+  fields with comment lines *above* them in any examples.
+
+## `SKILL.md` (`.agents/skills/<name>/SKILL.md`)
+
+- `name` is **required** and must:
+  - be 1-64 chars of lowercase letters/digits (Unicode allowed) and hyphens,
+    with no leading, trailing, or consecutive hyphen
+  - equal the parent directory name exactly
+- `description` is required; make it specific enough that another agent
+  can decide when to load it.
+- Shared portfolio cores also require string-valued `metadata.portability`,
+  `metadata.applicability`, `metadata.binding`, `metadata.risk`,
+  `metadata.maturity`, `metadata.requires`, and `metadata.related`. Use the
+  repository's `FORMAT.md` vocabulary; relationship names must resolve and the
+  required graph must remain acyclic.
+- For `optional-overlay` or `required-overlay`, keep the standard loader sentence
+  in the core. An `overlay.md` starts with `core` and `core-pin`; `core` matches
+  the directory, and a required overlay must exist.
+- A name/dir mismatch causes the skill to silently fail to load. Always
+  verify by running both the strict bundled validator and `skills-ref`.
+
+## `*.prompt.md` (reusable prompts)
+
+- No required frontmatter, but `description` is recommended for the slash
+  menu UX.

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,0 +1,49 @@
+---
+core: agent-files-review
+core-pin: v0.10.0
+---
+
+# madowaku overlay - agent-files-review
+
+Repository-specific companion to the vendored [agent-files-review](SKILL.md)
+skill. The `SKILL.md` and its `frontmatter.md` page are a **pinned copy of the
+portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku scaffold paths
+
+- **The validator is**
+  [tools/Validate-AgentFiles.ps1](../../../tools/Validate-AgentFiles.ps1). Run it
+  plain to check frontmatter, whitespace, and the mirror; run it with `-Fix` to
+  regenerate the [.github/copilot-instructions.md](../../../.github/copilot-instructions.md)
+  mirror from [AGENTS.md](../../../AGENTS.md).
+- **`AGENTS.md` is the single source of truth**; the copilot-instructions mirror
+  is generated and must never be hand-edited.
+- **Scanned locations**: [.github/instructions/](../../../.github/instructions/),
+  [.github/prompts/](../../../.github/prompts/),
+  [.github/agents/](../../../.github/agents/), and
+  [.agents/](../../), plus [docs/agent-customization.md](../../../docs/agent-customization.md).
+- **CI**:
+  [.github/workflows/agent-files.yml](../../../.github/workflows/agent-files.yml)
+  runs the validator, a 90-day skill-freshness warning, markdownlint
+  ([.markdownlint.jsonc](../../../.markdownlint.jsonc)), and an offline lychee
+  link check on `ubuntu-latest`.
+- **SKILL names** must match `^[a-z0-9-]{1,64}$` and equal the parent directory.
+  The vendored [frontmatter reference](frontmatter.md) describes a broader
+  portable rule; madowaku enforces this stricter ASCII form.
+
+## Cross-references
+
+- [`manage-skills`](../manage-skills/SKILL.md) - the lifecycle skill for adding,
+  vendoring, and updating skills (distinct from this file-syntax review).
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - its final audit runs
+  the link and validator checks before a PR.
+
+## Updating
+
+Pull upstream changes with `gh skill update agent-files-review` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/code-comprehension/SKILL.md
+++ b/.agents/skills/code-comprehension/SKILL.md
@@ -1,0 +1,90 @@
+---
+description: Evidence-based readability and cognitive-load review of code. Use when asked to "review this for readability", "is this too complex", "reduce nesting or cognitive load", "what is a reasonable method length / parameter count / nesting depth", or when judging whether code will be hard to understand. Screens code against research-backed thresholds and prioritizes the factors that actually drive comprehension - naming first, then structure that loads working memory.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/code-comprehension
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: d2e1be7b63a31345f054a1d0785a67d5ba2aa604
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review
+    requires: none
+    risk: advisory
+name: code-comprehension
+---
+
+# Code comprehension review
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+A research-backed screen for how hard code is to *understand* (not how hard it is
+to test). Four decades of studies - including recent eye-tracking, EEG, and fMRI
+work - converge on a few high-confidence rules. Lead with those; treat the
+threshold numbers as **screening heuristics, not hard limits**, and let a
+consuming repo's own style guide or `.editorconfig` win on any conflict.
+
+## The high-confidence rules (apply these first)
+
+1. **Naming is the #1 factor.** Across 40 years of studies, identifier quality
+   beats every structural metric. **Misleading names are worse than meaningless
+   ones.** Fix misleading or cryptic names before touching anything else; prefer
+   full words over abbreviations.
+2. **Cognitive load comes from working memory, not path count.** Deep nesting,
+   long parameter lists, and dense data-flow (many live variables a reader must
+   track) strain comprehension. McCabe's cyclomatic complexity is a weak proxy
+   for human effort - use it for testing, not readability.
+3. **Indentation and layout matter a lot.** Consistent indentation roughly
+   *halves* reading time versus unindented control flow; blank lines between
+   logical chunks help.
+4. **Complexity perception saturates.** Past a point (around cognitive complexity
+   15) more complexity barely changes perceived difficulty - so spend effort
+   *avoiding the extremes*, not micro-optimizing already-simple code.
+5. **Small reviews work.** Review effectiveness drops faster than linearly with
+   size; keep a change under roughly 200 lines so a reviewer can read it linearly.
+
+## Screening thresholds
+
+Flag for review at "Review", refactor at "Refactor". Values between "Low" and "Review" are "moderate" — usually acceptable, but worth a quick "why" check.
+Numbers aggregate research and industry-tool convergence; adjust to the team and language.
+
+| Factor | Low | Review | Refactor | Measure |
+| --- | --- | --- | --- | --- |
+| Nesting depth | 1-2 | 4-5 | >=6 | max nested control blocks |
+| Cognitive complexity (Sonar) | <=5 | 11-15 | >=16 | rule-based, penalizes nesting |
+| Method length | <=20 | 51-100 | >100 | SLOC (no blanks/comments) |
+| Parameter count | <=3 | 6-8 | >=9 | params per method |
+| Boolean terms in an expression | <=2 | 5-6 | >=7 | operands / sub-expressions |
+| Line length | <=80 | 101-120 | >=121 | columns |
+| Data-flow (DepDegree) | few | many | dense, long-range | live def-use links |
+| Coupling (CBO) | <=5 | 10-14 | >=15 | classes a class depends on |
+| Cohesion (LCOM4) | 1 | 3-4 | >=5 | connected components in a class |
+
+Cyclomatic complexity (McCabe) <=10 is the universal *testing* threshold - keep
+it, but don't use it to argue about readability.
+
+## Review priority order
+
+1. **Names** - scan for misleading identifiers first, then cryptic abbreviations;
+   ensure consistent vocabulary.
+2. **Working-memory load** - nesting depth, parameter count, and data-flow
+   (variable lifespans, cross-branch sharing). Extract methods, introduce
+   well-named temporaries, or use a parameter object.
+3. **Size** - over-long methods and over-large changesets; decompose.
+4. **Layout** - consistent indentation, blank lines between chunks, line length.
+5. **Stop at the extremes** - don't churn already-simple code to shave a metric.
+
+Tailor to the audience: novices are hit hardest by nesting, recursion, and poor
+names; default a mixed team to the novice-friendly choice.
+
+## Evidence
+
+The factor-by-factor research, the metric glossary, industry-tool thresholds, and
+the full citation list are in [references/research.md](references/research.md).
+The threshold numbers above are screening heuristics drawn from that evidence; the
+high-confidence rules at the top are the parts to rely on. A consuming repository
+binds its own style guide and any house thresholds in its overlay.

--- a/.agents/skills/code-comprehension/overlay.md
+++ b/.agents/skills/code-comprehension/overlay.md
@@ -1,0 +1,37 @@
+---
+core: code-comprehension
+core-pin: v0.10.0
+---
+
+# madowaku overlay - code-comprehension
+
+Repository-specific companion to the vendored [code-comprehension](SKILL.md)
+skill. The `SKILL.md` and its bundled `references/research.md` are a **pinned
+copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **Local style is [AGENTS.md](../../../AGENTS.md)** and the path-specific
+  [.github/instructions/](../../../.github/instructions/) rules. Judge
+  readability against those conventions (explicit types, no `var`, indented XML
+  docs, no end-of-line comments) rather than generic defaults.
+- **Interop density is expected.** Pointer-heavy, `unsafe`, multi-targeted code
+  is inherent here; weigh cognitive load against the interop patterns in
+  [`cswin32-com`](../cswin32-com/SKILL.md) and
+  [`cswin32-interop`](../cswin32-interop/SKILL.md), not against idiomatic managed
+  code.
+
+## Cross-references
+
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - where a readability
+  concern turns into a pre-PR action.
+
+## Updating
+
+Pull upstream changes with `gh skill update code-comprehension` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/code-comprehension/references/research.md
+++ b/.agents/skills/code-comprehension/references/research.md
@@ -1,0 +1,131 @@
+# Code comprehension - the evidence
+
+Backing detail for the [code-comprehension](../SKILL.md) skill: the factor-by-factor
+research, the metric glossary, industry-tool thresholds, and the citation list.
+The skill core distills the high-confidence parts; this page is the evidence and
+the lower-confidence frontier, so you can judge how hard to lean on any one number.
+
+> **How to read the thresholds.** They are *screening heuristics* aggregated from
+> empirical studies and widely used industry tools, not hard limits. Several
+> factors (naming, expression clarity, recursion style) are categorical, so their
+> "ranges" describe typical states, not numeric cut-offs.
+
+## Threshold table
+
+| Factor | Low | Moderate | High | Very high | Metric |
+| --- | --- | --- | --- | --- | --- |
+| Nesting depth | 1-2 | 3 | 4-5 | >=6 | max nested control blocks |
+| Cyclomatic complexity (McCabe) | <=5 | 6-10 | 11-20 | >=21 | independent paths (testing proxy) |
+| Cognitive complexity (Sonar) | <=5 | 6-10 | 11-15 | >=16 | rule-based understandability |
+| Method length | <=20 | 21-50 | 51-100 | >100 | SLOC, no blanks/comments |
+| Parameter count | <=3 | 4-5 | 6-8 | >=9 | params per method |
+| Line length | <=80 | 81-100 | 101-120 | >=121 | columns |
+| Identifier naming | descriptive, consistent | short / abbreviations | single letters in locals | misleading / inconsistent | qualitative |
+| Boolean / expression terms | <=2 | 3-4 | 5-6 | >=7 | operands / sub-expressions |
+| Recursion | tail / simple | single + obvious base case | mutual / non-obvious termination | deep, intertwined | presence and depth |
+| Data-flow (DepDegree) | few def-use links | moderate | many interdependent vars | dense, long-range | live def-use edges |
+| Layout / whitespace | consistent indent, blank lines | minor inconsistency | irregular indent, dense | no indent / hard wraps | indent consistency |
+| Coupling (CBO) | <=5 | 6-9 | 10-14 | >=15 | classes a class depends on |
+| Cohesion (LCOM4) | 1 | 2 | 3-4 | >=5 | connected components in a class |
+| Inheritance depth (DIT) | <=2 | 3-4 | 5-6 | >=7 | depth of inheritance tree |
+
+## Metric glossary
+
+- **Cyclomatic complexity (McCabe).** Independent paths through a method (decision
+  points plus one). Useful for *testing* effort; a weak proxy for human
+  comprehension - a 2023 neuroscience study (222 developers) confirmed poor
+  correlation with measured cognitive load.
+- **Cognitive complexity (Sonar).** Rule-based score built to mirror human
+  understandability: adds for flow breaks, adds *extra* for nesting, ignores
+  structures perceived as simple. Validated to correlate with comprehension time.
+- **DepDegree (data-flow).** Counts definition-use edges - how many variable
+  relationships a reader must track. Relates to brain-measured load more strongly
+  than control-flow-only metrics.
+- **Coupling Between Objects (CBO).** Classes a class depends on directly; high
+  values track with defect density and comprehension difficulty.
+- **Lack of Cohesion of Methods (LCOM4).** Connected components in a class's
+  method graph; 1 = single responsibility, higher = split candidate.
+
+## Factor details (what / why / guardrail)
+
+1. **Nesting depth and indentation.** Each level adds a simultaneously-active
+   condition; indentation is the visual scaffold. Indented code is read materially
+   faster (RCTs find unindented control flow roughly doubles reading time). Prefer
+   <=2-3 levels; refactor >=4 by extracting methods or flattening.
+2. **Cyclomatic vs cognitive complexity.** McCabe for testing; cognitive
+   complexity for readability (its nesting penalty is the point). Keep methods at
+   <=10 cognitive where feasible.
+3. **Method length.** Larger units combine more decisions, names, and data-flow.
+   Aim <=20 SLOC, review at 50+, refactor above 100.
+4. **Parameter count.** Parameters are vocabulary a reader holds in mind; count
+   correlates with working-memory brain activation. Prefer <=3; 4-5 = "explain
+   why"; 6+ = parameter object.
+5. **Line length and whitespace.** Long lines reduce scan anchors. <=100 columns
+   for code (<=80 for prose); add blank lines between logical chunks.
+6. **Identifier naming.** The primary carrier of meaning and the #1 factor in a
+   40-year review (named in 16 studies, ahead of every complexity metric).
+   Full-word names sped professionals ~19% in one study; misleading names are
+   worse than meaningless. Rename misleading identifiers first.
+7. **Expression complexity and explaining variables.** For experts, flat vs nested
+   boolean forms are often equivalent; well-named intermediate variables help when
+   an expression is genuinely hard. Prefer <=4 boolean terms; avoid long fluent
+   chains without breaks.
+8. **Recursion.** Readers must simulate the call stack and termination. Prefer
+   tail/simple recursion; make the base case and state explicit; consider an
+   iterative form when depth or state is non-obvious.
+9. **Data-flow dependencies.** Interleaved definitions and uses force
+   back-referencing. Keep variable lifespans short; reduce cross-branch sharing;
+   one purpose per variable per block.
+10. **Regularity / repetition.** Readers invest most in the first occurrence of a
+    pattern; later repeats cost less. Prefer consistent idioms; avoid needless
+    irregularity.
+11. **Coupling and cohesion.** Keep CBO <=9; LCOM4 = 1 ideal, refactor at >=3.
+    High coupling and low cohesion both track with maintenance and comprehension
+    problems.
+
+## Industry-tool convergence
+
+- Cyclomatic complexity: **10** (near-universal).
+- Method length: **~25 lines** (tools vary 20-30).
+- Parameter count: **4**.
+- Nesting depth: **4** (SonarQube, ESLint).
+- File length: **250-500 lines** (wide variation).
+
+Defaults by tool: SonarQube (cognitive 15, method 50), CodeClimate (method
+complexity 5, file 250), ESLint (complexity 20, max-depth 4), Visual Studio
+maintainability index (green 20-100, red 0-9).
+
+## Process factors (well-supported)
+
+- **Review size.** Effectiveness drops faster than linearly with changeset size;
+  under ~200 lines enables linear reading. Tool-assisted review yields about 2x
+  the accepted comments of over-the-shoulder review.
+- **Audience.** Novices are hit hardest by nesting, recursion, and weak names and
+  benefit most from consistent indentation; default mixed teams to the
+  novice-friendly choice.
+
+## Frontier (interesting, lower confidence)
+
+Treat these as directional, not as guardrails - small samples, single studies, or
+hard-to-reproduce instrumentation:
+
+- **Physiological measures.** Eye-tracking shows non-linear read patterns; EEG
+  theta rises and alpha falls with effort; fNIRS detects prefrontal load. Reported
+  accuracies (e.g. ~89% load detection, ~97% expertise prediction) come from small
+  lab studies.
+- **Paradigm effects.** Reported comprehension deltas - reactive vs OOP (~15-25%),
+  async/await debugging (~30%), static vs dynamic typing trade-offs - are single
+  studies with modest cohorts.
+- **ML smell detection.** Transformer models report 90%+ precision but 50-60%
+  recall; many flagged issues are never refactored (the actionability gap).
+
+## Citations
+
+The claims above trace to (among others): Sonar Cognitive Complexity whitepaper;
+Munoz Baron et al. 2020 (cognitive-complexity meta-analysis); Peitek et al. 2021
+(fMRI); Beyer et al. 2014 (DepDegree); Hofmeister et al. 2017 and Avidan &
+Feitelson 2017 (naming); the 40-year naming review (2022); Hanenberg et al. 2024
+and Miara et al. 1983 (indentation); Buse & Weimer 2010 (readability model);
+Jbara & Feitelson 2017 (regularity); Stoeckert et al. 2024 (recursion); and ICPC
+2025 review-strategy work. Each entry is searchable by author and year for the
+full source.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,210 @@
+---
+compatibility: Requires git; remote creation uses an available GitHub integration or authenticated gh, with a browser fallback.
+description: Create a pull request for the current changes. Use when asked to "make a PR", "open a pull request", "push and PR", or otherwise publish in-progress work for review. Ensures changes are on a non-`main` branch, commits are made and pushed, and the PR targets `upstream/main` when an `upstream` remote exists, otherwise `origin/main`.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/create-pr
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: dcdd58e7cad32b4907ce6a8bf0fe6bf01cb14f59
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review, address-pr-feedback
+    requires: none
+    risk: remote-write
+name: create-pr
+---
+
+# Create a pull request
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Follow these steps in order. Stop and ask the user if any check is ambiguous;
+do not force-push, rewrite history, or delete branches without explicit
+confirmation.
+
+**Approval scope.** A request to "open / make / create a PR" authorizes the
+*work* of preparing one. It does **not** authorize the commit or the push.
+The **Approval checkpoint** inside step 3 (Commit changes) is the gate:
+staging happens before it, `git commit` and everything after happen only
+once the user supplies an explicit publishing verb - `commit`, `push`,
+`ship it`, or equivalent. See your repo's agent guidance (the "Working with
+the user on changes" rules in `AGENTS.md`) for the canonical rule and the
+recurring not-approval phrasings.
+
+Before running this workflow, walk through the `pre-pr-self-review` checklist -
+it catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
+that repeatedly cost a review round-trip. If the change polyfills a .NET API for
+.NET Framework, a `polyfill-dotnet-api` skill (where the repo provides one)
+defines the design rules the self-review then validates against.
+
+## 1. Inspect repository state
+
+Run these (read-only) checks first:
+
+- `git remote -v` - determine whether an `upstream` remote exists.
+- `git rev-parse --abbrev-ref HEAD` - current branch name.
+- `git status --porcelain` - uncommitted changes.
+- `git log --oneline @{u}.. 2>$null` (if upstream is set) - unpushed commits.
+
+Decide the PR base:
+
+- If a remote literally named `upstream` exists, the PR base is
+  `upstream/main` (i.e. `--repo` points at the upstream repo, base branch
+  `main`).
+- Otherwise the PR base is `origin/main` (the fork itself, base `main`).
+
+## 2. Ensure work is on a feature branch
+
+- If the current branch is `main`, **do not commit on `main`**. Create a new
+  branch from the current `HEAD` with a short, descriptive, kebab-case name
+  derived from the change (e.g. `fix-span-enumerate-lines`,
+  `add-create-pr-skill`).
+- Confirm the branch name with an available structured-question capability
+  before creating it. Offer the suggested kebab-case name and a way to enter a
+  different name. If the host has no structured question tool, ask in chat.
+  Known client adapters are in [host-adapters.md](host-adapters.md).
+- Use `git switch -c <branch>` to move uncommitted changes onto the new
+  branch.
+- If already on a non-`main` branch, keep using it.
+
+## 3. Commit changes
+
+- If `git status` shows uncommitted changes that belong in the PR, stage them
+  with `git add` (prefer explicit paths over `git add -A` unless the user
+  asked for everything).
+- Write a concise commit message: short imperative subject (≤ 72 chars), and
+  a body only if the change needs explanation. Match the style of recent
+  commits (`git log --oneline -20`).
+- Do not amend or rebase published commits without explicit user approval.
+- Do not pass `--no-verify`; let hooks run.
+
+### Approval checkpoint
+
+**Stop here.** Show the user the staged diff (or summarize it) and the
+proposed commit message. Wait for the user to explicitly say `commit`,
+`push`, or `ship it` (or one of the other verbs listed in your repo's
+agent guidance "Working with the user on changes" rules) before running
+`git commit`. If the user already used one of those verbs in the message
+that triggered this skill, proceed without asking again. Do not infer
+approval from the original "open a PR" request.
+
+## 4. Push the branch
+
+### Pre-push conflict check
+
+Before pushing (or re-pushing), confirm the branch still merges cleanly into
+its base (`<base>` = `origin/main`, or `upstream/main` when that remote exists)
+so conflicts surface locally instead of on the PR:
+
+- `git fetch <remote> main`, then `git rev-list --left-right --count <base>...HEAD`.
+  Left count `0` means up to date - skip to push.
+- If behind, dry-run the merge without touching the tree:
+
+  ```pwsh
+  git merge-tree $(git merge-base HEAD <base>) HEAD <base> | Select-String 'CONFLICT|<<<<<<<'
+  ```
+
+- **Clean:** prefer rebasing onto `<base>` so the PR diff is current.
+- **Conflicts:** rebase (`git rebase <base>`, `$env:GIT_EDITOR='true'`), resolve,
+  `git add` by path, `git rebase --continue`, then re-run the build and the
+  test suite in Release (base may have moved/renamed code you depend on).
+- A rebase rewrites commits, so the next push needs `--force-with-lease` - a
+  force-push that **requires explicit user approval** per the publish-boundary rule.
+
+### Push
+
+- Fresh branch (no rebase): `git push -u origin <branch>`.
+- After rebasing an already-pushed branch (explicit approval only):
+  `git push --force-with-lease origin <branch>`.
+- Never `git push --force` or `--force-with-lease` without explicit user
+  confirmation.
+
+## 5. Open the PR
+
+**Prefer an available GitHub integration** that can create a pull request and
+return its number/URL. Fall back to the GitHub CLI (`gh`) when no integration is
+available, and only fall back to a browser compare URL if neither is available.
+Known client adapters are in [host-adapters.md](host-adapters.md).
+
+Determine the target with the rule from step 1.
+
+### Option A - GitHub integration (preferred)
+
+Call the host's pull-request creation capability with:
+
+- `title`, `body` (see PR title/body guidance below),
+- `head` = the feature branch name (no owner prefix),
+- `base` = `main`,
+- For an upstream-targeted PR, set `repo` to `{ owner: <upstreamOwner>, name: <repo> }` and `headOwner` to the fork owner.
+- For an origin-only PR, omit `repo` and `headOwner` (they default correctly).
+
+### Option B - GitHub CLI fallback
+
+- **Upstream exists**:
+
+  ```pwsh
+  gh pr create --repo <upstreamOwner>/<repo> --base main --head <forkOwner>:<branch> --title "<title>" --body "<body>"
+  ```
+
+- **No upstream**:
+
+  ```pwsh
+  gh pr create --base main --head <branch> --title "<title>" --body "<body>"
+  ```
+
+### PR title and body
+
+- Title: same style as the commit subject; reference the area touched.
+- Body: brief summary of what changed and why, bullet list of notable
+  changes, and any test/validation notes (e.g. "ran the test suite"). Link
+  related issues with `Fixes #N` when appropriate.
+- If the user has not supplied a title/body, propose one and confirm before
+  creating.
+
+### Option C - Browser fallback
+
+If neither the VS Code tool nor `gh` is available, print the compare URL:
+
+- Upstream: `https://github.com/<upstreamOwner>/<repo>/compare/main...<forkOwner>:<branch>?expand=1`
+- Origin only: `https://github.com/<originOwner>/<repo>/compare/main...<branch>?expand=1`
+
+## 6. Report back
+
+Tell the user:
+
+- The branch name and where it was pushed.
+- The base the PR targets (`upstream/main` or `origin/main`).
+- The PR URL (from `gh pr create` output) or the compare URL fallback.
+
+## 7. Watch for an automated reviewer
+
+Some repos auto-review PRs (e.g. GitHub Copilot), posting a review a minute or
+two after the PR opens or after each push; others let you request one.
+
+- Tell the user a review may land shortly; offer to fetch and investigate it
+  when it does. Don't poll - act when the user reports comments, or check once.
+- If nothing auto-reviews, offer to request a reviewer - a remote action, only
+  with the user's go-ahead.
+
+Opening the PR ends this skill. Handling whatever the reviewer posts - resolving
+threads, re-requesting review - is the `address-pr-feedback` workflow, under the
+same commit/push publish gate.
+
+## Guardrails
+
+- Never commit directly to `main`, even if the user is currently on it -
+  always branch first.
+- Never delete branches, force-push, or rewrite history as part of this
+  workflow.
+- If the working tree has unrelated changes, ask the user which files belong
+  in the PR before staging.
+
+## Host adapters
+
+- [host-adapters.md](host-adapters.md) - exact structured-question and GitHub
+  integration names for tested clients, plus the host-neutral fallbacks.

--- a/.agents/skills/create-pr/host-adapters.md
+++ b/.agents/skills/create-pr/host-adapters.md
@@ -1,0 +1,25 @@
+# Create-PR host adapters
+
+The [create-pr core](SKILL.md) is capability-based. Use this page only to map
+those capabilities to exact client tool names; the workflow and approval gates
+remain in the core.
+
+## GitHub Copilot in VS Code
+
+- Structured question: `vscode_askQuestions`. Supply two options - the suggested
+  branch name and `Use a different name` - and leave free-form input enabled.
+- Pull-request creation: `github-pull-request_create_pull_request`. Supply
+  `title`, `body`, `head`, and `base`. For an upstream-targeted PR, also supply
+  the upstream `repo` and the fork `headOwner`.
+
+## GitHub Copilot CLI
+
+The CLI has no built-in pull-request creation capability in the portable tool
+set. Ask the branch-name question in chat, then use authenticated `gh pr create`.
+The core contains the upstream and origin command forms.
+
+## Other Agent Skills hosts
+
+Use a host-native structured question or GitHub integration when one exists.
+Otherwise ask in chat and use `gh`. If `gh` is unavailable, emit the compare URL
+from the core and stop; do not invent a host tool name or silently install one.

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,0 +1,47 @@
+---
+core: create-pr
+core-pin: v0.10.0
+---
+
+# madowaku overlay - create-pr
+
+Repository-specific companion to the vendored [create-pr](SKILL.md) skill. The
+`SKILL.md` and its `host-adapters.md` page are a **pinned copy of the portable
+core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku publish boundary
+
+- **The approval rule the core points at is**
+  [AGENTS.md - Working with the user on changes](../../../AGENTS.md#working-with-the-user-on-changes),
+  the canonical source of the commit/push publish boundary and the phrasings that
+  are *not* approval ("open a PR", "address the review", "fix the CI failure",
+  a bare "go ahead").
+- **Never `git commit`, `git push`, or open a PR without an explicit publishing
+  verb in the user's most recent message.** Selecting a task is not authorizing
+  its publish.
+- **Mechanical backstop**:
+  [.vscode/settings.json](../../../.vscode/settings.json) denies `git commit`,
+  `git push`, and `gh pr create|merge|close|edit` in agent mode (each needs an
+  explicit Allow), and `main` is branch-protected. Treat these as backstops, not
+  a license to skip the conversation.
+- **`origin/main` is the target**; madowaku is the canonical repo.
+
+## Cross-references
+
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - the checklist to walk
+  before running this workflow.
+- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - the post-PR workflow
+  for subsequent edit rounds.
+- [`publish-release`](../publish-release/SKILL.md) - the separate,
+  madowaku-specific flow for cutting a `KlutzyNinja.Madowaku` release tag (not a
+  PR).
+
+## Updating
+
+Pull upstream changes with `gh skill update create-pr` (review the diff, re-pin
+`core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cswin32-com
-description: 'Guides struct-based COM interop in madowaku using CsWin32 patterns. Consult when working with ComScope<T>, IComIID, IID.Get<T>(), delegate* unmanaged vtables, CoCreateInstance / CoGetClassObject, the per-struct IComIID net472 polyfill, or manually defining COM interfaces not in Win32 metadata (e.g. CLR hosting ICLRMetaHost, ICLRRuntimeInfo).'
+description: 'Guides struct-based COM interop in madowaku using CsWin32 patterns. Consult when working with ComScope, IComIID, IID.Get, delegate* unmanaged vtables, CoCreateInstance / CoGetClassObject, the per-struct IComIID net472 polyfill, or manually defining COM interfaces not in Win32 metadata (e.g. CLR hosting ICLRMetaHost, ICLRRuntimeInfo).'
 argument-hint: 'Describe the COM interface or activation pattern you are working with.'
 ---
 

--- a/.agents/skills/dotnet-polyfills/SKILL.md
+++ b/.agents/skills/dotnet-polyfills/SKILL.md
@@ -1,0 +1,207 @@
+---
+compatibility: Requires the .NET SDK, package restore access, and a project targeting .NET Framework alongside modern .NET.
+description: Set up and use the standard .NET downlevel polyfill stack so a multi-targeted library can call modern BCL APIs on .NET Framework - PolySharp for compiler and language attributes, the official Microsoft downlevel NuGet packages (System.Memory, Microsoft.Bcl.Memory, Microsoft.Bcl.HashCode, Microsoft.IO.Redist, and the other Microsoft.Bcl.* / System.* backports), and the KlutzyNinja.Touki package's runtime polyfills layered on top. Use when adding a downlevel net472 / net481 target, choosing which package supplies a missing type before hand-rolling, configuring PolySharp, or checking whether an API is already polyfilled. For authoring a new hand-rolled polyfill inside a repo's own Framework tree, see polyfill-dotnet-api.
+license: MIT
+metadata:
+    applicability: dotnet-framework
+    binding: optional-overlay
+    github-path: skills/dotnet-polyfills
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: ae0aa41d3c5c002298172ba4e5f7b24eb615d9db
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review, framework-jit-optimization
+    requires: none
+    risk: local-write
+name: dotnet-polyfills
+---
+
+# .NET downlevel polyfills
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+The package-and-generator stack that lets a multi-targeted library call modern
+BCL APIs (`Span<T>`, `Index` / `Range`, `HashCode`, the C# language attributes,
+...) on **.NET Framework** (net472 / net481) without hand-writing a shim for
+each one. Most "this type doesn't exist downlevel" gaps are closed by adding the
+right package or source generator - reach for those before writing any polyfill
+of your own.
+
+## The decision order
+
+Work top to bottom and **stop at the first hit**. Never hand-roll something a
+package or generator already ships.
+
+1. **Probe first** - the member may already compile downlevel via a package you
+   already reference.
+2. **An official Microsoft package** supplies the runtime type or method.
+3. **PolySharp** supplies it, if it is a compiler / language *attribute*.
+4. **The `KlutzyNinja.Touki` package** already polyfills it, if you reference Touki.
+5. **Hand-roll** it - last resort, and a different skill (see the end).
+
+## 1. Probe before you polyfill
+
+Before adding anything, confirm the gap is real. Write a tiny `#if NETFRAMEWORK`
+snippet that calls the candidate API and build the **downlevel** target (e.g.
+`dotnet build -f net472`). If it compiles, a package you already reference
+supplies the member - delete the probe and move on. This catches the common case
+where `System.Memory` (or a transitive dependency) already covers the API.
+
+## 2. Official Microsoft downlevel packages
+
+The `Microsoft.Bcl.*` and `System.*` backport packages cover most runtime gaps -
+spans, `Index`/`Range`, `HashCode`, async interfaces, `TimeProvider`, modern
+`System.IO`, and more. The full catalog (package -> what it covers) is in
+[references/packages.md](references/packages.md).
+
+Two rules when adding one:
+
+- **Reference it for the downlevel target only.** Put the `<PackageReference>`
+  inside an ItemGroup conditioned on the framework target (e.g.
+  `Condition="'$(TargetFramework)' == 'net481'"` or the project's framework-version
+  property) - never unconditional, or it ships dead weight on modern .NET.
+- **Prefer the package over a hand-roll even for one member.** A referenced
+  package is maintained, correct on edge cases, and free; a hand-rolled shim is
+  none of those.
+
+### Microsoft.IO.Redist needs a namespace alias
+
+`Microsoft.IO.Redist` is the one package with an integration wrinkle worth
+spelling out. It backports the modern (.NET Core) `System.IO` surface - the fast
+`Directory` / `File` / `Path` helpers and `EnumerationOptions`-based enumeration -
+but it places those types under the **`Microsoft.IO`** namespace so they do not
+collide with the framework's built-in `System.IO`. To facilitate interchange it
+deliberately does **not** redefine the existing non-static *exchange* types
+(`Stream`, `StreamReader` / `StreamWriter`, `TextWriter`, `FileStream`, ...) -
+those have to stay the single `System.IO` type that the rest of the framework
+passes around.
+
+So alias the *namespace* per target, and alias the exchange *types* back to
+`System.IO` unconditionally (they are the same type on both targets) - this is the
+whole integration, usually in a `GlobalUsings.cs`:
+
+```csharp
+#if NETFRAMEWORK
+global using Microsoft.IO;             // Directory, File, Path, EnumerationOptions (backported static helpers)
+global using Microsoft.IO.Enumeration; // FileSystemEnumerable<T>, FileSystemEntry, ...
+#else
+global using System.IO;
+global using System.IO.Enumeration;
+#endif
+
+// Microsoft.IO does not provide these non-static exchange types - alias them to
+// System.IO so call sites stay uniform across both targets.
+global using Stream = System.IO.Stream;
+global using StreamWriter = System.IO.StreamWriter;
+global using StringWriter = System.IO.StringWriter;
+global using TextWriter = System.IO.TextWriter;
+```
+
+Now `Directory.EnumerateFiles(...)` binds to the fast `Microsoft.IO` helper on
+.NET Framework and to `System.IO` on modern .NET, while `Stream` and the other
+exchange types resolve to the one `System.IO` definition everywhere.
+
+## 3. PolySharp for compiler and language attributes
+
+[PolySharp](https://github.com/Sergio0694/PolySharp) source-generates the
+**compiler / language attributes** that newer C# needs but .NET Framework's
+reference assemblies lack - it does **not** supply runtime types. Use it for
+`IsExternalInit` (init-only setters and records), `RequiredMemberAttribute`,
+`CompilerFeatureRequiredAttribute`, `CallerArgumentExpressionAttribute`,
+`ModuleInitializerAttribute`, `SkipLocalsInitAttribute`, and the nullable
+analysis attributes (`NotNullWhen`, `MaybeNullWhen`, `MemberNotNull`,
+`DoesNotReturn`, ...).
+
+Reference it for the downlevel target only, as an analyzer/source-generator
+(`PrivateAssets="all"`), and enable the generated surface as needed:
+
+```xml
+<PropertyGroup>
+  <PolySharpUsePublicAccessibilityForGeneratedTypes>true</PolySharpUsePublicAccessibilityForGeneratedTypes>
+  <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+</PropertyGroup>
+```
+
+Never hand-write an attribute polyfill - PolySharp generates them, and a
+hand-written copy collides with the generated one.
+
+## 4. KlutzyNinja.Touki runtime polyfills on top
+
+The [`KlutzyNinja.Touki`](https://www.nuget.org/packages/KlutzyNinja.Touki)
+package ships a layer of **runtime** polyfills *on top of* the official packages -
+the members the Microsoft backports leave out. It uses C# `extension` blocks so
+member lookup binds the real BCL member on modern .NET and the polyfill on
+net472 / net481, which means callers reach them through the `using` they already
+have. The surface includes extra `MemoryExtensions` overloads, `Convert` /
+`Encoding` / cryptography helpers, span-based string helpers, and pooled buffer
+and collection utilities.
+
+If your project references `KlutzyNinja.Touki`, **check whether it already
+provides the member before hand-rolling** - it covers a large slice of the "the
+package doesn't have this one either" gap. (Touki also re-exposes the official
+packages it builds on, so referencing Touki often removes the need to add
+`System.Memory` and friends yourself.)
+
+## 5. Hand-rolling with extension types
+
+Only when no package, no generator, and no referenced library supplies the
+member - and there is a real caller for it - do you write your own. The portable
+technique is a C# **extension block** (the C# 14 extension-members feature). The
+polyfill binds the real BCL member on modern .NET and your version on net472 /
+net481, so call sites reach it through the `using` they already have for the BCL
+type - no `#if` at the call site.
+
+Put the extension in a static class whose **namespace matches the extended type's
+namespace** (so the caller's existing `using` finds it), and compile the polyfill
+only for the downlevel target.
+
+**Extending an instance type** - add a missing instance member; the receiver
+parameter (`encoding`) is the instance:
+
+```csharp
+#if NETFRAMEWORK
+namespace System.Text;
+
+public static class EncodingPolyfills
+{
+    extension(Encoding encoding)
+    {
+        public string GetString(ReadOnlySpan<byte> bytes) { /* ... */ }
+    }
+}
+#endif
+```
+
+**Extending a static class** - the newer capability that makes most BCL polyfills
+reachable: an extension block with **no receiver parameter** adds *static* members
+to the named type, including a `static` class like `Convert` or `MemoryMarshal`
+that classic extension methods could never touch:
+
+```csharp
+#if NETFRAMEWORK
+namespace System;
+
+public static class ConvertPolyfills
+{
+    extension(Convert)   // no parameter name -> static members on the Convert type
+    {
+        public static string ToHexString(ReadOnlySpan<byte> bytes) { /* ... */ }
+    }
+}
+#endif
+```
+
+Call sites then write `Convert.ToHexString(data)` unchanged on both targets. Keep
+the polyfill scoped to the member that has a caller - "completeness" polyfills
+just grow the surface.
+
+The repo-specific authoring conventions - where the files live, the
+behavior-parity and allocation rules, and the net472 / net481 codegen gotchas
+(like the `Unsafe.As` sign-extension trap) - are a separate skill,
+**polyfill-dotnet-api**. Come here first to ask "which package or generator covers
+this"; go there once the answer is genuinely "none." A consuming repository wires
+the concrete link to that authoring skill and its downlevel-package and
+polyfill-layout specifics in its overlay.

--- a/.agents/skills/dotnet-polyfills/overlay.md
+++ b/.agents/skills/dotnet-polyfills/overlay.md
@@ -1,0 +1,44 @@
+---
+core: dotnet-polyfills
+core-pin: v0.10.0
+---
+
+# madowaku overlay - dotnet-polyfills
+
+Repository-specific companion to the vendored [dotnet-polyfills](SKILL.md) skill.
+The `SKILL.md` and its `references/packages.md` page are a **pinned copy of the
+portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **The downlevel target is `net472`.** A polyfill exists to let modern-.NET APIs
+  compile and behave correctly there.
+- **Hand-rolled polyfills live under**
+  [madowaku/Framework/](../../../madowaku/Framework/), each declaring the BCL
+  namespace it polyfills (for example
+  `Framework/System/Runtime/InteropServices/ComWrappers.cs` ->
+  `namespace System.Runtime.InteropServices;`). The folder is net472-only by
+  construction, so no `#if NETFRAMEWORK` guards go inside it - see
+  [interop.instructions.md](../../../.github/instructions/interop.instructions.md).
+- **`KlutzyNinja.Touki` is an additive source.** madowaku depends on Touki;
+  prefer its runtime polyfills and helpers before hand-rolling one.
+- **Package versions** (`PolySharp`, `System.Memory`, `Microsoft.Bcl.*`) are
+  centralized in
+  [Directory.Packages.props](../../../Directory.Packages.props).
+
+## Cross-references
+
+- [`cswin32-interop`](../cswin32-interop/SKILL.md) - the CsWin32 interop rules and
+  the `ComWrappers` shim, the largest polyfilled surface in madowaku.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) - net472
+  codegen consequences of a polyfilled path.
+
+## Updating
+
+Pull upstream changes with `gh skill update dotnet-polyfills` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/dotnet-polyfills/references/packages.md
+++ b/.agents/skills/dotnet-polyfills/references/packages.md
@@ -1,0 +1,59 @@
+# Official .NET downlevel package catalog
+
+Reference for the [dotnet-polyfills](../SKILL.md) skill. The Microsoft-shipped
+packages that backport modern BCL surface to **.NET Framework** (net472 /
+net481) and older `netstandard`. Reach for one of these before hand-rolling a
+polyfill; add it to an ItemGroup conditioned on the downlevel target only.
+
+## The catalog
+
+Ordered foundational-first. Many of the lower rows depend transitively on
+`System.Memory`, so adding it (or a package that pulls it) often closes several
+gaps at once.
+
+| Package | Supplies |
+| ------- | -------- |
+| `System.Memory` | `Span<T>`, `ReadOnlySpan<T>`, `Memory<T>`, `ReadOnlyMemory<T>`, the base `MemoryExtensions`, `MemoryMarshal`, `BinaryPrimitives`, `ArrayPool<T>`, and (transitively) `System.Runtime.CompilerServices.Unsafe`. The foundation almost everything else builds on. |
+| `Microsoft.Bcl.Memory` | `Index`, `Range` (so `x[1..^1]` and `^1` work downlevel), plus newer `MemoryExtensions` members (`Count`, `CommonPrefixLength`, `ContainsAnyExcept`, `IsWhiteSpace`, ...). Layers on `System.Memory`. |
+| `Microsoft.Bcl.HashCode` | `System.HashCode` (the `Add` / `Combine` struct combiner). |
+| `System.Threading.Tasks.Extensions` | `ValueTask`, `ValueTask<T>`. |
+| `Microsoft.Bcl.AsyncInterfaces` | `IAsyncEnumerable<T>`, `IAsyncEnumerator<T>`, `IAsyncDisposable` - the plumbing behind `await foreach` and async-returning interfaces. |
+| `Microsoft.Bcl.TimeProvider` | `TimeProvider` and `ITimer` (the testable clock abstraction). |
+| `Microsoft.IO.Redist` | The modern `System.IO` surface - notably `Directory` / `DirectoryInfo` enumeration with `EnumerationOptions`. Reach it via `global using Microsoft.IO;`. |
+| `Microsoft.Bcl.Numerics` | `MathF` and newer `System.Math` members downlevel. |
+| `System.Text.Json` | `System.Text.Json` (serializer + DOM) on .NET Framework. |
+| `System.Collections.Immutable` | `ImmutableArray<T>`, `ImmutableList<T>`, and the rest of the immutable collections. |
+
+The list is not exhaustive - the `Microsoft.Bcl.*` / `System.*` family is large.
+When a type is missing downlevel, search NuGet for an official
+`Microsoft.Bcl.<Area>` or `System.<Area>` package before assuming you must
+hand-roll it.
+
+## Referencing them safely
+
+- **Downlevel target only.** Wrap the references in an ItemGroup conditioned on
+  the framework target so they never ship on modern .NET:
+
+  ```xml
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481'">
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="Microsoft.Bcl.Memory" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
+    <PackageReference Include="Microsoft.IO.Redist" />
+  </ItemGroup>
+  ```
+
+  (With central package management the versions live in
+  `Directory.Packages.props`; the project file carries only the
+  `Include`.)
+
+- **Pin centrally, update deliberately.** These packages move with the BCL.
+  Representative versions at the time of writing: `System.Memory` 4.6.x,
+  `Microsoft.Bcl.Memory` 10.0.x, `Microsoft.Bcl.HashCode` 6.0.x,
+  `Microsoft.IO.Redist` 6.1.x. Treat those as examples, not a recommendation -
+  check NuGet for the current release.
+
+- **Mind the transitive graph.** `System.Memory` pulls `System.Buffers` and
+  `System.Runtime.CompilerServices.Unsafe`; adding it may already give you a type
+  you were about to reference separately. Probe (build the downlevel target)
+  after each addition to see what is now covered.

--- a/.agents/skills/engineering-baseline/SKILL.md
+++ b/.agents/skills/engineering-baseline/SKILL.md
@@ -1,0 +1,125 @@
+---
+compatibility: Requires PowerShell 7.2, git, and the .NET SDK; remote setup additionally uses authenticated gh.
+description: Create a new .NET repository fully wired for building, testing, and publishing with OSS best practices, or bring an existing repository up to a documented engineering baseline. Use when asked to "create a new repository" / "scaffold a new project" (a CLI tool, a class library / NuGet package, or a multi-target library) with CI, packaging, branch protection, and governance files, or to "ensure this repo follows modern engineering best practices" / "audit this repository" / "bring this repo up to standard". Scores a repository across nine domains - foundation, build, test, publish, versioning, CI, supply-chain security, OSS governance, and agent enablement - against an industry-cited baseline, then reports gaps and remediates. Irreversible or remote actions (repository creation, branch protection, release settings, publishing) are proposed for explicit approval, never run silently.
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/engineering-baseline
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: a5b695d91108206c115e7915dfafc1b3c54d3ada
+    maturity: canary
+    portability: portable
+    related: manage-skills, security-review, create-pr
+    requires: none
+    risk: remote-write
+name: engineering-baseline
+---
+
+# Engineering baseline
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+The repository-lifecycle skill: stand up a new repository wired for the full
+build / test / publish path with open-source best practices, or measure an
+existing repository against the same standard and close the gaps. Both verbs
+share one normative definition of "good" - the **baseline** - and one record of
+the choices behind it, each traced to an authoritative industry source.
+
+The standard in one paragraph: a high-quality .NET repository is **buildable**
+(centralized, deterministic, analyzer-enforced), **tested** (with coverage and,
+where it applies, perf and fuzz surfaces), **publishable** (signed, SourceLinked,
+validated packages with rich metadata), **released** deterministically from tags,
+**gated** by CI with least-privilege tokens and pinned actions, **secured** by
+branch protection, dependency updates, and scanning, **governed** by the OSS
+community files, and **agent-enabled** with vendored skills and the agent-file
+gates. The [baseline](baseline.md) is that standard as a checklist; the
+[citation catalog](references/best-practices.md) is the *why* behind every line.
+
+## When to use
+
+- "Create a new repository for a command-line tool", "scaffold a new library",
+  "set up a new project with CI and publishing" - the greenfield path.
+- "Ensure this repository follows modern engineering best practices", "audit
+  this repo", "bring this repo up to standard", "what is missing for engineering
+  fundamentals here" - the brownfield path.
+- Before making a repository public, or onboarding it into a shared fleet, to
+  confirm the governance and supply-chain gates are in place.
+
+Not for vendoring or syncing the agent skills themselves - that is the
+skill-lifecycle skill (a consuming repository names it in its overlay). This
+skill *consumes* that one as the agent-enablement domain of the baseline.
+
+## The two verbs
+
+| Ask | Do | Detail |
+| --- | --- | ------ |
+| "audit this repo", "bring it up to standard" | Inventory the repo, score it by domain against the baseline, report gaps highest-risk-first, then remediate in safe-to-risky order. | [assess.md](assess.md) |
+| "create a new repo", "scaffold a CLI tool / library" | Pick the archetype, lay down the standard structure, build/test/publish wiring, CI, governance files, and the agent gates, then propose the remote setup. | [scaffold.md](scaffold.md) |
+
+Both measure against the same [baseline.md](baseline.md), and both end at the
+same remote-setup boundary (below). Scaffold is "build to the baseline from
+nothing"; assess is "diff an existing repo against the baseline and converge."
+
+## The baseline domains
+
+The baseline groups every check into nine domains, used identically by both
+verbs and by the scoring report:
+
+1. Repository foundation and licensing
+2. Build configuration
+3. Testing and coverage
+4. Packaging and publishing
+5. Versioning and releases
+6. CI/CD
+7. Supply-chain and security
+8. OSS governance and community
+9. Agent enablement
+
+Each domain's concrete checks, the recommended choice, and the one-line rationale
+live in [baseline.md](baseline.md). The external authority for each choice - and
+the notes on where reasonable setups diverge - live in the
+[citation catalog](references/best-practices.md).
+
+## Guardrails: the remote boundary
+
+Most of the baseline is local, reversible, and safe to apply directly: writing
+`Directory.Build.props`, adding a workflow file, creating a `SECURITY.md`. Apply
+those directly.
+
+A few actions are remote or hard to reverse. **Never run these silently.**
+Propose the exact command or setting, show it, and wait for an explicit
+publishing verb before executing:
+
+- Creating or renaming the remote repository (`gh repo create`).
+- Branch protection or repository rulesets (`gh api`, ruleset JSON).
+- Release, tag, and publishing settings, including trusted-publishing policies
+  and the first package push.
+- Anything that pushes commits, opens a PR, or cuts a release.
+
+This mirrors the publish boundary in the repository's own agent guidance: the
+work of preparing a change is authorized by the request; the publish is not.
+When in doubt, stop and ask one yes/no question.
+
+## Related skills
+
+Run a security review over any code the scaffold generates or the assessment
+adds, and use the repository's PR skills to publish the result. The
+agent-enablement domain hands off to the skill-lifecycle skill and the fleet
+onboarding runbook for vendoring the skill tier and wiring the agent-file gates.
+A consuming repository wires these concrete cross-references in its overlay.
+
+## Sub-pages
+
+- [baseline.md](baseline.md) - the nine-domain gold-standard checklist with the
+  recommended choice and rationale for each item.
+- [assess.md](assess.md) - the brownfield procedure: inventory, score, gap
+  report, and safe-order remediation.
+- [scaffold.md](scaffold.md) - the greenfield procedure: archetype selection and
+  the build-to-baseline sequence for a CLI tool, library, or multi-target library.
+- [references/best-practices.md](references/best-practices.md) - the citation
+  catalog: every baseline choice traced to its industry source, with the
+  rationale and the divergence notes.

--- a/.agents/skills/engineering-baseline/assess.md
+++ b/.agents/skills/engineering-baseline/assess.md
@@ -1,0 +1,145 @@
+# Assess an existing repository
+
+The brownfield verb: measure a repository against [baseline.md](baseline.md),
+report the gaps by risk, and converge - applying safe fixes directly and
+proposing the rest. Triggered by "ensure this repo follows modern engineering
+best practices", "audit this repository", or "bring this repo up to standard".
+
+The output is a **scored gap report plus an applied set of safe fixes**, never a
+silent rewrite. Stop at the remote boundary (see the core's guardrails) and at
+anything that needs a judgment call.
+
+## 1. Inventory
+
+Read the repository's actual state before judging it. Gather, read-only:
+
+- Root files: `LICENSE`, `README.md`, `SECURITY.md`, `CONTRIBUTING.md`,
+  `CODE_OF_CONDUCT.md`, `CHANGELOG.md`, `.editorconfig`, `.gitignore`,
+  `.gitattributes`, `global.json`, `Directory.Build.props` / `.targets`,
+  `Directory.Packages.props`.
+- The project graph: which projects exist, their target frameworks, which is the
+  shippable one, whether test / perf / fuzz / analyzer projects are present.
+- `.github/`: workflows, `dependabot.yml`, `CODEOWNERS`, issue/PR templates,
+  rulesets, `copilot-instructions.md`.
+- Agent wiring: `AGENTS.md`, the skills location, the agent-file validator and
+  its CI gate.
+- Remote settings you can read without admin: read them from the repository's
+  own files rather than the GitHub API - the workflow YAML shows whether publish
+  uses OIDC (`id-token: write` plus a trusted-publishing login step) or a stored
+  key. Toggles that need an admin token (branch protection / rulesets, secret
+  scanning, push protection) cannot be read from the tree; mark them
+  **unverified - admin required** rather than guessing.
+
+Record two things that drive applicability: the primary **archetype** (tool,
+library, multi-target library, or app), which selects the archetype tags, and
+the **release status** (pre-release, stable, or end-of-life). Determine release
+status from the tag list (read-only `git tag` or `.git/refs/tags`) and the
+package gallery; if there are no tags and no published package, treat the repo as
+**pre-release**, corroborated by README markers like "coming soon". Release
+status decides whether the temporal items (package validation, release record,
+immutability, signing) apply yet or score N/A.
+
+## 2. Score by domain
+
+For each of the nine [baseline.md](baseline.md) domains, mark every applicable
+item (by its archetype tag) as one of:
+
+- **Met** - present and correct.
+- **Partial** - present but weaker than the baseline (for example actions pinned
+  by a mutable tag/major version instead of a SHA, or coverage collected but not
+  gated).
+- **Missing** - absent and applicable now.
+- **N/A** - does not apply: the archetype tag excludes it, or a **temporal**
+  item's milestone has not been reached (record why, for example "N/A until the
+  first stable release").
+
+Two scoring rules the cold cases need:
+
+- **Temporal items** (marked temporal in the baseline, for example
+  `EnablePackageValidation` "once a stable release exists") score **N/A with a
+  note** before the milestone, not **Missing** - a pre-release library is not
+  failing a post-release check.
+- **Pick-one items** (a release record: `CHANGELOG.md` *or* curated GitHub
+  Releases) score **Met** if either is present, **Partial** if neither is present
+  yet but the repo must eventually choose - flag the pending choice in the report.
+
+Produce a compact table, one row per domain, plus an itemized list of every
+Partial and Missing finding. Keep it factual - cite the file and the line, not
+an opinion.
+
+## 3. Report gaps, highest-risk first
+
+Order findings so the report leads with what matters. Use this risk order, which
+follows the OpenSSF Scorecard risk levels in the
+[citation catalog](references/best-practices.md):
+
+1. **Critical / High** - no branch protection, a stored long-lived publishing
+   key, no static analysis, missing license, a workflow that checks out and runs
+   untrusted PR code with write scope, or actions referenced by a **floating
+   ref** (a branch or `@latest`, which can change under you).
+2. **Medium** - no dependency-update tool, no SECURITY.md, no package validation,
+   missing SourceLink, no coverage gate, or actions pinned by a **mutable
+   tag/major version** without a stated policy (weaker than a SHA, but not a
+   floating ref - score Partial).
+3. **Low** - missing community files (code of conduct, templates), no CHANGELOG,
+   stylistic analyzer gaps.
+
+Action pinning has a deliberate gray zone: a SHA pin is the recommended choice, a
+floating branch ref is High, and a tag/major-version pin sits in between -
+**Partial**, and an **accepted divergence** when the repo states it as policy
+(see the catalog's divergence notes). Do not score a tag/major pin as Critical.
+
+For each finding give: the gap, the baseline item it fails, the cited reason,
+and the concrete remediation. Where the repository made a **deliberate** contrary
+choice (GitHub Releases instead of a `CHANGELOG.md`; major-version action pins as
+a stated policy), record it as an accepted divergence, not a defect - the
+catalog's divergence notes describe the common ones. If the repo documents its
+engineering choices (in `AGENTS.md`, a `docs/` philosophy page, or the README),
+read that first - a mature repo's conscious omission is an accepted divergence,
+not a gap.
+
+## 4. Remediate in safe-to-risky order
+
+Apply fixes in this order, so the reversible work lands first and the report
+stays ahead of the risky steps:
+
+1. **Local, additive, inert (apply directly).** Files that neither execute nor
+   change build behavior on merge, and opt-in metadata: `.editorconfig`,
+   `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, issue/PR templates,
+   SourceLink and package-metadata properties, `ContinuousIntegrationBuild`,
+   coverage collection. Validate after each (build, and the repo's agent-file
+   gates for agent files).
+2. **Local but behavior-changing (apply, then call out).** Anything that runs or
+   changes behavior on merge, even though the file itself is reversible: a new
+   workflow (a CodeQL or other CI job executes on the next push), a
+   `dependabot.yml` (it opens PRs on its own), turning on `TreatWarningsAsErrors`,
+   raising `AnalysisLevel`, pinning actions to SHAs, adding a coverage gate. These
+   can break the build or CI or generate activity; do them in a reviewable commit
+   and say so. Re-pin actions to SHAs using the version the repo already trusts,
+   recording the version in a trailing comment.
+3. **Remote or irreversible (propose, then run only on approval).** Branch
+   protection / rulesets, secret-scanning and push-protection toggles, the
+   trusted-publishing policy and the switch off a stored API key, the default
+   branch, repository visibility. Emit the exact `gh` / API command or the ruleset
+   JSON, show it, and wait for an explicit publishing verb. Never run these
+   silently.
+
+Batch related local fixes into coherent commits with clear messages. Do not
+commit or push unless the user asks - preparing the changes is authorized;
+publishing them is not.
+
+## 5. Hand off the security and agent domains
+
+- For domain 7 findings on code that handles untrusted input, run the security
+  review skill rather than judging vulnerability shapes here.
+- For domain 9 (vendoring the skill tier, wiring the validator and link checker,
+  the drift loop), hand off to the skill-lifecycle skill and the fleet
+  onboarding runbook - this skill confirms the gate exists; those own the how.
+
+A consuming repository names both skills in its overlay.
+
+## 6. Report back
+
+Summarize: the per-domain score before and after, the fixes applied, the
+behavior-changing commits to review, and the remote actions awaiting approval
+with their exact commands. End with the single highest-value next step.

--- a/.agents/skills/engineering-baseline/baseline.md
+++ b/.agents/skills/engineering-baseline/baseline.md
@@ -1,0 +1,249 @@
+# The baseline
+
+The normative gold standard, grouped into nine domains. Each item states the
+**recommended choice** and a one-line **why**; the external authority and the
+divergence notes are in the [citation catalog](references/best-practices.md),
+keyed by the same domain numbers.
+
+Each item is tagged:
+
+- **(core)** - every repository should satisfy it.
+- **(library)** - applies when the repo ships a NuGet package.
+- **(tool)** - applies when the repo ships an executable / `dotnet` tool.
+- **(conditional: <condition>)** - applies only when the named condition holds;
+  the parenthetical states the trigger so applicability is mechanical (for
+  example *(conditional: untrusted input)*).
+- **(deferred)** - in scope, but the actual judgment is owned by another skill;
+  confirm the check is wired, do not perform it here.
+
+Scoring and remediation read these tags to decide applicability; see
+[assess.md](assess.md). An item marked **temporal** applies only after a
+milestone ("once a stable release exists"); before that milestone it scores
+**N/A** with a note, not **Missing**. Concrete file names below
+(`Directory.Build.props`, `global.json`, ...) are .NET ecosystem conventions,
+not repo-specific paths. A repository's own layout, target frameworks, and
+project names are bound in its overlay - this core states the *shape*, not the
+literals.
+
+## 1. Repository foundation and licensing
+
+- **(core)** A top-level `LICENSE` file with an [SPDX](https://spdx.org/licenses/)-identified
+  open-source license (MIT is the fleet default). Why: without a license the
+  project defaults to exclusive copyright and cannot be used or reviewed.
+- **(core)** A `README.md` that states what the project is, how to install it,
+  and where to find docs. Why: it is the first and most-read artifact, and it
+  doubles as the package landing page.
+- **(core)** A `.gitignore` scoped to the toolchain (build output, `obj/`,
+  `bin/`, IDE state) and a `.gitattributes` that normalizes line endings
+  (`* text=auto`). Why: keeps generated and machine-specific files out of history
+  and avoids cross-platform diff churn.
+- **(core)** An `.editorconfig` that sets indentation, encoding, naming rules,
+  and analyzer severities. Why: makes style machine-enforceable instead of a
+  review topic.
+- **(core)** A license header on every source file, enforced
+  (`file_header_template` + `IDE0073`). Why: each file states its license and
+  copyright with a machine-readable SPDX id. Omit a per-file year (maintenance
+  churn, no legal benefit) and credit "<owner> and contributors" rather than a
+  roster.
+- **(conditional: redistributes third-party code)** A `NOTICE` /
+  `THIRD-PARTY-NOTICES` file when third-party code is redistributed. Why:
+  satisfies attribution obligations of bundled licenses.
+
+## 2. Build configuration
+
+- **(core)** SDK-style projects; framework and package metadata in the project
+  file. Why: the supported, tooling-friendly project format.
+- **(core)** Central build properties in `Directory.Build.props` /
+  `Directory.Build.targets`. Why: one source of truth for language version,
+  nullability, and analysis settings across every project.
+- **(core)** Route build output and intermediates to a top-level `artifacts/`
+  tree (for example `artifacts/bin/` and `artifacts/obj/` via
+  `BaseOutputPath` / `BaseIntermediateOutputPath`). Why: keeps repository roots
+  clean, makes cleanup deterministic, and standardizes paths for CI artifacts.
+- **(core)** Central Package Management via `Directory.Packages.props`
+  (`ManagePackageVersionsCentrally=true`). Why: one pinned version per package,
+  repo-wide, removing version drift between projects.
+- **(core)** Commit a lock file (`packages.lock.json` via
+  `RestorePackagesWithLockFile`) and enable NuGet audit (`NuGetAudit` with
+  `NuGetAuditMode=all`); CI restores with `--locked-mode`. Why: pins the full
+  dependency graph including transitives, fails on drift, and flags advisories on
+  direct and transitive packages every restore.
+- **(core)** A pinned SDK in `global.json` with a `rollForward` policy. Why:
+  reproducible builds across machines and CI; no silent SDK drift.
+- **(core)** `Nullable=enable` globally (in `Directory.Build.props`), plus a
+  current `LangVersion` and a deliberate `ImplicitUsings` setting. Why: every
+  project opts into the compiler's null-safety analysis by default.
+- **(core)** Keep the shippable project AOT/trim clean on its modern target
+  (`IsAotCompatible=true`), which turns on the trim, AOT, and single-file
+  analyzers. Why: the code composes into trimmed/AOT apps and avoids expensive
+  runtime reflection - worth keeping clean even if you never publish AOT, and
+  with warnings-as-errors a regression fails the build.
+- **(core)** `TreatWarningsAsErrors=true` (with a short, documented
+  `WarningsNotAsErrors` escape list) and `EnableNETAnalyzers` with a chosen
+  `AnalysisLevel` / `AnalysisMode`. Why: keeps warnings from accumulating and
+  turns the analyzers on by default.
+- **(core)** `EnforceCodeStyleInBuild=true`. Why: surfaces the `.editorconfig`
+  IDE rules as build diagnostics so style is enforced headlessly in CI.
+- **(library)** `GenerateDocumentationFile=true`. Why: ships XML docs and flags
+  undocumented public surface.
+- **(core)** Deterministic build, with `ContinuousIntegrationBuild=true` set
+  under the CI environment. Why: reproducible, path-independent outputs and PDBs.
+
+## 3. Testing and coverage
+
+- **(core)** A dedicated test project on the
+  [Microsoft Testing Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro)
+  (MTP): the test project is an executable (`OutputType=Exe`) with an MTP runner
+  (`EnableMSTestRunner` for MSTest, `UseMicrosoftTestingPlatformRunner` for
+  xunit.v3), selected in `global.json` (`"test": { "runner":
+  "Microsoft.Testing.Platform" }`). Why: MTP is the supported, self-contained,
+  faster successor to the VSTest host and the direction for every .NET test
+  framework.
+- **(core)** Default to MSTest; when using xunit, use v3 - both are first-class
+  on MTP. Why: a current, MTP-native framework; the fleet defaults away from
+  xunit's contribution policy on AI-assisted changes. This is a fleet choice, not
+  a hard rule - an overlay may pick another MTP-capable framework.
+- **(core)** Run at the fullest concurrency the framework allows by default
+  (MSTest `[assembly: Parallelize(Workers = 0, Scope = MethodLevel)]`; xunit.v3
+  unlimited parallel threads). Why: fast feedback, and it surfaces hidden test
+  ordering or shared-state bugs early.
+- **(core)** Tests run in CI on every push and pull request, in Release. Why:
+  Release codegen and timing differ from Debug; gate what ships.
+- **(core)** Code coverage collected and reported, with a gate on patch
+  coverage (new/changed lines). Why: a patch gate holds new code to a bar
+  without fighting noise in the whole-project number.
+- **(conditional: perf claim or hot path)** A perf project (for example
+  BenchmarkDotNet) where a performance claim or hot path exists - a hot path is
+  code on a measured critical path or tight loop (parsing, encoding, crypto,
+  byte/image processing), or any explicit performance claim in the README. Why:
+  perf assertions need measurement, not intuition.
+- **(conditional: untrusted input)** A fuzz project (for example SharpFuzz) for
+  any parser, decoder, or buffer surface that takes untrusted input. Why:
+  coverage-guided fuzzing finds the malformed-input bugs unit tests miss.
+
+## 4. Packaging and publishing
+
+- **(library)** Complete package metadata: `PackageId`, `Description`,
+  `Authors`, `PackageLicenseExpression`, `PackageProjectUrl`, `RepositoryUrl`,
+  `RepositoryType`, `PackageReadmeFile`, and `PackageTags`. Why: metadata drives
+  discoverability and trust on the gallery.
+- **(library)** [Source Link](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink)
+  enabled (`PublishRepositoryUrl`, the Source Link package, `EmbedUntrackedSources`)
+  with symbols published (embedded PDBs or a `.snupkg`). Why: lets consumers
+  step into library source while debugging.
+- **(library, temporal)** Package validation (`EnablePackageValidation`, with a
+  baseline version once a stable release exists). Temporal: score N/A until the
+  first stable release, then required. Why: catches accidental breaking API and
+  cross-framework surface gaps at pack time.
+- **(library)** A README packed into the package (`PackageReadmeFile`). Why: the
+  README renders on the gallery package page.
+- **(library)** Strong-named assemblies for identity (not as a security
+  boundary), shipped consistently. Why: required by some consumers; do not ship
+  both signed and unsigned variants of the same library.
+- **(tool)** `PackAsTool=true` with a `ToolCommandName`, packaged for
+  `dotnet tool` install. Why: the supported distribution path for a CLI tool.
+
+## 5. Versioning and releases
+
+- **(core)** [SemVer](https://semver.org/) version numbers. Why: communicates
+  compatibility expectations to consumers.
+- **(library)** Tag-driven, deterministic versioning from git history
+  (for example MinVer or Nerdbank.GitVersioning) rather than a hand-edited
+  version. Why: the released version is a function of the tag, not a manual edit
+  that can drift.
+- **(core)** A release record per version - a `CHANGELOG.md`
+  ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/)) or curated GitHub
+  Releases notes. Why: consumers need to know what changed and whether it breaks.
+- **(library)** Releases are immutable once published, and the package is
+  published only from a tagged commit. Why: a pinned version must never change
+  underneath a consumer.
+- **(library)** Releases are signed or carry build provenance / attestation.
+  Why: lets consumers verify an artifact came from the expected build.
+
+## 6. CI/CD
+
+- **(core)** A build-and-test workflow triggered on push and pull request to the
+  default branch. Why: the gate that keeps the default branch green.
+- **(core)** A least-privilege token: top-level `permissions: contents: read`,
+  with any write scope granted per-job. Why: limits blast radius if a workflow
+  step is compromised.
+- **(core)** Third-party actions pinned by full commit SHA (with the version in
+  a trailing comment). Why: a tag or branch is mutable and can be repointed at
+  malicious code; a SHA cannot.
+- **(core)** Concurrency control that cancels superseded in-flight runs for a
+  pull request. Why: saves runner time and surfaces only the latest result.
+- **(conditional: restorable dependencies)** Dependency caching keyed on the
+  lock/props files. Why: cuts CI time without staleness when versions change.
+- **(core)** A stable aggregate status-check name that branch protection can
+  require, even when the matrix underneath changes. Why: keeps the required
+  check name from breaking when the build matrix is edited.
+- **(library)** Publishing via OIDC
+  [trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+  (short-lived key, `id-token: write`) rather than a stored long-lived API key.
+  Why: removes the standing secret that is the usual supply-chain leak.
+
+## 7. Supply-chain and security
+
+- **(core)** A `SECURITY.md` with a private reporting channel and a disclosure
+  expectation. Why: gives reporters a safe path and is an
+  [OpenSSF Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md)
+  Security-Policy signal.
+- **(core)** A dependency-update tool (Dependabot or Renovate) configured. Why:
+  out-of-date dependencies accrue known-vulnerable flaws; automate the bumps.
+- **(core)** Restore from a single trusted feed with package source mapping (a
+  `nuget.config` that clears inherited sources and maps every package to one
+  feed). Why: blocks dependency-confusion, where a package is silently served
+  from an unexpected source.
+- **(core)** Adopt only vetted, quarantined dependency versions - pin a
+  known-good floor and bump deliberately (a minimum release age, advisory,
+  deprecation, and listing checks, and a license allowlist) rather than tracking
+  latest. Why: a freshly published version is the least-vetted and the usual
+  vector for a compromised release.
+- **(core)** Static analysis / code scanning (for example CodeQL) on a schedule
+  and on pull requests. Why: catches injectable and memory-safety bug classes
+  before merge.
+- **(core)** Secret scanning and push protection enabled. Why: stops credentials
+  from entering history.
+- **(core)** Branch protection or a repository ruleset on the default branch:
+  require the status check, require pull requests, block force-push and deletion.
+  Why: prevents direct, unreviewed, or history-rewriting changes to main.
+- **(conditional: untrusted input) (deferred)** Address the
+  [OWASP Top Ten](https://owasp.org/www-project-top-ten/) classes for any code
+  that handles untrusted input or runs as a service - the security-review skill
+  owns the actual review; here, only confirm it has been run. Why: the consensus
+  baseline for application-level vulnerability review.
+
+## 8. OSS governance and community
+
+- **(core)** A `CODE_OF_CONDUCT.md` (the
+  [Contributor Covenant](https://www.contributor-covenant.org/) is the default).
+  Why: sets behavioral expectations and is a GitHub community-standards signal.
+- **(core)** A `CONTRIBUTING.md` covering how to build, test, and submit
+  changes, and the contribution license terms. Why: lowers the barrier to a
+  correct first contribution.
+- **(conditional: multiple maintainers)** A `CODEOWNERS` file once more than one
+  maintainer or area exists. Why: routes review to the right owners automatically.
+- **(core)** Issue and pull-request templates. Why: makes reports and proposals
+  actionable by default.
+- **(conditional: defined support channel)** A `SUPPORT.md` when there is a
+  defined support channel. Why: directs help requests away from the issue tracker.
+
+## 9. Agent enablement
+
+- **(core)** An `AGENTS.md` as the single source of agent guidance, with the
+  tool-specific mirror (for example `.github/copilot-instructions.md`) generated
+  from it, not hand-edited. Why: one canonical instruction set, many consumers.
+- **(core)** Vendored agent skills under the host-read skills location, each
+  pinned and provenance-stamped, with the repo-specific overlay. Why: the
+  reviewed, version-controlled skill set instead of ad-hoc prompting.
+- **(core)** An agent-file gate in CI: frontmatter validation, the mirror check,
+  markdown lint, and an offline link check over the agent files. Why: keeps the
+  instruction set valid and its internal links resolvable.
+- **(conditional: distinct domains)** Path-specific instructions and reviewer
+  agent personas where the repo has distinct domains. Why: focuses guidance and
+  review on the area being changed.
+
+The mechanics of *vendoring* the skill tier, wiring the validator and link
+checker, and the drift loop are owned by the skill-lifecycle skill and the fleet
+onboarding runbook; this domain confirms they are present, and defers the how to
+them. A consuming repository names both in its overlay.

--- a/.agents/skills/engineering-baseline/overlay.md
+++ b/.agents/skills/engineering-baseline/overlay.md
@@ -1,0 +1,49 @@
+---
+core: engineering-baseline
+core-pin: v0.10.0
+---
+
+# madowaku overlay - engineering-baseline
+
+Repository-specific companion to the vendored [engineering-baseline](SKILL.md)
+skill. The `SKILL.md`, its sibling pages (`assess.md`, `baseline.md`,
+`scaffold.md`), the bundled `references/best-practices.md`, and the `scripts/`
+scaffolding tree are a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **madowaku is an established multi-target library, not a greenfield.** Use this
+  skill for the *assess* path (audit the nine domains and report gaps), not the
+  scaffold path.
+- **Existing baseline the audit should recognize**: CI in
+  [.github/workflows/dotnet.yml](../../../.github/workflows/dotnet.yml), packaging
+  and publish in [.github/workflows/publish.yml](../../../.github/workflows/publish.yml)
+  (`KlutzyNinja.Madowaku`), agent-file validation in
+  [.github/workflows/agent-files.yml](../../../.github/workflows/agent-files.yml),
+  central package management in
+  [Directory.Packages.props](../../../Directory.Packages.props), and governance in
+  [CONTRIBUTING.md](../../../CONTRIBUTING.md) and [LICENSE](../../../LICENSE).
+- **Remote or irreversible actions** (branch protection, release settings,
+  publishing) are proposed for explicit approval, never run silently - this
+  matches [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes).
+
+## Cross-references
+
+- [`manage-skills`](../manage-skills/SKILL.md) - the agent-enablement domain the
+  audit scores.
+- [`security-review`](../security-review/SKILL.md) - the supply-chain and
+  unsafe-input domain.
+- [`create-pr`](../create-pr/SKILL.md) - to land remediation under the publish
+  gate.
+- [`github-actions-cost-optimization`](../github-actions-cost-optimization/SKILL.md)
+  - the CI-cost lens on the workflows above.
+
+## Updating
+
+Pull upstream changes with `gh skill update engineering-baseline` (review the
+diff, re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/engineering-baseline/references/best-practices.md
+++ b/.agents/skills/engineering-baseline/references/best-practices.md
@@ -1,0 +1,158 @@
+# Citation catalog
+
+The authority behind every [baseline.md](../baseline.md) choice. Each domain
+table lists the **choice**, the **industry source** that backs it, and the
+**rationale**. The closing [divergence notes](#divergence-notes) record where
+reasonable, vetted setups legitimately differ - the places to "consult where
+they collide" rather than treat as defects.
+
+External links here are not network-checked by the offline link gate; keep them
+correct by hand. Sources are canonical standards bodies and vendor docs, not
+blog posts, so they age slowly.
+
+## Umbrella frameworks
+
+The cross-cutting standards the domain checks draw from.
+
+| Framework | Source | What it anchors |
+| --------- | ------ | --------------- |
+| OpenSSF Scorecard | [scorecard checks](https://github.com/ossf/scorecard/blob/main/docs/checks.md) | The supply-chain checks and their risk levels (branch protection, pinned deps, token permissions, SAST, ...) |
+| OpenSSF Best Practices Badge | [bestpractices.dev](https://www.bestpractices.dev/) | The passing/silver/gold criteria for OSS process health |
+| OpenSSF Concise Guide | [secure-software guide](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md) | A short, prioritized secure-development checklist |
+| SLSA | [slsa.dev](https://slsa.dev/) | Build provenance and supply-chain integrity levels |
+| OWASP Top Ten | [owasp.org/Top10](https://owasp.org/www-project-top-ten/) | The application-level vulnerability classes |
+| Reproducible Builds | [reproducible-builds.org](https://reproducible-builds.org/) | Why deterministic, verifiable builds matter |
+| .NET library guidance | [learn.microsoft.com](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/) | The official "what and why" for high-quality .NET libraries |
+| NuGet authoring best practices | [learn.microsoft.com](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices) | Package metadata and packing recommendations |
+
+## 1. Repository foundation and licensing
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| SPDX-identified open-source license | [SPDX license list](https://spdx.org/licenses/), [choosealicense.com](https://choosealicense.com/) | No license means exclusive copyright; an SPDX id is machine-readable on the gallery and by Scorecard |
+| Pick the license deliberately | [GitHub: licensing a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository) | The license governs all downstream use; default to MIT for permissive reuse |
+| `.editorconfig` for style and severities | [EditorConfig](https://editorconfig.org/), [.NET code-style options](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options) | Makes style machine-enforceable instead of a review topic |
+| `.gitattributes` line-ending normalization | [GitHub: configuring line endings](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) | Prevents cross-platform diff churn |
+| Redistribution notices when bundling code | [REUSE](https://reuse.software/) | Satisfies attribution obligations of bundled licenses |
+
+## 2. Build configuration
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| SDK-style projects | [NuGet: project format](https://learn.microsoft.com/en-us/nuget/resources/check-project-format) | The supported, metadata-in-project format |
+| Central Package Management | [NuGet: central package management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) | One pinned version per package repo-wide; no inter-project drift |
+| Lock file + restore audit | [Lock files](https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#locking-dependencies), [NuGet audit](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) | Pins the full transitive graph (`--locked-mode` in CI) and flags advisories every restore |
+| Pinned SDK in `global.json` | [global.json overview](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) | Reproducible builds across machines and CI |
+| Nullable reference types on | [Nullable references](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) | Opts into compiler null-safety |
+| Analyzers on, warnings as errors | [.NET code analysis overview](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview) | Stops warnings accumulating; turns analyzers on by default |
+| Deterministic build / `ContinuousIntegrationBuild` | [.NET reproducible builds](https://github.com/dotnet/reproducible-builds), [MSBuild props](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild) | Path-independent, reproducible outputs and PDBs |
+| Nullable reference types enabled repo-wide | [Nullable references](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) | Every project opts into compiler null-safety by default |
+| AOT/trim-clean shippable project | [Prepare libraries for trimming](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming), [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) | `IsAotCompatible` runs the trim/AOT analyzers so code composes into AOT apps and avoids runtime reflection |
+
+## 3. Testing and coverage
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| A real test project and suite | [.NET unit-testing best practices](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices) | A repo without runnable tests cannot gate regressions; OpenSSF CI-Tests check |
+| Microsoft Testing Platform (MTP) | [MTP overview](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro), [MTP + dotnet test](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-integration-dotnet-test) | The supported, self-contained successor to the VSTest host; the direction for all .NET test frameworks |
+| Coverage collected and gated | [.NET code coverage](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage) | A patch-coverage gate holds new code to a bar without whole-project noise |
+| Perf project where a hot path exists | [BenchmarkDotNet](https://benchmarkdotnet.org/) | Perf claims need measurement, not intuition |
+| Fuzz untrusted-input surfaces | [OWASP: fuzzing](https://owasp.org/www-community/Fuzzing), [Scorecard: Fuzzing](https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing) | Coverage-guided fuzzing finds malformed-input bugs unit tests miss |
+
+## 4. Packaging and publishing
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Complete package metadata | [NuGet authoring best practices](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices) | Metadata drives discoverability and trust |
+| Source Link + symbols | [Source Link guidance](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink), [symbol packages](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg) | Lets consumers step into library source while debugging |
+| Package validation | [Package validation overview](https://learn.microsoft.com/en-us/dotnet/fundamentals/apicompat/package-validation/overview) | Catches accidental breaking API and cross-framework gaps at pack time |
+| README packed into the package | [PackageReadmeFile](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile) | The README renders on the gallery package page |
+| Strong naming for identity, applied consistently | [Strong naming guidance](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming) | Some consumers require it; never ship signed and unsigned variants |
+| CLI tool packaged as a `dotnet` tool | [Create a dotnet tool](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create) | The supported distribution path for a command-line tool |
+
+## 5. Versioning and releases
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| SemVer | [semver.org](https://semver.org/), [.NET versioning](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/versioning) | Communicates compatibility expectations |
+| Tag-driven deterministic versioning | [MinVer](https://github.com/adamralph/minver), [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) | The version is a function of the tag, not a hand-edit that drifts |
+| A release record per version | [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), [GitHub releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) | Consumers need to know what changed and whether it breaks |
+| Optional commit convention | [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) | Enables automated changelog and version inference |
+| Build provenance / attestation | [GitHub artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds), [SLSA](https://slsa.dev/) | Lets consumers verify an artifact came from the expected build |
+
+## 6. CI/CD
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Harden the workflows | [GitHub: security hardening for Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) | The canonical list of Actions-specific risks and mitigations |
+| Least-privilege `GITHUB_TOKEN` | [Automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication), [Scorecard: Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) | Limits blast radius if a step is compromised; default to `contents: read` |
+| Pin actions by full commit SHA | [Scorecard: Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies), [StepSecurity](https://github.com/step-security/harden-runner) | A tag is mutable and can be repointed at malicious code; a SHA cannot |
+| OIDC trusted publishing | [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing), [GitHub OIDC](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) | Removes the standing long-lived secret that is the usual leak |
+| Concurrency and caching | [Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency), [Caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) | Cancels superseded runs and cuts CI time |
+
+## 7. Supply-chain and security
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Branch protection / rulesets on the default branch | [GitHub: about rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [Scorecard: Branch-Protection](https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection) | Prevents direct, unreviewed, or history-rewriting changes to main |
+| A dependency-update tool | [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates), [Renovate](https://docs.renovatebot.com/) | Out-of-date dependencies accrue known-vulnerable flaws |
+| Single trusted feed (source mapping) | [Package source mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping) | Blocks dependency-confusion across configured feeds |
+| Adopt only vetted, quarantined versions | [Renovate: minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage), [OpenSSF Concise Guide](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md) | A freshly published version is least-vetted and the usual compromised-release vector |
+| Static analysis / code scanning | [CodeQL code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql), [Scorecard: SAST](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast) | Catches injectable and memory-safety bug classes before merge |
+| Secret scanning + push protection | [About secret scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning), [About push protection](https://docs.github.com/en/code-security/secret-scanning/introduction/about-push-protection) | Stops credentials from entering history |
+| `SECURITY.md` with private reporting | [GitHub: adding a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository), [Scorecard: Security-Policy](https://github.com/ossf/scorecard/blob/main/docs/checks.md#security-policy) | Gives reporters a safe path; a Scorecard signal |
+| Dependency vulnerability auditing | [NuGet audit](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) | Surfaces advisories against the restored graph at build time |
+| Review untrusted-input code against OWASP | [OWASP Top Ten](https://owasp.org/www-project-top-ten/) | The consensus application-vulnerability baseline |
+
+## 8. OSS governance and community
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Set up healthy-contribution files | [GitHub community standards](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions) | The community-profile checklist GitHub surfaces |
+| `CODE_OF_CONDUCT.md` | [Contributor Covenant](https://www.contributor-covenant.org/) | Sets behavioral expectations; a community-standards signal |
+| `CONTRIBUTING.md` | [Setting contribution guidelines](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors) | Lowers the barrier to a correct first contribution |
+| `CODEOWNERS` | [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) | Routes review to the right owners automatically |
+| Issue / PR templates | [About issue and PR templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) | Makes reports and proposals actionable by default |
+| `SUPPORT.md` | [Adding support resources](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project) | Directs help requests away from the issue tracker |
+
+## 9. Agent enablement
+
+| Choice | Source | Rationale |
+| ------ | ------ | --------- |
+| Vendor-neutral agent skills | [agentskills.io](https://agentskills.io/) | The discovered skills format across Copilot and Claude |
+| `AGENTS.md` single source | [agents.md](https://agents.md/) | One canonical instruction set, many consumers |
+| Generated tool mirror | [Copilot repository instructions](https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot), [VS Code customization](https://code.visualstudio.com/docs/copilot/copilot-customization) | Tool-specific files are mirrors of the canonical `AGENTS.md`, not hand-edited |
+
+The mechanics of vendoring the skill tier and wiring the agent-file gates are
+owned by the skill-lifecycle skill and the fleet onboarding runbook, which a
+consuming repository names in its overlay.
+
+## Divergence notes
+
+Where vetted setups legitimately differ. Treat these as choices to record, not
+defects to flag.
+
+- **Action pinning: SHA vs major version.** The
+  [Scorecard Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+  best practice is a full commit SHA (with the version in a trailing comment),
+  and a dependency-update tool keeps the SHA fresh. Some repositories pin by
+  major version instead, trading supply-chain strictness for lower maintenance
+  and automatic patch uptake. The baseline recommends SHA pinning; a major-version
+  policy is an accepted, stated divergence - record it rather than silently
+  "fixing" it.
+- **Changelog: a file vs GitHub Releases.** [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+  favors an in-repo `CHANGELOG.md`; tag-driven repos often curate
+  [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+  notes instead. Either satisfies the baseline - pick one and state it in the
+  README; do not require both.
+- **Strong naming.** [Guidance](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/strong-naming)
+  treats it as identity, not a security boundary, and it is genuinely optional.
+  The rule that is not optional: never ship both a signed and an unsigned variant
+  of the same library.
+- **Coverage thresholds.** A strict whole-project gate is noisy on small or
+  fast-moving repos; a patch gate on changed lines is the pragmatic default. The
+  baseline requires *a* gate, not a specific number.
+- **Branch protection as code vs UI.** Classic branch protection is configured in
+  the UI; [repository rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
+  can be exported and version-controlled as JSON. Prefer as-code for
+  reproducibility, but UI-configured protection still satisfies the baseline.

--- a/.agents/skills/engineering-baseline/scaffold.md
+++ b/.agents/skills/engineering-baseline/scaffold.md
@@ -1,0 +1,160 @@
+# Scaffold a new repository
+
+The greenfield verb: stand up a new repository built to [baseline.md](baseline.md)
+from nothing. Triggered by "create a new repository for a command-line tool",
+"scaffold a new library", or "set up a new project with CI and publishing".
+
+The primary mechanism is the scaffold script ([scripts/New-DotnetRepo.ps1](scripts/New-DotnetRepo.ps1)),
+which uses `dotnet new` for the project skeleton and then applies the hardening
+layer (centralized build, CI workflows, governance files, agent stubs). Running
+the script produces an immediately buildable, testable, and packable tree. Stop
+at the remote boundary and propose those steps for explicit approval.
+
+## 1. Confirm the archetype and identity
+
+Pick the archetype - it selects which baseline items and script parameters apply:
+
+| Archetype | Ships | Key script parameters |
+| --------- | ----- | --------------------- |
+| **tool** | A `dotnet` tool executable | `-Archetype tool -ToolCommandName <cmd>` |
+| **library** | A single-TFM NuGet library | `-Archetype library` |
+| **multi-target** | A library across a modern + legacy TFM | `-Archetype multi-target -Framework net10.0 -FrameworkLegacy net481` |
+
+Confirm, before running the script, with one short prompt: the repository name,
+the target framework(s), the package id and one-line description, the license
+(default MIT), and the owner. Do not invent these - if the user did not supply
+them, ask once. These are the literals the script takes as parameters, and what
+a brownfield repo would keep in its overlay.
+
+## 2. Run the scaffold script
+
+Invoke `New-DotnetRepo.ps1` from the skill's `scripts/` directory (or a
+vendored copy in the consuming repo). Use an empty directory outside any
+existing repository as the root - the script refuses to run in a non-empty
+directory.
+
+The static file bodies it lays down are real files under `scripts/template/`
+(rendered with simple `{{TOKEN}}` substitution); the `.ps1` is the orchestration
+layer that runs `dotnet new`, renders the template, and applies project-file
+hardening. To change what a scaffolded repo contains, edit the template files,
+not here-strings.
+
+```pwsh
+# Example: scaffold a dotnet tool
+pwsh /path/to/New-DotnetRepo.ps1 `
+    -Root   C:\src\widgettool `
+    -Name   widgettool `
+    -Archetype tool `
+    -PackageId     WidgetTool `
+    -ToolCommandName widgettool `
+    -Description   "A sample command-line tool." `
+    -Owner  YourGitHubHandle
+```
+
+The script produces: `global.json`, `Directory.Build.props/.targets`,
+`Directory.Packages.props` (CPM on), a `dotnet new`-generated project and test
+project, `.gitignore`/`.gitattributes`/`.editorconfig`, `README.md`, `LICENSE`,
+`.github/workflows/` (ci, publish, codeql), `dependabot.yml`, `SECURITY.md`,
+`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, issue/PR templates, and `AGENTS.md`
+with its generated Copilot mirror.
+
+It also standardizes output paths to a top-level `artifacts/` tree:
+
+- `artifacts/bin/` - build outputs
+- `artifacts/obj/` - intermediates
+- `artifacts/packages/` - packed `.nupkg` output
+
+The scaffold is **born safe** on the supply-chain axis: a committed
+`packages.lock.json` (restored with `--locked-mode` in CI), NuGet audit over
+direct and transitive packages, and a `nuget.config` that maps every package to
+nuget.org to block dependency-confusion. Package versions are **pinned from the
+vetted manifest `scripts/versions.json`** - a known-good floor, never "latest".
+Refresh that floor deliberately with `scripts/Update-ScaffoldVersions.ps1`, which
+proposes only versions that pass a quarantine window plus advisory, deprecation,
+listing, and license-allowlist checks (and can scaffold-and-build to confirm TFM
+compatibility); review the diff before committing. The GitHub Actions pinned in
+the workflow templates carry the same quarantine floor, refreshed by
+`scripts/Update-ScaffoldActions.ps1` (the actions counterpart). Keeping both
+floors current, plus a `dependabot.yml` that **groups every update per ecosystem
+into one PR**, is what stops a fresh repo from opening a long list of day-one
+dependency bumps.
+
+Test projects run on the **Microsoft Testing Platform** (MTP) and default to
+**MSTest** (`-TestRunner xunit` switches to xunit.v3); both run at the fullest
+parallelism by default, and `global.json` selects the MTP runner.
+
+The shippable project is marked **AOT/trim clean** (`IsAotCompatible`) on its
+modern target, so the trim, AOT, and single-file analyzers run by default and the
+code stays composable into AOT apps even when AOT is never published.
+
+## 3. Pin the action SHAs (domain 6)
+
+The workflows emit `<SHA>` placeholders for every third-party action, each with
+its target version in a trailing comment kept current by
+`scripts/Update-ScaffoldActions.ps1`. Replace each placeholder with the full
+commit SHA for the commented version before the first push, then let Dependabot's
+grouped `github-actions` updates keep them current. Use
+[StepSecurity](https://app.stepsecurity.io) or
+`gh api repos/<owner>/<repo>/git/refs/tags` to resolve each version to a SHA.
+
+This is a local, reversible edit - do it before `git init`.
+
+## 4. Extend for multi-target (domain 2, conditional)
+
+For `multi-target`, the script adds the framework pair to `Directory.Build.props`
+and switches the main project to `<TargetFrameworks>`. The polyfill package
+strategy for the legacy target (PolySharp, `Microsoft.Bcl.*`, `System.Memory`,
+etc.) is not added by the script - hand that off to the polyfill skill a
+consuming repository names in its overlay.
+
+## 5. Add optional surfaces (domain 3, conditional)
+
+The script does not scaffold a perf or fuzz project; add those only if the
+tool/library has a hot path or an untrusted-input surface. Hand them off to the
+perf-testing and fuzz-testing skills a consuming repository names in its overlay.
+
+## 6. Wire agent enablement (domain 9)
+
+The script creates an `AGENTS.md` stub, generates its Copilot mirror
+(`.github/copilot-instructions.md`) with `tools/Sync-AgentInstructions.ps1`, adds
+an `agent-files.yml` workflow that fails if the mirror drifts from `AGENTS.md`,
+and vendors a pinned starting skill tier into `.agents/skills/` via `gh skill`
+(`manage-skills`, `agent-files-review`, `create-pr`, `address-pr-feedback`,
+`security-review` by default; override with `-Skills` / `-SkillsRef`). When
+`gh skill` is unavailable it records the pinned install commands instead of
+failing. The broader agent-file gate (skill-frontmatter validation, link
+checking) and vendoring any domain skills remain a handoff to the skill-lifecycle
+skill and the fleet onboarding runbook - do not reinvent that pipeline here.
+
+## 7. Validate locally
+
+```pwsh
+dotnet build -c Release
+dotnet test  -c Release
+dotnet pack  src/<Name>/<Name>.csproj -c Release -o artifacts/packages
+```
+
+All three must be clean before going near the remote. The pack confirms the
+package metadata is correct and SourceLink is wired. Fix anything red first.
+
+## 8. Propose the remote setup (the boundary)
+
+The script prints a remote setup checklist at the end. Everything on it is
+remote or hard to reverse - **propose each step and wait for an explicit
+publishing verb.** Do not run them silently:
+
+- Replace `<SHA>` placeholders in workflows (see step 3).
+- `gh repo create <owner>/<name> --public --source . --remote origin`
+- `git init && git add -A && git commit -m "Initial scaffold" && git push -u origin main`
+- Branch protection / ruleset on `main`: require the `build` status check,
+  require pull requests, block force-push and deletion. Emit the exact
+  `gh api` call or ruleset JSON for review.
+- Enable secret scanning and push protection (GitHub repo Settings > Security).
+- Register the trusted-publishing policy on nuget.org before the first publish.
+
+Present these as a numbered checklist, then stop.
+
+## 9. Report back
+
+Summarize the archetype, the tree created, what was validated locally, and the
+remote checklist still awaiting approval. End with the single next action.

--- a/.agents/skills/engineering-baseline/scripts/New-DotnetRepo.ps1
+++ b/.agents/skills/engineering-baseline/scripts/New-DotnetRepo.ps1
@@ -1,0 +1,631 @@
+<#
+.SYNOPSIS
+    Scaffolds a new .NET repository built to the engineering-baseline standard.
+
+.DESCRIPTION
+    Creates the local tree for a CLI tool, class library, or multi-target library,
+    including centralized build configuration, test project, CI workflows,
+    governance files, and agent-enablement stubs.
+
+    The static file bodies live as real files under this script's `template/`
+    folder and are rendered with simple {{TOKEN}} substitution. This script is the
+    orchestration layer: it runs `dotnet new` for the project skeletons, renders
+    the template folder, and applies the project-file hardening that `dotnet new`
+    does not (Central Package Management fix-ups, packaging metadata, Source Link).
+
+    Stops at the remote boundary: does not create the GitHub repository, configure
+    branch protection, or publish any package. Those steps are printed at the end
+    as a checklist for explicit approval.
+
+.PARAMETER Root
+    The directory to scaffold into. Created if it does not exist. Must be empty.
+
+.PARAMETER Name
+    The repository and solution name (for example "widgettool" or "MyLib").
+
+.PARAMETER Archetype
+    The kind of project to create:
+      tool          - A dotnet tool (PackAsTool). Produces a console entry point.
+      library       - A single-TFM NuGet library.
+      multi-target  - A library targeting a modern TFM and a legacy TFM side by side.
+
+.PARAMETER PackageId
+    The NuGet package id (for example "WidgetTool" or "Contoso.MyLib").
+
+.PARAMETER Description
+    One-line package description, used in csproj and README.
+
+.PARAMETER Owner
+    The GitHub owner (user or org) for repository URLs and author metadata.
+
+.PARAMETER ToolCommandName
+    For archetype=tool: the CLI command name. Defaults to -Name in lowercase.
+
+.PARAMETER Framework
+    The primary (modern) target framework moniker. Default: net10.0.
+
+.PARAMETER FrameworkLegacy
+    For archetype=multi-target: the legacy TFM (for example "net481").
+
+.PARAMETER License
+    SPDX license identifier. Default: MIT. Only the MIT body is bundled; other
+    licenses render every reference but skip the LICENSE file with a warning.
+
+.PARAMETER TestRunner
+    The test framework, both run on Microsoft Testing Platform. Accepted:
+    mstest (default) or xunit (uses xunit.v3).
+
+.PARAMETER Skills
+    The agent skills to vendor into .agents/skills from the commons. Default: the
+    universal starting tier (manage-skills, agent-files-review, create-pr,
+    address-pr-feedback, security-review). Pass an empty array to skip vendoring.
+
+.PARAMETER SkillsRef
+    The release tag or commit SHA to pin vendored skills to. Default: the latest
+    published release of -SkillsRepo, resolved at run time via gh.
+
+.PARAMETER SkillsRepo
+    The OWNER/REPO of the skills commons to vendor from. Default:
+    JeremyKuhne/agent-skills.
+
+.EXAMPLE
+    .\New-DotnetRepo.ps1 -Root C:\src\widgettool -Name widgettool `
+        -Archetype tool -PackageId WidgetTool -ToolCommandName widgettool `
+        -Description "A sample command-line tool." -Owner JeremyKuhne
+#>
+
+#Requires -Version 7.2
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $Root,
+    [Parameter(Mandatory)] [string] $Name,
+    [Parameter(Mandatory)] [ValidateSet('tool', 'library', 'multi-target')] [string] $Archetype,
+    [Parameter(Mandatory)] [string] $PackageId,
+    [Parameter(Mandatory)] [string] $Description,
+    [Parameter(Mandatory)] [string] $Owner,
+    [string] $ToolCommandName,
+    [string] $Framework = 'net10.0',
+    [string] $FrameworkLegacy,
+    [string] $License = 'MIT',
+    [ValidateSet('mstest', 'xunit')] [string] $TestRunner = 'mstest',
+    [string[]] $Skills = @('manage-skills', 'agent-files-review', 'create-pr', 'address-pr-feedback', 'security-review'),
+    [string] $SkillsRef,
+    [string] $SkillsRepo = 'JeremyKuhne/agent-skills'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+function Step ([string] $msg) { Write-Host "  $msg" -ForegroundColor Cyan }
+function Done ([string] $msg) { Write-Host "  OK  $msg" -ForegroundColor Green }
+function Warn ([string] $msg) { Write-Host "  WARN $msg" -ForegroundColor Yellow }
+
+function New-Dir ([string] $path) {
+    if ($path -and -not (Test-Path $path)) { New-Item -ItemType Directory -Path $path -Force | Out-Null }
+}
+
+function Invoke-Dotnet {
+    $output = & dotnet @args 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "dotnet $args failed (exit $LASTEXITCODE):`n$output" }
+}
+
+# Render every file under $TemplateRoot into $DestRoot, stripping the trailing
+# .tmpl and replacing {{TOKEN}} placeholders. {{TOKEN}} never collides with
+# GitHub Actions ${{ ... }} expressions because only the literal token keys below
+# are replaced.
+function Expand-Template {
+    param(
+        [string] $TemplateRoot,
+        [string] $DestRoot,
+        [hashtable] $Tokens,
+        [string[]] $SkipLeaf = @()
+    )
+    Get-ChildItem -LiteralPath $TemplateRoot -Recurse -File -Force | ForEach-Object {
+        $rel = $_.FullName.Substring($TemplateRoot.Length).TrimStart([char]'\', [char]'/')
+        if ($rel.EndsWith('.tmpl')) { $rel = $rel.Substring(0, $rel.Length - 5) }
+        if ($SkipLeaf -contains (Split-Path $rel -Leaf)) { return }
+        $text = Get-Content -LiteralPath $_.FullName -Raw
+        foreach ($k in $Tokens.Keys) { $text = $text.Replace("{{$k}}", [string]$Tokens[$k]) }
+        $dest = Join-Path $DestRoot $rel
+        New-Dir (Split-Path $dest -Parent)
+        Set-Content -LiteralPath $dest -Value $text -Encoding utf8NoBOM -NoNewline
+    }
+}
+
+# ---------------------------------------------------------------------------
+# locate the bundled template content folder (travels next to this script)
+# ---------------------------------------------------------------------------
+
+$TemplateRoot = Join-Path $PSScriptRoot 'template'
+if (-not (Test-Path $TemplateRoot)) { throw "Template folder not found next to the script: $TemplateRoot" }
+
+# ---------------------------------------------------------------------------
+# derived values and template tokens
+# ---------------------------------------------------------------------------
+
+if ($Archetype -eq 'multi-target' -and -not $FrameworkLegacy) {
+    throw "Archetype 'multi-target' requires -FrameworkLegacy (for example -FrameworkLegacy net472)."
+}
+
+$ToolCommandName = if ($ToolCommandName) { $ToolCommandName } else { $Name.ToLowerInvariant() }
+$RepoUrl       = "https://github.com/$Owner/$Name"
+$Year          = (Get-Date).Year
+$IsMultiTarget = $Archetype -eq 'multi-target'
+$IsTool        = $Archetype -eq 'tool'
+$MainTfm       = $Framework
+# Title-case only an all-lowercase name; preserve any name the user already cased
+# (ToTitleCase would downcase internal capitals, for example MyLib -> Mylib).
+$NameTitle     = if ($Name -cmatch '[A-Z]') { $Name } else { (Get-Culture).TextInfo.ToTitleCase($Name) }
+$SdkVersion    = (& dotnet --version 2>&1).Trim()
+
+# The generated global.json pins this exact SDK. If the host SDK is a prerelease,
+# allowPrerelease must be true or the pinned version cannot resolve - keep them in
+# sync rather than emitting a contradictory, unbuildable global.json.
+$SdkIsPrerelease = $SdkVersion -match '-'
+$AllowPrerelease = if ($SdkIsPrerelease) { 'true' } else { 'false' }
+if ($SdkIsPrerelease) { Warn "host SDK $SdkVersion is a prerelease; global.json will set allowPrerelease=true" }
+
+$LegacyTfmLine     = if ($IsMultiTarget) { "`n    <LegacyTfm>$FrameworkLegacy</LegacyTfm>" } else { '' }
+$FrameworksDisplay = if ($IsMultiTarget) { "$Framework, $FrameworkLegacy" } else { $Framework }
+
+$installLines = if ($IsTool) {
+    @('```shell', "dotnet tool install --global $PackageId", '```')
+} else {
+    @('```shell', "dotnet add package $PackageId", '```')
+}
+$InstallCommand = $installLines -join "`n"
+
+# Pinned, vetted package versions come from the manifest - never 'latest'.
+# Refresh deliberately with scripts/Update-ScaffoldVersions.ps1.
+$versionsPath = Join-Path $PSScriptRoot 'versions.json'
+if (-not (Test-Path $versionsPath)) { throw "Version manifest not found: $versionsPath" }
+$pin = (Get-Content $versionsPath -Raw | ConvertFrom-Json).packages
+
+$coreIds = @('MinVer', 'Microsoft.SourceLink.GitHub')
+$testIds = switch ($TestRunner) {
+    'mstest' { @('MSTest') }
+    'xunit'  { @('xunit.v3', 'xunit.runner.visualstudio') }
+}
+$PackageVersionsXml = (@($coreIds; $testIds) | ForEach-Object {
+    $v = $pin.$_
+    if (-not $v) { throw "versions.json has no pinned version for '$_'. Run Update-ScaffoldVersions.ps1." }
+    "    <PackageVersion Include=`"$_`" Version=`"$v`" />"
+}) -join "`n"
+
+$tokens = @{
+    SDK_VERSION        = $SdkVersion
+    ALLOW_PRERELEASE   = $AllowPrerelease
+    FRAMEWORK          = $Framework
+    LEGACY_TFM_LINE    = $LegacyTfmLine
+    FRAMEWORKS_DISPLAY = $FrameworksDisplay
+    OWNER              = $Owner
+    YEAR               = "$Year"
+    LICENSE            = $License
+    REPO_URL           = $RepoUrl
+    NAME               = $Name
+    NAME_TITLE         = $NameTitle
+    DESCRIPTION        = $Description
+    PACKAGE_ID         = $PackageId
+    ARCHETYPE          = $Archetype
+    INSTALL_COMMAND    = $InstallCommand
+    PACKAGE_VERSIONS   = $PackageVersionsXml
+}
+
+# License header for generated source. No per-file year - that is maintenance
+# churn with no legal benefit; "and contributors" credits everyone without a roster.
+$headerLines = @(
+    "Copyright (c) $Owner and contributors."
+    "SPDX-License-Identifier: $License"
+    "See LICENSE in the project root for license information."
+)
+$fileHeaderComment = (($headerLines | ForEach-Object { "// $_" }) -join "`n") + "`n`n"
+
+# ---------------------------------------------------------------------------
+# 0. prepare root
+# ---------------------------------------------------------------------------
+
+Write-Host "`nScaffolding '$Name' ($Archetype) -> $Root`n" -ForegroundColor White
+
+if (Test-Path -LiteralPath $Root) {
+    $existing = @(Get-ChildItem -LiteralPath $Root -Force -ErrorAction SilentlyContinue)
+    if ($existing.Count -gt 0) {
+        throw "Root '$Root' is not empty ($($existing.Count) items). Remove it or choose a different path."
+    }
+} else {
+    New-Item -ItemType Directory -Path $Root -Force | Out-Null
+}
+
+Push-Location -LiteralPath $Root
+try {
+
+# ---------------------------------------------------------------------------
+# 1. project skeleton via dotnet new
+# ---------------------------------------------------------------------------
+Step 'solution'
+Invoke-Dotnet new sln -n $Name --output . --format slnx
+
+Step 'main project'
+$srcDir = "src/$Name"
+if ($IsTool) {
+    Invoke-Dotnet new console -n $Name -o $srcDir --framework $MainTfm --no-restore
+} else {
+    Invoke-Dotnet new classlib -n $Name -o $srcDir --framework $MainTfm --no-restore
+}
+Invoke-Dotnet sln "$Name.slnx" add $srcDir --in-root
+
+Step 'test project'
+$testDir = "tests/$Name.tests"
+$testProjectName = "$Name.Tests"
+if ($TestRunner -eq 'mstest') {
+    # No --coverage-tool: the hardening step below wipes the template's package
+    # references, so the coverage package it would add is removed anyway.
+    Invoke-Dotnet new mstest --test-runner Microsoft.Testing.Platform -n $testProjectName -o $testDir --framework $MainTfm --no-restore
+} else {
+    # The SDK ships no xunit v3 template; generate the v2 template for its file
+    # structure and convert it to xunit.v3 + MTP during hardening below.
+    Invoke-Dotnet new xunit -n $testProjectName -o $testDir --framework $MainTfm --no-restore
+}
+Invoke-Dotnet sln "$Name.slnx" add $testDir --in-root
+Done 'project skeleton'
+
+# Point every project's TargetFramework at the central $(MainTfm) property so
+# Directory.Build.props is the single source of truth.
+foreach ($csproj in Get-ChildItem -Recurse -Filter '*.csproj') {
+    $doc = [xml](Get-Content $csproj.FullName -Raw)
+    foreach ($node in $doc.SelectNodes('//*[local-name()="TargetFramework"]')) { $node.InnerText = '$(MainTfm)' }
+    $doc.Save($csproj.FullName)
+}
+
+# ---------------------------------------------------------------------------
+# 2. render the bundled template content folder
+# ---------------------------------------------------------------------------
+Step 'render template files'
+$skip = @()
+if ($License -ne 'MIT') { $skip += 'LICENSE' }
+Expand-Template -TemplateRoot $TemplateRoot -DestRoot (Get-Location).Path -Tokens $tokens -SkipLeaf $skip
+if ($License -ne 'MIT') {
+    # Only the MIT body ships with the scaffold. Write a TODO placeholder so the
+    # source headers and the README "See LICENSE" reference still resolve to a file.
+    $licensePlaceholder = @(
+        "Copyright (c) $Year $Owner and contributors."
+        ''
+        "SPDX-License-Identifier: $License"
+        ''
+        "TODO: Replace this placeholder with the full $License license text before"
+        "publishing. The scaffold only bundles the MIT body; the canonical text is at"
+        "https://spdx.org/licenses/$License.html."
+    )
+    Set-Content -LiteralPath 'LICENSE' -Value (($licensePlaceholder -join "`n") + "`n") -Encoding utf8NoBOM -NoNewline
+    Warn "License '$License': wrote a TODO placeholder LICENSE - replace it with the full $License text before publishing."
+}
+Done 'template files rendered'
+
+# ---------------------------------------------------------------------------
+# 3. foundation: .editorconfig + .gitignore via dotnet new (good defaults)
+# ---------------------------------------------------------------------------
+Step 'foundation (.editorconfig, .gitignore)'
+Invoke-Dotnet new gitignore --output .
+Invoke-Dotnet new editorconfig --output .
+
+# Enforce a license header on C# source (IDE0073). The file_header_template uses
+# a literal \n as its line separator; warnings-as-errors then fails the build on
+# any file missing the header.
+$headerTemplate = $headerLines -join '\n'
+Add-Content -LiteralPath '.editorconfig' -Value "`n[*.cs]`nfile_header_template = $headerTemplate`ndotnet_diagnostic.IDE0073.severity = warning`n"
+
+# Keep the top-level artifacts output tree untracked - but only if the gitignore
+# template does not already cover it. Matched per line (Get-Content strips line
+# endings) so a CRLF gitignore does not defeat the check and duplicate the entry.
+$ignoreLines = if (Test-Path -LiteralPath '.gitignore') { Get-Content -LiteralPath '.gitignore' } else { @() }
+if ($ignoreLines -notcontains 'artifacts/') {
+    Add-Content -LiteralPath '.gitignore' -Value "`n# Build outputs`nartifacts/`n"
+}
+Done 'foundation'
+
+# ---------------------------------------------------------------------------
+# 4. harden the main project file (packaging metadata, Source Link, MinVer)
+# ---------------------------------------------------------------------------
+Step "harden $srcDir/$Name.csproj"
+$mainCsproj = "$srcDir/$Name.csproj"
+$xml = [xml](Get-Content $mainCsproj -Raw)
+
+$pg = $xml.CreateElement('PropertyGroup')
+$pg.SetAttribute('Label', 'Package identity')
+$props = [ordered]@{
+    PackageId         = $PackageId
+    Description       = $Description
+    PackageTags       = if ($IsTool) { 'dotnet;dotnet-tool;cli' } else { 'dotnet;library' }
+    PackageReadmeFile = 'README.md'
+}
+if ($IsTool) {
+    $props['PackAsTool']      = 'true'
+    $props['ToolCommandName'] = $ToolCommandName
+}
+foreach ($kv in $props.GetEnumerator()) {
+    $el = $xml.CreateElement($kv.Key); $el.InnerText = $kv.Value; $pg.AppendChild($el) | Out-Null
+}
+# Keep the shippable project AOT/trim clean on its modern target: enables the
+# trim, AOT, and single-file analyzers so the code composes into trimmed/AOT apps
+# and avoids runtime reflection, even when AOT is never published. (Net-only, so
+# it is scoped to the modern TFM - the analyzers do not apply to .NET Framework.)
+$aot = $xml.CreateElement('IsAotCompatible')
+$aot.SetAttribute('Condition', "'`$(TargetFramework)' == '`$(MainTfm)'")
+$aot.InnerText = 'true'
+$pg.AppendChild($aot) | Out-Null
+$xml.Project.AppendChild($pg) | Out-Null
+
+# README packed onto the gallery page.
+$ig = $xml.CreateElement('ItemGroup')
+$none = $xml.CreateElement('None')
+$none.SetAttribute('Include', '$(MSBuildThisFileDirectory)../../README.md')
+$none.SetAttribute('Pack', 'true')
+$none.SetAttribute('PackagePath', '\')
+$none.SetAttribute('Visible', 'false')
+$ig.AppendChild($none) | Out-Null
+$xml.Project.AppendChild($ig) | Out-Null
+
+# MinVer + Source Link (versions come from Directory.Packages.props).
+$ig2 = $xml.CreateElement('ItemGroup')
+foreach ($ref in @(
+    @{ Include = 'MinVer'; PrivateAssets = 'all' },
+    @{ Include = 'Microsoft.SourceLink.GitHub'; PrivateAssets = 'All'; IncludeAssets = 'runtime; build; native; contentfiles; analyzers; buildtransitive' }
+)) {
+    $pr = $xml.CreateElement('PackageReference')
+    $pr.SetAttribute('Include', $ref.Include)
+    $pr.SetAttribute('PrivateAssets', $ref.PrivateAssets)
+    if ($ref.ContainsKey('IncludeAssets')) { $pr.SetAttribute('IncludeAssets', $ref.IncludeAssets) }
+    $ig2.AppendChild($pr) | Out-Null
+}
+$xml.Project.AppendChild($ig2) | Out-Null
+
+if ($IsMultiTarget) {
+    $tfmNode = $xml.SelectSingleNode('//*[local-name()="TargetFramework"]')
+    if ($tfmNode) {
+        $tfs = $xml.CreateElement('TargetFrameworks')
+        $tfs.InnerText = '$(MainTfm);$(LegacyTfm)'
+        $tfmNode.ParentNode.ReplaceChild($tfs, $tfmNode) | Out-Null
+    }
+}
+
+$xml.Save((Resolve-Path $mainCsproj))
+Done "$Name.csproj hardened"
+
+if ($IsTool) {
+    # Replace the console template's top-level statements with an explicit Program
+    # class and Main method - a clearer, more discoverable entry point for a CLI.
+    $rootNs = $Name -replace '[^\w.]', '_'
+    if ($rootNs -match '^[0-9]') { $rootNs = "_$rootNs" }
+    $programLines = @(
+        "namespace $rootNs;"
+        ''
+        'internal sealed class Program'
+        '{'
+        '    private static void Main(string[] args)'
+        '    {'
+        '        Console.WriteLine("Hello, World!");'
+        '    }'
+        '}'
+    )
+    Set-Content -LiteralPath "$srcDir/Program.cs" -Value (($programLines -join "`n") + "`n") -Encoding utf8NoBOM -NoNewline
+}
+else {
+    # Document the classlib placeholder so a library builds under
+    # GenerateDocumentationFile + TreatWarningsAsErrors (CS1591).
+    $classFile = "$srcDir/Class1.cs"
+    if (Test-Path $classFile) {
+        $doc = "/// <summary>`n/// Placeholder type - replace with the library's public API.`n/// </summary>`npublic class Class1"
+        (Get-Content $classFile -Raw) -replace 'public class Class1', $doc |
+            Set-Content -LiteralPath $classFile -Encoding utf8NoBOM -NoNewline
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 5. harden the test project file (CPM fix-up, doc-gen off, project reference)
+# ---------------------------------------------------------------------------
+Step "harden $testDir/$testProjectName.csproj"
+$testCsproj = "$testDir/$testProjectName.csproj"
+$xml = [xml](Get-Content $testCsproj -Raw)
+$proj = $xml.Project
+
+# Drop the template's PackageReferences (packages/versions vary) and any now-empty
+# ItemGroup, then add the MTP package set from the manifest (versionless; CPM pins).
+foreach ($pr in @($xml.SelectNodes('//*[local-name()="PackageReference"]'))) {
+    $grp = $pr.ParentNode; $grp.RemoveChild($pr) | Out-Null
+    if (-not $grp.HasChildNodes) { $grp.ParentNode.RemoveChild($grp) | Out-Null }
+}
+$pkgGroup = $xml.CreateElement('ItemGroup')
+foreach ($pkgId in $testIds) {
+    $pr = $xml.CreateElement('PackageReference'); $pr.SetAttribute('Include', $pkgId)
+    $pkgGroup.AppendChild($pr) | Out-Null
+}
+$proj.AppendChild($pkgGroup) | Out-Null
+
+# Idempotently set the MTP + test-project properties (the mstest template already
+# sets some of these, so update in place rather than duplicating). Keep XML-doc
+# generation enabled because IDE0005 requires it when code style runs at build;
+# suppress only CS1591 for the test surface.
+$firstPg = $xml.SelectSingleNode('//*[local-name()="PropertyGroup"]')
+if (-not $firstPg) { $firstPg = $xml.CreateElement('PropertyGroup'); $proj.InsertBefore($firstPg, $proj.FirstChild) | Out-Null }
+$wanted = [ordered]@{ OutputType = 'Exe'; IsPackable = 'false'; GenerateDocumentationFile = 'true'; NoWarn = '$(NoWarn);CS1591' }
+if ($TestRunner -eq 'mstest') { $wanted['EnableMSTestRunner'] = 'true' }
+else { $wanted['UseMicrosoftTestingPlatformRunner'] = 'true' }
+foreach ($kv in $wanted.GetEnumerator()) {
+    $existing = $xml.SelectSingleNode("//*[local-name()='$($kv.Key)']")
+    if ($existing) { $existing.InnerText = $kv.Value }
+    else { $el = $xml.CreateElement($kv.Key); $el.InnerText = $kv.Value; $firstPg.AppendChild($el) | Out-Null }
+}
+
+# Reference the project under test.
+$ig = $xml.CreateElement('ItemGroup')
+$ref = $xml.CreateElement('ProjectReference'); $ref.SetAttribute('Include', "../../$srcDir/$Name.csproj")
+$ig.AppendChild($ref) | Out-Null
+$proj.AppendChild($ig) | Out-Null
+$xml.Save((Resolve-Path $testCsproj))
+
+# Run at the fullest level of concurrency by default.
+if ($TestRunner -eq 'mstest') {
+    # The MTP MSTest template emits MSTestSettings.cs with method-level parallelism;
+    # overwrite it to make the worker count explicit (0 = all processors). Fully
+    # qualify the attribute because MSTest is already imported implicitly and an
+    # explicit using fails the generated repo's IDE0005 build gate.
+    Set-Content -LiteralPath "$testDir/MSTestSettings.cs" -Encoding utf8NoBOM -NoNewline -Value @'
+// Fullest MSTest parallelization: every test method may run concurrently across
+// all available processors.
+[assembly: Microsoft.VisualStudio.TestTools.UnitTesting.Parallelize(
+    Workers = 0,
+    Scope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope.MethodLevel)]
+'@
+} else {
+    Set-Content -LiteralPath "$testDir/Parallelism.cs" -Encoding utf8NoBOM -NoNewline -Value @'
+// xunit.v3 parallelizes test collections by default; lift the thread cap so every
+// available processor is used (the fullest level of concurrency).
+[assembly: Xunit.CollectionBehavior(MaxParallelThreads = -1)]
+'@
+}
+Done "$testProjectName.csproj hardened"
+
+# ---------------------------------------------------------------------------
+# 5b. prepend the license header to generated source (enforced by IDE0073)
+# ---------------------------------------------------------------------------
+Step 'file headers'
+Get-ChildItem -Path 'src', 'tests' -Recurse -Filter '*.cs' -File |
+    Where-Object { $_.FullName -notmatch '[\\/](obj|bin|artifacts)[\\/]' } |
+    ForEach-Object {
+        $body = Get-Content -LiteralPath $_.FullName -Raw
+        if ($body -notmatch '(?m)^// Copyright \(c\)') {
+            Set-Content -LiteralPath $_.FullName -Value ($fileHeaderComment + $body) -Encoding utf8NoBOM -NoNewline
+        }
+    }
+Done 'file headers'
+
+# ---------------------------------------------------------------------------
+# 6. AGENTS.md -> .github/copilot-instructions.md mirror
+# ---------------------------------------------------------------------------
+# The mirror logic lives in the generated repo's tools/Sync-AgentInstructions.ps1
+# so the same code regenerates the mirror here and verifies it in CI
+# (.github/workflows/agent-files.yml).
+Step 'agent mirror'
+& (Join-Path $PWD 'tools/Sync-AgentInstructions.ps1')
+Done 'agent mirror'
+
+# ---------------------------------------------------------------------------
+# 6b. vendor the starting agent-skill tier (domain 9)
+# ---------------------------------------------------------------------------
+# Pinned, provenance-stamped copies of the universal skill cores from the commons.
+# A greenfield repo has nothing to reconcile, so this reduces to "vendor the tier".
+# Graceful: install with `gh skill` when available, otherwise record the exact
+# pinned commands in the final summary so the scaffold never hard-fails offline.
+$skillSummary = ''
+if ($Skills -and $Skills.Count -gt 0) {
+    Step 'vendor starting skills'
+    $skillsDir = '.agents/skills'
+    New-Dir $skillsDir
+    $destAbs = Join-Path (Get-Location).Path $skillsDir
+
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    $ref = $SkillsRef
+    if ($gh -and -not $ref) {
+        $ref = (& gh release view --repo $SkillsRepo --json tagName --jq '.tagName' 2>$null)
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($ref)) { $ref = $null }
+    }
+    $ghSkill = $false
+    if ($gh) { & gh skill --help *> $null; $ghSkill = ($LASTEXITCODE -eq 0) }
+
+    $vendored = @()
+    $pending = @()
+    if ($ghSkill -and $ref) {
+        foreach ($s in $Skills) {
+            & gh skill install $SkillsRepo $s --pin $ref --dir $destAbs --agent github-copilot --force *> $null
+            if ($LASTEXITCODE -eq 0) { $vendored += $s; Done "vendored $s ($ref)" }
+            else { $pending += $s; Warn "could not vendor $s - recorded as a manual step" }
+        }
+    }
+    else {
+        $pending = @($Skills)
+        $reason = if (-not $gh) { 'gh not found' } elseif (-not $ghSkill) { 'gh skill unavailable' } else { 'could not resolve a release ref' }
+        Warn "skill vendoring deferred ($reason) - commands are in the final summary"
+    }
+
+    # A short catalog documents the intended set and how to manage it even when the
+    # install was deferred; gh skill writes per-skill provenance into frontmatter.
+    $pin = if ($ref) { $ref } else { '<latest release>' }
+    $readmePath = Join-Path $skillsDir 'README.md'
+    if (-not (Test-Path $readmePath)) {
+        $lines = @(
+            '# Vendored agent skills'
+            ''
+            "Pinned, provenance-stamped copies of shared skill cores from $SkillsRepo,"
+            'each with a thin repo-specific overlay. Manage them with the manage-skills'
+            'skill (find / build / update); never edit a vendored core silently - record'
+            'every change as upstreamed, moved to the overlay, or a tracked divergence.'
+            ''
+            '| Skill | Pin |'
+            '| ----- | --- |'
+        ) + ($Skills | ForEach-Object { "| $_ | $pin |" })
+        Set-Content -LiteralPath $readmePath -Value (($lines -join "`n") + "`n") -Encoding utf8NoBOM -NoNewline
+    }
+
+    if ($vendored.Count -gt 0) {
+        $skillSummary += "`n  Review and commit the vendored skills under .agents/skills (pinned $ref):`n" +
+            (($vendored | ForEach-Object { "    - $_" }) -join "`n") + "`n"
+    }
+    if ($pending.Count -gt 0) {
+        $pinCmd = if ($ref) { $ref } else { 'vX.Y.Z' }
+        $cmds = ($pending | ForEach-Object { "    gh skill install $SkillsRepo $_ --pin $pinCmd --agent github-copilot" }) -join "`n"
+        $skillSummary += "`n  Vendor the starting skill tier (needs gh skill), then commit .agents/skills:`n$cmds`n"
+    }
+    Done 'starting skills'
+}
+
+# ---------------------------------------------------------------------------
+# 7. final restore (packages now centrally pinned)
+# ---------------------------------------------------------------------------
+Step 'dotnet restore'
+Invoke-Dotnet restore
+Done 'restore'
+
+# ---------------------------------------------------------------------------
+# done - print the remote boundary checklist
+# ---------------------------------------------------------------------------
+
+Write-Host @"
+
+Local scaffold complete. Before starting remote setup, verify:
+  dotnet build -c Release
+  dotnet test  -c Release
+$skillSummary
+Then, with explicit approval for each step, run:
+
+  REMOTE SETUP CHECKLIST
+  ----------------------
+  1. Replace <SHA> placeholders in .github/workflows/*.yml with full commit SHAs
+     (use Dependabot or https://app.stepsecurity.io to resolve them).
+
+  2. Create the repository (choose visibility - default to private):
+       gh repo create $Owner/$Name --private --source . --remote origin
+     (use --public instead to publish it openly)
+
+  3. git init && git add -A && git commit -m "Initial scaffold"
+     git branch -M main
+     git push -u origin main
+
+  4. Branch protection (propose exact ruleset JSON or enable via GitHub web UI):
+     - Require status check:  build
+     - Require pull requests
+     - Block force-push and deletion
+
+  5. Enable secret scanning and push protection (GitHub repo Settings > Security).
+
+  6. Register trusted-publishing policy on nuget.org before the first publish:
+     Owner: $Owner  Repo: $Name  Workflow: publish.yml
+     https://www.nuget.org/account/transform/trusted-publishers
+
+"@ -ForegroundColor White
+
+} finally {
+    Pop-Location
+}

--- a/.agents/skills/engineering-baseline/scripts/Update-ScaffoldActions.ps1
+++ b/.agents/skills/engineering-baseline/scripts/Update-ScaffoldActions.ps1
@@ -1,0 +1,223 @@
+<#
+.SYNOPSIS
+    Vets and pins the GitHub Actions referenced by the scaffold's workflow
+    templates. The github-actions counterpart to Update-ScaffoldVersions.ps1
+    (which pins NuGet packages in versions.json).
+
+.DESCRIPTION
+    Scans the workflow templates under template/.github/workflows for
+    `uses: <owner>/<repo>[/<path>]@<ref> # vX.Y.Z` lines and, for every distinct
+    action, resolves the newest STABLE release that was published at least
+    -MinimumReleaseAgeDays ago. That quarantine window keeps freshly published -
+    and therefore least-vetted, possibly compromised - action releases out of
+    newly scaffolded repositories, mirroring the NuGet policy in versions.json.
+
+    Keeping these version comments current is what stops a freshly scaffolded
+    repo from opening a long list of day-one Dependabot action bumps: if the
+    template already pins the newest vetted major, Dependabot has nothing to
+    propose. Stale comments (for example checkout pinned at v4 while v7 ships)
+    are exactly what produce that flood.
+
+    Reports proposed changes by default. Use -Apply to rewrite the version
+    comment (and any already-resolved 40-hex commit SHA) in every template. The
+    `<SHA>` placeholder that the scaffold resolves at pin time is preserved; the
+    refreshed comment is the version the pinner should resolve that placeholder
+    to. Review the diff before committing.
+
+    Requires the GitHub CLI (gh), authenticated, to read release metadata.
+
+.PARAMETER WorkflowsDir
+    Directory of workflow templates to scan. Defaults to
+    template/.github/workflows next to this script.
+
+.PARAMETER MinimumReleaseAgeDays
+    Quarantine window in days. A release newer than this is skipped in favour of
+    the newest release old enough to have been vetted. Default: 30.
+
+.PARAMETER Apply
+    Write the refreshed version comments (and resolved SHAs) back to the
+    templates. Without it, only a report is printed.
+
+.EXAMPLE
+    .\Update-ScaffoldActions.ps1                 # report only
+    .\Update-ScaffoldActions.ps1 -Apply          # refresh the templates
+#>
+
+#Requires -Version 7.2
+[CmdletBinding()]
+param(
+    [string] $WorkflowsDir = (Join-Path $PSScriptRoot 'template/.github/workflows'),
+    [int]    $MinimumReleaseAgeDays = 30,
+    [switch] $Apply,
+    [Parameter(DontShow)] [switch] $SkipMain
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Step ([string] $msg) { Write-Host "  $msg" -ForegroundColor Cyan }
+function Warn ([string] $msg) { Write-Host "  WARN $msg" -ForegroundColor Yellow }
+
+# uses: owner/repo[/sub/path]@<ref> # vX[.Y[.Z]][suffix]
+$usesRegex = [regex]'^(?<pre>\s*(?:-\s+)?uses:\s*)(?<action>[^@\s]+)@(?<ref>\S+)(?<mid>\s+#\s+)(?<ver>v\d[^\s]*)\s*$'
+
+# owner/repo from owner/repo[/sub/...] (codeql-action/init -> codeql-action).
+function Get-ActionRepo ([string] $action) {
+    $parts = $action -split '/'
+    if ($parts.Count -lt 2) { return $null }
+    "$($parts[0])/$($parts[1])"
+}
+
+# [version] from a vX[.Y[.Z]] tag, padded to three components.
+function ConvertTo-SortableVersion ([string] $tag) {
+    $base = ($tag.TrimStart('v') -split '[-+]', 2)[0]
+    $n = @($base -split '\.' | ForEach-Object { [int]$_ })
+    while ($n.Count -lt 3) { $n += 0 }
+    [version]::new($n[0], $n[1], $n[2])
+}
+
+# Newest stable vX.Y.Z release published at least $minAge days ago. Falls back to
+# tags (no publish date, so no age gate) for actions that ship without releases.
+function Resolve-ActionVersion ([string] $repo, [int] $minAge) {
+    $cutoff = (Get-Date).ToUniversalTime().AddDays(-$minAge)
+
+    $releases = @(gh api "repos/$repo/releases" --paginate `
+            --jq '.[] | select(.draft==false and .prerelease==false) | "\(.tag_name)\t\(.published_at)"' 2>$null)
+
+    $candidates = @()
+    foreach ($line in $releases) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $tag, $published = $line -split "`t", 2
+        if ($tag -notmatch '^v\d+(\.\d+){0,2}$') { continue }
+        $pub = [datetime]::Parse($published).ToUniversalTime()
+        if ($pub -gt $cutoff) { continue }
+        $candidates += [pscustomobject]@{ Tag = $tag; Published = $pub }
+    }
+
+    $usedFallback = $false
+    if (-not $candidates) {
+        # No qualifying releases; fall back to stable tags (age cannot be checked).
+        $tags = @(gh api "repos/$repo/tags" --paginate --jq '.[].name' 2>$null)
+        foreach ($tag in $tags) {
+            if ($tag -notmatch '^v\d+(\.\d+){0,2}$') { continue }
+            $candidates += [pscustomobject]@{ Tag = $tag; Published = $null }
+        }
+        $usedFallback = $true
+    }
+    if (-not $candidates) { return $null }
+
+    $best = $candidates | Sort-Object { ConvertTo-SortableVersion $_.Tag } -Descending | Select-Object -First 1
+    $sha = (gh api "repos/$repo/commits/$($best.Tag)" --jq '.sha' 2>$null)
+    if ([string]::IsNullOrWhiteSpace($sha)) { return $null }
+
+    [pscustomobject]@{ Tag = $best.Tag; Sha = $sha; Fallback = $usedFallback }
+}
+
+# ---------------------------------------------------------------------------
+# 1. discover every action reference in the templates
+# ---------------------------------------------------------------------------
+
+if ($SkipMain) { return }
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "gh (GitHub CLI) is required to resolve action releases. Install it and run 'gh auth login'."
+}
+if (-not (Test-Path $WorkflowsDir)) {
+    throw "Workflows directory not found: $WorkflowsDir"
+}
+
+$files = @(Get-ChildItem -Path $WorkflowsDir -Recurse -File -Filter '*.tmpl' |
+    Sort-Object FullName)
+if (-not $files) { $files = @(Get-ChildItem -Path $WorkflowsDir -Recurse -File | Sort-Object FullName) }
+
+$refs = @()   # one row per matching line
+foreach ($file in $files) {
+    $lineNo = 0
+    foreach ($line in [System.IO.File]::ReadAllLines($file.FullName)) {
+        $lineNo++
+        $m = $usesRegex.Match($line)
+        if (-not $m.Success) { continue }
+        $repo = Get-ActionRepo $m.Groups['action'].Value
+        if (-not $repo) { continue }
+        $refs += [pscustomobject]@{
+            File    = $file.FullName
+            Line    = $lineNo
+            Action  = $m.Groups['action'].Value
+            Repo    = $repo
+            CurRef  = $m.Groups['ref'].Value
+            CurVer  = $m.Groups['ver'].Value
+        }
+    }
+}
+
+if (-not $refs) {
+    Write-Host "No action references found under $WorkflowsDir." -ForegroundColor Yellow
+    return
+}
+
+# ---------------------------------------------------------------------------
+# 2. resolve the newest vetted release per distinct repo
+# ---------------------------------------------------------------------------
+Step "Resolving latest vetted releases (>= ${MinimumReleaseAgeDays}d old)..."
+$resolved = @{}
+foreach ($repo in ($refs.Repo | Sort-Object -Unique)) {
+    $r = Resolve-ActionVersion $repo $MinimumReleaseAgeDays
+    if (-not $r) { Warn "could not resolve a release for $repo - leaving as-is"; continue }
+    if ($r.Fallback) { Warn "$repo has no dated releases - used tag $($r.Tag) without an age check" }
+    $resolved[$repo] = $r
+}
+
+# ---------------------------------------------------------------------------
+# 3. report, and (optionally) rewrite the templates
+# ---------------------------------------------------------------------------
+$changes = 0
+$plan = @{}   # file -> ordered list of {Line, New}
+foreach ($ref in $refs) {
+    if (-not $resolved.ContainsKey($ref.Repo)) { continue }
+    $target = $resolved[$ref.Repo]
+    $newVer = $target.Tag
+    $newRef = if ($ref.CurRef -match '^[0-9a-f]{40}$') { $target.Sha } else { $ref.CurRef }
+    $verChanged = ($ref.CurVer -ne $newVer)
+    $refChanged = ($ref.CurRef -ne $newRef)
+    if (-not ($verChanged -or $refChanged)) { continue }
+
+    $changes++
+    $short = [System.IO.Path]::GetFileName($ref.File)
+    Write-Host ("  {0,-22} {1,-28} {2,-9} -> {3}" -f $short, $ref.Action, $ref.CurVer, $newVer)
+
+    if ($Apply) {
+        if (-not $plan.ContainsKey($ref.File)) { $plan[$ref.File] = @() }
+        $plan[$ref.File] += [pscustomobject]@{ Line = $ref.Line; Ref = $newRef; Ver = $newVer }
+    }
+}
+
+if ($changes -eq 0) {
+    Write-Host "All action pins are already current. Nothing to do." -ForegroundColor Green
+    return
+}
+
+if (-not $Apply) {
+    Write-Host ""
+    Write-Host "Report only. Re-run with -Apply to rewrite the templates, then review the diff." -ForegroundColor Yellow
+    return
+}
+
+foreach ($file in $plan.Keys) {
+    # Preserve the file's existing newline style (LF vs CRLF). WriteAllLines would
+    # otherwise force the current platform's newline (CRLF on Windows) and churn
+    # every line across OSes.
+    $raw = [System.IO.File]::ReadAllText($file)
+    $nl = if ($raw.Contains("`r`n")) { "`r`n" } else { "`n" }
+    $lines = [System.IO.File]::ReadAllLines($file)
+    foreach ($edit in $plan[$file]) {
+        $idx = $edit.Line - 1
+        $m = $usesRegex.Match($lines[$idx])
+        if (-not $m.Success) { continue }
+        $lines[$idx] = "{0}{1}@{2}{3}{4}" -f `
+            $m.Groups['pre'].Value, $m.Groups['action'].Value, $edit.Ref, $m.Groups['mid'].Value, $edit.Ver
+    }
+    [System.IO.File]::WriteAllText($file, ($lines -join $nl) + $nl)
+}
+
+Write-Host ""
+Write-Host "Updated $changes reference(s) across $($plan.Keys.Count) file(s). Review the diff before committing." -ForegroundColor Green

--- a/.agents/skills/engineering-baseline/scripts/Update-ScaffoldVersions.ps1
+++ b/.agents/skills/engineering-baseline/scripts/Update-ScaffoldVersions.ps1
@@ -1,0 +1,229 @@
+<#
+.SYNOPSIS
+    Vets and pins the package versions used by New-DotnetRepo.ps1.
+
+.DESCRIPTION
+    Resolves the latest KNOWN-GOOD version of each managed package - never simply
+    the latest. A candidate is rejected unless it is, per the policy in
+    versions.json: old enough (minimum release age / quarantine), listed (not
+    yanked), not deprecated, free of known advisories, and under an allowed
+    license. This keeps freshly published - and therefore least-vetted - versions,
+    including compromised ones, out of newly scaffolded repositories.
+
+    Reports proposed changes by default. Use -Apply to write versions.json (review
+    the diff before committing). Use -SmokeTest to authoritatively validate the
+    pinned set against the real project layouts (a tool and a multi-target library
+    that builds on net472), which is the ground-truth TFM-compatibility check.
+
+.PARAMETER VersionsPath
+    Path to the manifest. Defaults to versions.json next to this script.
+
+.PARAMETER MinimumReleaseAgeDays
+    Override the manifest's quarantine window for this run.
+
+.PARAMETER Source
+    NuGet v3 source. Defaults to the manifest's source (nuget.org).
+
+.PARAMETER Apply
+    Write the resolved versions back to versions.json and stamp lastVetted.
+
+.PARAMETER SmokeTest
+    After resolving (and applying), scaffold a tool and a multi-target library
+    into temp folders and build them, to confirm the pinned set restores and
+    builds on every targeted TFM.
+
+.EXAMPLE
+    .\Update-ScaffoldVersions.ps1                 # report only
+    .\Update-ScaffoldVersions.ps1 -Apply -SmokeTest
+#>
+
+#Requires -Version 7.2
+[CmdletBinding()]
+param(
+    [string] $VersionsPath = (Join-Path $PSScriptRoot 'versions.json'),
+    [int]    $MinimumReleaseAgeDays,
+    [string] $Source,
+    [switch] $Apply,
+    [switch] $SmokeTest,
+    [Parameter(DontShow)] [switch] $SkipMain
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Resolved from the feed's v3 service index once $Source is known (see below).
+$flat = $null
+$reg  = $null
+
+function Get-StableVersions ([string] $id) {
+    $u = "$flat/$($id.ToLowerInvariant())/index.json"
+    (Invoke-RestMethod $u -TimeoutSec 30).versions | Where-Object { $_ -notmatch '-' }
+}
+
+function Get-VersionMeta ([string] $id, [string] $v) {
+    $lid  = $id.ToLowerInvariant()
+    $leaf = Invoke-RestMethod "$reg/$lid/$v.json" -TimeoutSec 30
+    $ce = $leaf.catalogEntry
+    if ($ce -is [string]) { $ce = Invoke-RestMethod $ce -TimeoutSec 30 }
+
+    $license = if ($ce.PSObject.Properties['licenseExpression'] -and $ce.licenseExpression) {
+        $ce.licenseExpression
+    } else {
+        try {
+            $nuspec = [xml]((Invoke-WebRequest "$flat/$lid/$v/$lid.nuspec" -TimeoutSec 30).Content)
+            [string]$nuspec.package.metadata.license.'#text'
+        } catch { $null }
+    }
+
+    [pscustomobject]@{
+        Version    = $v
+        Published  = [datetime]$ce.published
+        Listed     = [bool]$ce.listed
+        Deprecated = [bool]($ce.PSObject.Properties['deprecation'] -and $ce.deprecation)
+        Vulnerable = [bool]($ce.PSObject.Properties['vulnerabilities'] -and $ce.vulnerabilities)
+        License    = $license
+    }
+}
+
+# True only when every SPDX identifier in the (possibly compound) expression is on
+# the allowlist. NuGet returns SPDX expressions such as "MIT OR Apache-2.0" or
+# "(MIT AND BSD-3-Clause)"; an exact match would wrongly reject those. Custom
+# (LicenseRef) expressions cannot be validated and are rejected.
+function Test-LicenseAllowed ([string] $license, [string[]] $allow) {
+    if ([string]::IsNullOrWhiteSpace($license)) { return $false }
+    if ($license -match '(?i)LicenseRef') { return $false }
+    $ids = $license -split '(?i)\s+(?:AND|OR|WITH)\s+' |
+        ForEach-Object { ($_ -replace '[()]', '').Trim().TrimEnd('+') } |
+        Where-Object { $_ }
+    if (-not $ids) { return $false }
+    foreach ($id in $ids) { if ($allow -notcontains $id) { return $false } }
+    return $true
+}
+
+# Newest stable version that passes every gate, scanning newest-first.
+function Resolve-KnownGood ([string] $id, [int] $minAge, [string[]] $allow) {
+    $versions = Get-StableVersions $id | Sort-Object {
+        # Order by full numeric version, padding to four components and dropping any
+        # build metadata, so 4-segment versions are not collapsed to three.
+        $base = ($_ -split '[-+]', 2)[0]
+        $n = @($base -split '\.' | ForEach-Object { [int]$_ })
+        while ($n.Count -lt 4) { $n += 0 }
+        [version]::new($n[0], $n[1], $n[2], $n[3])
+    } -Descending
+    foreach ($v in $versions) {
+        try { $m = Get-VersionMeta $id $v } catch { continue }
+        $age = [int]((Get-Date) - $m.Published).TotalDays
+        $reasons = @()
+        if (-not $m.Listed)  { $reasons += 'unlisted' }
+        if ($m.Deprecated)   { $reasons += 'deprecated' }
+        if ($m.Vulnerable)   { $reasons += 'advisory' }
+        if ($age -lt $minAge) { $reasons += "age ${age}d<${minAge}d" }
+        if (-not $m.License) { $reasons += 'license unknown' }
+        elseif (-not (Test-LicenseAllowed $m.License $allow)) { $reasons += "license $($m.License)" }
+        if ($reasons.Count -eq 0) {
+            return [pscustomobject]@{ Version = $v; Age = $age; License = $m.License; Reason = '' }
+        }
+        Write-Verbose "$id $v rejected: $($reasons -join ', ')"
+    }
+    return [pscustomobject]@{ Version = $null; Age = $null; License = $null; Reason = 'no known-good version' }
+}
+
+# ---------------------------------------------------------------------------
+
+if ($SkipMain) { return }
+
+$doc    = Get-Content $VersionsPath -Raw | ConvertFrom-Json
+$minAge = if ($PSBoundParameters.ContainsKey('MinimumReleaseAgeDays')) { $MinimumReleaseAgeDays } else { [int]$doc.policy.minimumReleaseAgeDays }
+$allow  = @($doc.policy.allowedLicenses)
+if (-not $Source) { $Source = [string]$doc.policy.source }
+
+# Resolve the flat-container and registration endpoints from the feed's v3 service
+# index so -Source actually targets the requested feed (not a hard-coded nuget.org).
+$index = Invoke-RestMethod $Source -TimeoutSec 30
+$flat = ($index.resources | Where-Object { $_.'@type' -eq 'PackageBaseAddress/3.0.0' } | Select-Object -First 1).'@id'
+foreach ($rt in @('RegistrationsBaseUrl/3.6.0', 'RegistrationsBaseUrl/Versioned', 'RegistrationsBaseUrl/3.4.0', 'RegistrationsBaseUrl')) {
+    $reg = ($index.resources | Where-Object { $_.'@type' -eq $rt } | Select-Object -First 1).'@id'
+    if ($reg) { break }
+}
+if (-not $flat -or -not $reg) { throw "Could not resolve PackageBaseAddress/RegistrationsBaseUrl from the service index at $Source." }
+$flat = $flat.TrimEnd('/')
+$reg = $reg.TrimEnd('/')
+
+Write-Host "Vetting scaffold package versions" -ForegroundColor White
+Write-Host "  source:    $Source"
+Write-Host "  min age:   $minAge days (quarantine)"
+Write-Host "  licenses:  $($allow -join ', ')`n"
+
+$rows = foreach ($prop in $doc.packages.PSObject.Properties) {
+    $id = $prop.Name
+    $current = [string]$prop.Value
+    $kg = Resolve-KnownGood $id $minAge $allow
+    $action = if (-not $kg.Version) { 'BLOCKED' }
+              elseif ($kg.Version -eq $current) { 'current' }
+              else { 'bump' }
+    [pscustomobject]@{
+        Package   = $id
+        Current   = $current
+        KnownGood = $kg.Version
+        AgeDays   = $kg.Age
+        License   = $kg.License
+        Action    = $action
+        Note      = $kg.Reason
+    }
+}
+
+$rows | Format-Table Package, Current, KnownGood, AgeDays, License, Action -AutoSize | Out-String | Write-Host
+$blocked = @($rows | Where-Object Action -eq 'BLOCKED')
+if ($blocked) { Write-Host "BLOCKED (no known-good version): $($blocked.Package -join ', ')" -ForegroundColor Yellow }
+
+if ($Apply) {
+    foreach ($r in $rows) { if ($r.KnownGood) { $doc.packages.$($r.Package) = $r.KnownGood } }
+    if ($blocked) {
+        Write-Host "`nNOT stamping lastVetted - no known-good version for $($blocked.Package -join ', '); resolve those before claiming a full vet." -ForegroundColor Yellow
+    } else {
+        $doc.policy.lastVetted = (Get-Date).ToString('yyyy-MM-dd')
+    }
+    ($doc | ConvertTo-Json -Depth 8) + "`n" | Set-Content -LiteralPath $VersionsPath -Encoding utf8NoBOM -NoNewline
+    Write-Host "`nApplied to $VersionsPath. Review the diff and commit deliberately." -ForegroundColor Green
+} else {
+    Write-Host "`nReport only. Re-run with -Apply to write versions.json." -ForegroundColor Cyan
+}
+
+if ($SmokeTest) {
+    $scaffold = Join-Path $PSScriptRoot 'New-DotnetRepo.ps1'
+    $cases = @(
+        @{ Name = 'vettool'; WindowsOnly = $false; Args = @('-Archetype', 'tool', '-PackageId', 'VetTool', '-ToolCommandName', 'vettool', '-Description', 'compat probe', '-Owner', 'vet') }
+        @{ Name = 'vetlib';  WindowsOnly = $true;  Args = @('-Archetype', 'multi-target', '-PackageId', 'Vet.Lib', '-Framework', 'net10.0', '-FrameworkLegacy', 'net472', '-Description', 'compat probe', '-Owner', 'vet') }
+    )
+    $smokeFailed = $false
+    foreach ($c in $cases) {
+        if ($c.WindowsOnly -and -not $IsWindows) {
+            Write-Host "`nSmoke test ($($c.Name)) skipped - building net472 needs Windows (or reference-assembly packages)." -ForegroundColor DarkGray
+            continue
+        }
+        $root = Join-Path ([IO.Path]::GetTempPath()) "vet-$($c.Name)-$(Get-Random)"
+        Write-Host "`nSmoke test ($($c.Name)) -> $root" -ForegroundColor White
+        try {
+            $out = & pwsh -NoProfile -File $scaffold -Root $root -Name $c.Name @($c.Args) *>&1
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "  SCAFFOLD FAILED for $($c.Name) (exit $LASTEXITCODE)" -ForegroundColor Red
+                $out | Select-Object -Last 20 | Out-String | Write-Host
+                $smokeFailed = $true
+                continue
+            }
+            Push-Location $root
+            try {
+                $out = & dotnet build -c Release --nologo *>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "  BUILD FAILED for $($c.Name) - the pinned set is not TFM-compatible" -ForegroundColor Red
+                    $out | Select-Object -Last 20 | Out-String | Write-Host
+                    $smokeFailed = $true
+                }
+                else { Write-Host "  OK ($($c.Name) builds on its targeted TFMs)" -ForegroundColor Green }
+            } finally { Pop-Location }
+        } finally {
+            Remove-Item $root -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    if ($smokeFailed) { throw "Smoke test failed: the pinned set did not scaffold and build on every targeted TFM." }
+}

--- a/.agents/skills/engineering-baseline/scripts/template/.gitattributes.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.gitattributes.tmpl
@@ -1,0 +1,2 @@
+# Normalize line endings on check-in so cross-platform clones are consistent.
+* text=auto

--- a/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/bug_report.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/bug_report.md.tmpl
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Report a defect
+labels: bug
+---
+
+**Describe the bug**
+A clear, concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS:
+- .NET version:
+- Package version:

--- a/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/feature_request.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/ISSUE_TEMPLATE/feature_request.md.tmpl
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest a new capability
+labels: enhancement
+---
+
+**Is this related to a problem?**
+A clear, concise description of what the problem is.
+
+**Proposed solution**
+Describe the change you would like to see.
+
+**Alternatives considered**
+Any alternative solutions you have considered.

--- a/.agents/skills/engineering-baseline/scripts/template/.github/PULL_REQUEST_TEMPLATE.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/PULL_REQUEST_TEMPLATE.md.tmpl
@@ -1,0 +1,17 @@
+## Summary
+
+*Describe what this PR does and why.*
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] `dotnet build -c Release` passes
+- [ ] `dotnet test -c Release` passes
+- [ ] New public surface has tests
+
+## Related issues
+
+Fixes #

--- a/.agents/skills/engineering-baseline/scripts/template/.github/dependabot.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/dependabot.yml.tmpl
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Collapse every NuGet update into ONE grouped PR so the repo never opens a
+    # long list of individual bump PRs (day one or later).
+    groups:
+      nuget:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    # Collapse every GitHub Actions update into ONE grouped PR (same reason).
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/agent-files.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/agent-files.yml.tmpl
@@ -1,0 +1,25 @@
+name: Agent files
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  mirror-check:
+    name: copilot-instructions mirror
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+
+      - name: Verify .github/copilot-instructions.md mirrors AGENTS.md
+        shell: pwsh
+        run: ./tools/Sync-AgentInstructions.ps1 -Check

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/ci.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/ci.yml.tmpl
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: build
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/cache@<SHA> # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('**/Directory.Packages.props', '**/Directory.Build.props', 'global.json') }}
+          restore-keys: nuget-
+
+      - uses: actions/setup-dotnet@<SHA> # v5.3.0
+        # SDK version comes from global.json
+
+      - run: dotnet restore --locked-mode
+      - run: dotnet build --configuration ${{ matrix.configuration }} --no-restore
+      # The global.json MTP runner treats --no-build as a test-app argument and
+      # exits 5 with zero tests. CI=true keeps this implicit restore locked.
+      - run: dotnet test --configuration ${{ matrix.configuration }}

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/codeql.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/codeql.yml.tmpl
@@ -1,0 +1,25 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '17 4 * * 1'   # weekly Monday scan
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<SHA> # v6.0.3
+      - uses: github/codeql-action/init@<SHA> # v4.36.2
+        with:
+          languages: csharp
+      - uses: github/codeql-action/autobuild@<SHA> # v4.36.2
+      - uses: github/codeql-action/analyze@<SHA> # v4.36.2

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/publish.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/publish.yml.tmpl
@@ -1,0 +1,47 @@
+name: publish
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: pack and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # OIDC trusted publishing
+    steps:
+      - name: Validate SemVer tag
+        shell: bash
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Tag '${GITHUB_REF_NAME}' is not a valid SemVer tag." && exit 1
+          fi
+
+      - uses: actions/checkout@<SHA> # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@<SHA> # v5.3.0
+
+      - run: dotnet restore --locked-mode
+      - run: dotnet pack src/{{NAME}}/{{NAME}}.csproj --configuration Release --no-restore --output artifacts/packages
+
+      # Exchange the workflow OIDC token for a short-lived NuGet API key.
+      # Requires a trusted-publishing policy registered on nuget.org (see the
+      # remote setup checklist the scaffold script prints).
+      - name: Authenticate to NuGet
+        id: nuget-login
+        uses: NuGet/login@<SHA> # v1.2.0
+        with:
+          user: {{OWNER}}
+
+      - run: >
+          dotnet nuget push artifacts/packages/*.nupkg
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/.agents/skills/engineering-baseline/scripts/template/AGENTS.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/AGENTS.md.tmpl
@@ -1,0 +1,32 @@
+# Agent guidance for {{NAME_TITLE}}
+
+<!--
+Single source of truth for AI agent instructions. After editing this file, run
+tools/Sync-AgentInstructions.ps1 to regenerate the mirror
+.github/copilot-instructions.md; do not edit the mirror directly. CI
+(agent-files.yml) verifies the two stay in sync.
+-->
+
+## Project overview
+
+{{DESCRIPTION}}
+
+**Archetype:** {{ARCHETYPE}} | **Target frameworks:** {{FRAMEWORKS_DISPLAY}}
+
+## Repository layout
+
+| Directory | Purpose |
+| --------- | ------- |
+| `src/{{NAME}}/` | Main project |
+| `tests/{{NAME}}.tests/` | Tests |
+
+## Build and test
+
+```shell
+dotnet build
+dotnet test -c Release
+```
+
+## Conventions
+
+*TODO: document coding style, naming, and design conventions.*

--- a/.agents/skills/engineering-baseline/scripts/template/CODE_OF_CONDUCT.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/CODE_OF_CONDUCT.md.tmpl
@@ -1,0 +1,9 @@
+# Contributor Covenant Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+We pledge to make participation in our community a harassment-free experience for everyone.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+project maintainer at the email address listed in the project's GitHub profile.

--- a/.agents/skills/engineering-baseline/scripts/template/CONTRIBUTING.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/CONTRIBUTING.md.tmpl
@@ -1,0 +1,24 @@
+# Contributing to {{NAME_TITLE}}
+
+Thanks for your interest in contributing!
+
+## Getting started
+
+```shell
+git clone {{REPO_URL}}
+cd {{NAME}}
+dotnet build
+dotnet test
+```
+
+## Submitting changes
+
+1. Fork the repository and create a branch from `main`.
+2. Make your changes and add or update tests.
+3. Ensure `dotnet build` and `dotnet test` both pass in Release.
+4. Open a pull request against `main`.
+
+## License
+
+By submitting a pull request you agree that your contribution is licensed under
+the [{{LICENSE}} license](LICENSE) that governs this project.

--- a/.agents/skills/engineering-baseline/scripts/template/Directory.Build.props.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/Directory.Build.props.tmpl
@@ -1,0 +1,76 @@
+<Project>
+
+  <PropertyGroup Label="Target frameworks">
+    <MainTfm>{{FRAMEWORK}}</MainTfm>{{LEGACY_TFM_LINE}}
+  </PropertyGroup>
+
+  <PropertyGroup Label="Output layout">
+    <!-- Keep all build output under a single top-level artifacts/ directory. -->
+    <ArtifactsDir>$(MSBuildThisFileDirectory)artifacts\</ArtifactsDir>
+    <BaseOutputPath>$(ArtifactsDir)bin\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(ArtifactsDir)obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Language and analysis">
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!--
+      NuGet audit advisories (NU190x) warn but must not block an otherwise green
+      build; a newly published advisory should not break CI until the bump lands.
+    -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>Recommended</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Deterministic build">
+    <Deterministic>true</Deterministic>
+    <!--
+      GitHub Actions sets CI=true; enables deterministic source-path
+      normalization in PDBs so the package is reproducible.
+    -->
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Supply chain">
+    <!--
+      Commit packages.lock.json so the full dependency graph (including
+      transitives, where compromises usually hide) is pinned; CI restores in
+      locked mode to fail on any drift.
+    -->
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <RestoreLockedMode Condition="'$(CI)' == 'true'">true</RestoreLockedMode>
+    <!--
+      Audit direct AND transitive packages against the GitHub Advisory DB on
+      every restore (NU1901-1904). Kept as warnings via WarningsNotAsErrors so
+      a newly disclosed advisory surfaces without breaking the build.
+    -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package metadata (shared)">
+    <Authors>{{OWNER}}</Authors>
+    <Copyright>Copyright (c) {{YEAR}} {{OWNER}} and contributors</Copyright>
+    <PackageLicenseExpression>{{LICENSE}}</PackageLicenseExpression>
+    <PackageProjectUrl>{{REPO_URL}}</PackageProjectUrl>
+    <RepositoryUrl>{{REPO_URL}}</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <!--
+      Source Link embeds the exact commit in the PDB so debuggers can fetch
+      source on demand.
+    -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Documentation">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+</Project>

--- a/.agents/skills/engineering-baseline/scripts/template/Directory.Build.targets.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/Directory.Build.targets.tmpl
@@ -1,0 +1,12 @@
+<Project>
+
+  <!--
+    MinVer derives the package version from the nearest git tag.
+    Create a tag "v0.1.0" to release; CI produces "0.1.0-alpha.0.N" until then.
+    See https://github.com/adamralph/minver
+  -->
+  <PropertyGroup>
+    <MinVerTagPrefix Condition="'$(MinVerTagPrefix)' == ''">v</MinVerTagPrefix>
+  </PropertyGroup>
+
+</Project>

--- a/.agents/skills/engineering-baseline/scripts/template/Directory.Packages.props.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/Directory.Packages.props.tmpl
@@ -1,0 +1,17 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <!--
+    Central Package Management pins one version per package for every project.
+    Dependabot (.github/dependabot.yml) proposes updates; review and merge them
+    deliberately.
+  -->
+  <ItemGroup>
+{{PACKAGE_VERSIONS}}
+  </ItemGroup>
+
+</Project>

--- a/.agents/skills/engineering-baseline/scripts/template/LICENSE.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/LICENSE.tmpl
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) {{YEAR}} {{OWNER}} and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/engineering-baseline/scripts/template/README.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/README.md.tmpl
@@ -1,0 +1,15 @@
+# {{NAME_TITLE}}
+
+{{DESCRIPTION}}
+
+## Installation
+
+{{INSTALL_COMMAND}}
+
+## Usage
+
+*TODO: add usage examples.*
+
+## License
+
+[{{LICENSE}}](LICENSE)

--- a/.agents/skills/engineering-baseline/scripts/template/SECURITY.md.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/SECURITY.md.tmpl
@@ -1,0 +1,15 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Report privately via GitHub Security Advisories:
+[https://github.com/{{OWNER}}/{{NAME}}/security/advisories/new](https://github.com/{{OWNER}}/{{NAME}}/security/advisories/new)
+
+We aim to acknowledge reports within 5 business days and provide a patch or
+mitigation plan within 90 days.
+
+## Supported versions
+
+Only the latest release receives security fixes.

--- a/.agents/skills/engineering-baseline/scripts/template/global.json.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/global.json.tmpl
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "{{SDK_VERSION}}",
+    "rollForward": "disable",
+    "allowPrerelease": {{ALLOW_PRERELEASE}}
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/.agents/skills/engineering-baseline/scripts/template/nuget.config.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/nuget.config.tmpl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--
+      Clear inherited sources so the build only ever resolves from nuget.org,
+      regardless of machine-level NuGet configuration.
+    -->
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <!--
+    Source mapping pins every package id to nuget.org. This is the primary
+    defense against dependency-confusion: a package can never be silently
+    served from an unexpected feed.
+  -->
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/.agents/skills/engineering-baseline/scripts/template/tools/Sync-AgentInstructions.ps1.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/tools/Sync-AgentInstructions.ps1.tmpl
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+    Keeps .github/copilot-instructions.md in sync with AGENTS.md.
+
+.DESCRIPTION
+    AGENTS.md is the single source of truth for agent instructions. GitHub Copilot
+    reads .github/copilot-instructions.md, so this script regenerates that file as
+    a mirror with a "do not edit" header.
+
+    Default: rewrite the mirror from AGENTS.md. With -Check: verify only and fail
+    if the mirror is missing or stale (used by the agent-files CI workflow);
+    nothing is written in -Check mode.
+
+.PARAMETER Check
+    Verify the mirror is current without modifying it. Fails on drift.
+
+.EXAMPLE
+    ./tools/Sync-AgentInstructions.ps1
+    Regenerate the mirror after editing AGENTS.md.
+
+.EXAMPLE
+    ./tools/Sync-AgentInstructions.ps1 -Check
+    Fail if the mirror is out of date (CI).
+#>
+
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [switch] $Check
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# tools/ sits one level under the repository root.
+$repoRoot = Split-Path $PSScriptRoot -Parent
+$source   = Join-Path $repoRoot 'AGENTS.md'
+$mirror   = Join-Path $repoRoot '.github/copilot-instructions.md'
+
+if (-not (Test-Path $source)) { throw "Source not found: $source" }
+
+# The expected mirror is a do-not-edit header over the verbatim source. Line
+# endings are normalized to LF so the check is stable across platforms and the
+# `* text=auto` .gitattributes policy.
+$header   = '<!-- DO NOT EDIT. Generated mirror of /AGENTS.md. -->'
+$body     = (Get-Content -LiteralPath $source -Raw) -replace "`r`n", "`n"
+$expected = "$header`n$body"
+
+if ($Check) {
+    $current = if (Test-Path $mirror) { (Get-Content -LiteralPath $mirror -Raw) -replace "`r`n", "`n" } else { '' }
+    if ($current -ne $expected) {
+        throw "'.github/copilot-instructions.md' is out of sync with AGENTS.md. Run tools/Sync-AgentInstructions.ps1 and commit the result."
+    }
+    Write-Host '.github/copilot-instructions.md is in sync with AGENTS.md.'
+    return
+}
+
+New-Item -ItemType Directory (Split-Path $mirror -Parent) -Force | Out-Null
+Set-Content -LiteralPath $mirror -Value $expected -Encoding utf8NoBOM -NoNewline
+Write-Host 'Regenerated .github/copilot-instructions.md from AGENTS.md.'

--- a/.agents/skills/engineering-baseline/scripts/versions.json
+++ b/.agents/skills/engineering-baseline/scripts/versions.json
@@ -1,0 +1,22 @@
+{
+  "policy": {
+    "minimumReleaseAgeDays": 30,
+    "allowedLicenses": [
+      "MIT",
+      "Apache-2.0",
+      "BSD-2-Clause",
+      "BSD-3-Clause",
+      "MS-PL"
+    ],
+    "source": "https://api.nuget.org/v3/index.json",
+    "lastVetted": "2026-07-04",
+    "note": "Pinned, vetted versions for scaffolded repos. Do not edit versions by hand - run scripts/Update-ScaffoldVersions.ps1, review the diff, then commit. New projects start from this known-good floor, never from 'latest'."
+  },
+  "packages": {
+    "MinVer": "7.0.0",
+    "Microsoft.SourceLink.GitHub": "10.0.300",
+    "MSTest": "4.2.3",
+    "xunit.v3": "3.2.2",
+    "xunit.runner.visualstudio": "3.1.5"
+  }
+}

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -1,0 +1,159 @@
+---
+compatibility: Requires a .NET SDK that can build both modern .NET and .NET Framework targets; measurements use BenchmarkDotNet.
+description: Optimize hot-path code for the `net481` (.NET Framework) target in a multi-targeted library's Framework-only sources. Use when writing or reviewing performance-sensitive loops, deciding whether to specialize a generic method for primitive types, choosing between scalar/unrolled/BCL-delegating implementations, or diagnosing why a net481 micro-benchmark regresses on the older RyuJIT. Also covers the modern .NET (net10) counterpart - vectorization, hardware intrinsics, struct-generic kernels, JIT-friendly shapes - and the cross-TFM codegen fundamentals shared by both targets (arithmetic and branchless lowering, struct layout, zero-allocation static data, hot-path allocation anti-patterns). For BenchmarkDotNet harness mechanics (authoring/running benchmarks, evaluating allocations) see the `performance-testing` skill.
+license: MIT
+metadata:
+    applicability: dotnet-framework
+    binding: optional-overlay
+    github-path: skills/framework-jit-optimization
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 1523bdc712c82636a88605ecf3f31b95308a0e39
+    maturity: canary
+    portability: portable
+    related: performance-testing, scratch-buffer-strategy, pre-pr-self-review
+    requires: none
+    risk: local-write
+name: framework-jit-optimization
+---
+
+# .NET Framework 4.8.1 JIT optimization
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+A multi-targeted library targets `net481` in addition to modern .NET. Code in the
+Framework-only source tree (the `Framework/` subtree by convention, excluded from
+the modern build) only ever runs on the older RyuJIT. Treat `net481` as a separate
+optimization target with its own rules.
+
+This skill captures decisions distilled from real BenchmarkDotNet experiments in
+the repo's perf project (`<root>.perf` by convention). The deep span-walking
+field manual is bundled alongside this skill in
+[references/framework-span-performance.md](references/framework-span-performance.md).
+
+Always validate with the `performance-testing` skill workflow before committing a
+change, and run the `pre-pr-self-review` checklist before opening a PR - in
+particular its framework-correctness items (allocation-free over raw speed; perf
+claims must name the JIT and be measured) apply directly to changes guided by this
+skill.
+
+For the broader "how do I polyfill API X for net472?" question (which packages to
+prefer, when to hand-roll), see the `polyfill-dotnet-api` skill. This skill picks
+up after that decision is already made and the polyfill lives in the Framework-only
+tree.
+
+For choosing how a hot path gets its scratch buffer (zeroed `stackalloc` vs
+`[SkipLocalsInit]` vs a stack-with-pool-fallback buffer vs an `ArrayPool` rental,
+and the net481/net10 size crossovers), see the `scratch-buffer-strategy` skill.
+
+The net481 rules below have two companions. What the **modern target enables** that
+net481 does not (vectorization, hardware intrinsics, struct-generic kernels, and the
+JIT-friendly shapes you should *not* hand-tune away) is in
+[modern-net.md](modern-net.md). The codegen fundamentals that hold on **both**
+targets (arithmetic and branchless lowering, `uint`-for-non-negative, struct layout,
+zero-allocation static data, hot-path allocation anti-patterns) are in
+[cross-tfm-codegen.md](cross-tfm-codegen.md).
+
+A consuming repository wires the concrete cross-skill links and source-tree paths
+in its overlay.
+
+## What is and isn't available on `net481`
+
+- **No auto-vectorization.** The BCL `MemoryExtensions` methods on net481 ship with
+  System.Memory. They are hand-tuned scalar / integer-stride implementations -
+  they do **not** use SIMD.
+- **No `System.Runtime.Intrinsics`.** `Vector128`/`Vector256`/`Vector512`,
+  `Sse2.CompareEqual`, `Avx2.MoveMask` are .NET 5+. Not available here.
+- **No tiered JIT or PGO.** What you write is what gets compiled, once.
+- **`Vector<T>` from `System.Numerics.Vectors`** technically exists but does not
+  auto-vectorize equality-replace loops on the older JIT, and per-load/store
+  overhead loses to a plain unrolled scalar loop at typical sizes.
+- **No source-level loop alignment** controls.
+
+"Integer-stride" means routines like `IndexOf` and `SequenceEqual` internally
+process multiple elements per loop step (e.g. compare a `ulong` chunk that spans
+4 chars or 8 bytes) rather than one element at a time. This is **not**
+vectorization - just careful scalar code - but it still substantially
+beats a naive per-element loop for whole-buffer primitives.
+
+**Practical consequence:** do not assume "the BCL is vectorized so my generic code
+is fine." On `net481` a hand-written specialized loop frequently beats the BCL by
+2-3&times; for full-scan workloads.
+
+## Decision flow for a new framework-only fast path
+
+1. Start with the simplest possible scalar loop and measure it as the baseline.
+   Capture the baseline on **both** `net10.0` and `net481` before editing, and
+   keep the full BenchmarkDotNet rows (`Mean`/`Error`/`StdDev`/`Allocated`), not
+   a one-line summary - see the before/after discipline in the
+   `performance-testing` skill. EventPipe line
+   profiling is net10-only, but every change still has to be re-measured on
+   net481 overall.
+2. Decide whether to specialize. See [specialization.md](specialization.md) for the
+   `typeof(T)` pattern and primitive equivalence classes.
+3. Decide whether to defer to a BCL primitive. See
+   [bcl-tradeoffs.md](bcl-tradeoffs.md) for the visit-most-vs-skip-runs rule.
+4. If specializing, add `[MethodImpl(MethodImplOptions.AggressiveInlining)]` on the
+   generic entry point. The `net481` JIT's default heuristics are conservative;
+   small specialized loops often will not inline without it.
+5. If the loop is the hot path, unroll by 4 with indexed reads + bulk pointer
+   increment. See [unrolling.md](unrolling.md) for the right form (and the wrong
+   ones).
+6. **Stop there.** Do not pursue SIMD, SWAR, or branchless tricks without data
+   showing they win - in practice they regress more often than they help.
+   See [antipatterns.md](antipatterns.md).
+7. Run the same benchmark on `net10.0` to confirm you have not regressed the
+   modern path. If a specialization is harmful on net10 (because the BCL is
+   actually vectorized there), guard it with `#if NETFRAMEWORK` so only `net481`
+   gets the loop.
+8. Report both TFMs' before/after tables together, and confirm the targeted hot
+   line/method from the net10 trace actually shrank (e.g. `System.Array.Copy`
+   self-time dropping). A faster `Mean` with the targeted frame unchanged is
+   usually noise or an unrelated win.
+
+## Quick reference: ratios from real benchmarks
+
+All numbers are from the smoke benchmarks in the repo's perf project. Treat as
+order-of-magnitude, not exact - rerun before claiming a specific number in
+a PR.
+
+| Decision | Net481 effect (length 4096, full scan) |
+| --- | --- |
+| `typeof(T)` specialization vs generic `IEquatable` loop | 1.42&times; faster |
+| `[AggressiveInlining]` on a tight scalar loop (length 16) | 1.82&times; &rarr; 1.07&times; vs baseline |
+| Unroll-4 indexed (`ptr[0..3]` + `ptr += 4`) | 1.5&times; faster than scalar |
+| Unroll-8 same form | **1.6&times; slower** than scalar at 256+ |
+| Per-iteration `*ptr; ptr++` instead of indexed reads | ~1.4&times; slower than indexed |
+| Integer-indexed unroll (`ptr[i+0..3]; i += 4`) | **Worse than the scalar baseline** |
+| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5-3&times; slower** than branchful conditional store |
+| SWAR haszero for char `Replace` (dense matches) | **3&times; slower** than scalar |
+| BCL `IndexOf` for `Replace` (full-scan) | 2.18-3.08&times; slower than specialized scalar |
+| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2-3&times; **faster** than full-scan specialization |
+| Exponential `SequenceEqual` probe for `CommonPrefixLength` (4096, full match) | 3.3&times; faster than per-element scalar |
+| Tuple swap `(a, b) = (b, a)` for plain locals | **~23% slower** than `T t = a; a = b; b = t;` |
+| Tuple swap on paired `Span<T>` indexed swap (sort hot path) | **~9% slower** than explicit temps |
+| Tuple swap on a single `Span<T>` indexed swap or two `ref` locals | Equivalent (within noise) |
+
+The two BCL rows look contradictory. They aren't. See
+[bcl-tradeoffs.md](bcl-tradeoffs.md).
+
+## Sub-pages
+
+- [specialization.md](specialization.md) - `typeof(T)` pattern, `Unsafe.As`,
+  primitive bit-equality classes, when generic methods get inlined.
+- [unrolling.md](unrolling.md) - the only unroll form that wins on `net481`,
+  and three that don't.
+- [bcl-tradeoffs.md](bcl-tradeoffs.md) - when to defer to BCL `IndexOf` /
+  `SequenceEqual` on `net481` despite no vectorization.
+- [antipatterns.md](antipatterns.md) - specific tricks that look clever but
+  regress on the older JIT.
+- [modern-net.md](modern-net.md) - the `net10` counterpart: BCL-first
+  (`SearchValues`/`TensorPrimitives`), the canonical vectorized loop, hardware
+  intrinsics, struct-generic kernels, sealing/devirtualization, escape analysis,
+  and why to keep the modern source simple.
+- [cross-tfm-codegen.md](cross-tfm-codegen.md) - fundamentals for both targets:
+  division/modulo lowering, `uint`-for-non-negative, `BitOperations`, struct field
+  ordering, AoS->SoA, false sharing, `ReadOnlySpan<byte>` blobs, `[InlineArray]`,
+  `const`-vs-`static readonly`, and hot-path allocation anti-patterns.

--- a/.agents/skills/framework-jit-optimization/antipatterns.md
+++ b/.agents/skills/framework-jit-optimization/antipatterns.md
@@ -1,0 +1,120 @@
+# Anti-patterns on `net481`
+
+Tricks that look clever, are documented elsewhere as wins, and **regress** on
+the older RyuJIT. Don't try them without benchmark data showing they win for
+your specific call pattern.
+
+## Branchless conditional store
+
+```c#
+// BAD on net481 for sparse matches.
+*ptr = *ptr == oldShort ? newShort : *ptr;
+```
+
+The `net481` JIT does not lower the ternary into a `cmov` for `ushort` / `byte`
+stores. You get a guaranteed store every iteration regardless of whether the
+value changed. For a sparse-match `Replace` workload (the realistic case), the
+extra writes cost 1.5-3&times; vs the branchful form below.
+
+```c#
+// GOOD on net481.
+ushort v = *ptr;
+if (v == oldShort) *ptr = newShort;
+ptr++;
+```
+
+The branch predictor handles "almost never matches" extremely well. Real-world
+`Replace` calls are usually sparse, so the branchful form wins.
+
+**On `net10`** the branchless form is roughly tied or slightly better. If you
+want a single shape, prefer branchful: it's the safer choice for the older JIT
+and not measurably worse on the newer one.
+
+## Copy-replace exception
+
+For methods that **always store to a separate destination buffer** (e.g.
+`ReadOnlySpan<T>.Replace(Span<T> destination, T, T)`), every destination slot
+must be written either way. The right form there is "always copy, then
+conditionally overwrite":
+
+```c#
+ushort i0 = src[0]; ushort i1 = src[1]; ushort i2 = src[2]; ushort i3 = src[3];
+dst[0] = i0; dst[1] = i1; dst[2] = i2; dst[3] = i3;
+if (i0 == oldShort) dst[0] = newShort;
+if (i1 == oldShort) dst[1] = newShort;
+if (i2 == oldShort) dst[2] = newShort;
+if (i3 == oldShort) dst[3] = newShort;
+```
+
+Same conclusion (avoid the JIT's poorly-lowered ternary over `ushort` / `byte`),
+different surface form because the copy can't be avoided.
+
+## SWAR haszero scan over a `ulong` window
+
+```c#
+// BAD: regresses by up to 3x on dense matches.
+const ulong Lo16 = 0x0001_0001_0001_0001UL;
+const ulong Hi16 = 0x8000_8000_8000_8000UL;
+ulong oldBcast = (ulong)oldShort * Lo16;
+
+while (ptr < unrollEnd)
+{
+    ulong word = *(ulong*)ptr;
+    ulong x = word ^ oldBcast;
+    ulong has = (x - Lo16) & ~x & Hi16;
+    if (has != 0)
+    {
+        if (ptr[0] == oldShort) ptr[0] = newShort;
+        if (ptr[1] == oldShort) ptr[1] = newShort;
+        if (ptr[2] == oldShort) ptr[2] = newShort;
+        if (ptr[3] == oldShort) ptr[3] = newShort;
+    }
+    ptr += 4;
+}
+```
+
+The bit-trick (`(x - Lo16) & ~x & Hi16`) adds a dependent-chain of 3 arithmetic
+ops per chunk, plus a load and an XOR, plus the broadcast computation. **Whenever
+any lane matches, the code falls through to the four scalar checks** - you
+pay the SWAR overhead **on top of** the mutation cost. On dense matches this
+regresses by 3&times;.
+
+The classic strchr-style SWAR optimization makes sense in C without true SIMD;
+on `net481` it does not pay back its overhead even for sparse data, because the
+`net481` JIT keeps the bit-trick in a long dependency chain rather than
+parallelizing the arithmetic with the scalar reads.
+
+## Replacing BCL `IndexOf` with a scalar specialization for sparse search
+
+See [bcl-tradeoffs.md](bcl-tradeoffs.md). The rule cuts both ways - full
+scan favors specialization, sparse search favors the BCL. Don't apply one half
+without the other.
+
+## Unroll by 8 (and beyond)
+
+See [unrolling.md](unrolling.md). Unroll-8 wins at length 16 and regresses at
+length 256+ on `net481`. Stick to unroll-4 unless you have measurements showing
+the larger unroll is worth it for *your specific size distribution*.
+
+## Stripping `[MethodImpl(MethodImplOptions.AggressiveInlining)]` "for code size"
+
+The attribute looks like a non-functional hint, but on `net481` it's load-bearing.
+A small specialized loop that doesn't get inlined into its caller becomes a
+JIT-time call, defeating the entire `typeof(T)` specialization (because the
+caller now invokes a generic stub through a virtual dispatch mechanism the
+specialization was meant to elide). Measured: 1.82&times; &rarr; 1.07&times; on
+a tight scalar loop at length 16 just from adding the attribute back.
+
+If you really must remove it (e.g. method body becomes too large), measure
+before and after. Don't strip it because "the method is short anyway, the JIT
+will inline it" - on `net481` the JIT often won't.
+
+## `Vector<T>` from `System.Numerics.Vectors` "for portable SIMD"
+
+It exists on `net481`. It does not auto-vectorize equality-replace loops on
+the older JIT, and per-load/store overhead loses to a plain unrolled scalar
+loop at typical sizes (16-4096). Don't reach for it unless you've
+benchmarked it for your specific shape and seen a win.
+
+True SIMD on `net481` requires `System.Runtime.Intrinsics`, which is .NET 5+
+only. Out of scope here.

--- a/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
+++ b/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
@@ -1,0 +1,124 @@
+# BCL trade-offs on `net481`
+
+The System.Memory primitives `IndexOf` and `SequenceEqual` are not vectorized on
+`net481`, but they're not naive per-element loops either. They use
+**integer-stride scalar tricks** - comparing `ulong`-sized chunks (4 chars
+or 8 bytes at a time) with bit operations. This makes the choice between
+"specialize my own loop" and "lean on the BCL" non-obvious.
+
+## Decision rule
+
+> Specialize when your loop visits most elements.
+> Defer to the BCL primitive when the realistic input lets it skip large runs cheaply.
+
+The decision is about **the realistic input distribution**, not the worst case.
+A method that's used to scan dense data should specialize; a method that's used
+to find sparse markers in mostly-irrelevant data should defer.
+
+## Cases where specializing wins (full-scan workloads)
+
+The hot loop visits every element. The BCL primitive's per-call overhead and
+slightly less aggressive unrolling lose to a hand-written `ushort*` /
+`byte*` loop with the unroll-4 form.
+
+| Method | Realistic input | Win factor (length 4096) |
+| --- | --- | --- |
+| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18-3.08&times; faster than `IndexOf`-walking |
+| `IndexOfAnyExcept(T)` | typically scans most of the buffer (e.g. trim, parse) | 0.34&times; vs scalar = 3&times; faster |
+
+These are the methods that already have `typeof(T)` specialization in the
+Framework-only tree.
+
+## Cases where deferring to the BCL wins (skip-run / log-probe workloads)
+
+The hot loop **doesn't** visit every element - the BCL's stride trick
+skips long non-match runs faster than per-element compares can advance.
+
+### `Count(T)` via repeated `IndexOf` slicing
+
+```c#
+public int Count(T value)
+{
+    ReadOnlySpan<T> remaining = span;
+    int count = 0;
+    int index;
+    while ((index = remaining.IndexOf(value)) >= 0)
+    {
+        count++;
+        remaining = remaining[(index + 1)..];
+    }
+
+    return count;
+}
+```
+
+Measured ratios vs a full-scan `ushort*` unroll-4 specialization on `net481`:
+
+| Match density (1 in N) | BCL `IndexOf`-walk vs specialized |
+| ---: | --- |
+| 1   | **9&times; slower** (specialization wins) |
+| 7   | 1.85&times; slower (specialization still wins) |
+| 64  | **0.45&times; slower** (BCL wins) |
+
+Realistic `Count` calls are sparse (counting newlines in source, separators in a
+path, error markers in a log line). The BCL form is correct.
+
+### Exponential `SequenceEqual` probe for `CommonPrefixLength`
+
+```c#
+int matched = 0;
+int probe = 16;
+while (matched + probe <= length
+    && span.Slice(matched, probe).SequenceEqual(other.Slice(matched, probe)))
+{
+    matched += probe;
+    if (probe < 1024)
+    {
+        probe *= 2;
+    }
+}
+
+// Scalar tail for the last < probe elements.
+for (int i = matched; i < length; i++) { /* ... */ }
+return length;
+```
+
+`O(log n)` BCL calls instead of `O(n)` element compares. At length 4096 with a
+full match this beats any scalar loop by **3.3&times;** even on `net481`.
+
+The early-divergence case (mismatch at index 8) is roughly tied with a scalar
+specialization - absolute saving is ~8 ns - not worth a 3.3&times;
+regression on the long-prefix case (path normalization, string interning,
+sorted-key compression are the realistic callers).
+
+## How to decide for a new method
+
+1. Identify the hottest call pattern. What does the input usually look like?
+   Dense or sparse matches? Long shared prefixes or short ones? Full scan or
+   early exit?
+2. Write **both** versions. Don't guess.
+3. Benchmark with `[Params]` covering the realistic range plus the dense /
+   worst case at the extreme. A `MatchEvery` / `Diverge` param pair (match
+   density and divergence point) is a good template.
+4. Pick the form whose worst case on the realistic distribution is best,
+   not the form whose absolute peak is best.
+
+## What about both?
+
+It's tempting to combine the two: short-circuit with a BCL `IndexOf` to skip
+forward, then specialize the tight inner loop. **Don't do this without
+measurement.** The branch on whether the BCL primitive returned `< 0` adds
+overhead, and you lose the simple unrolled body. The cases above all picked
+either-or; we have no benchmark showing a hybrid wins.
+
+## Reference benchmarks
+
+The numbers above were measured with local BenchmarkDotNet harnesses that are not
+check-in artifacts; reproduce them in the repo's perf project when revisiting a
+decision:
+
+- A `Count` / `CommonPrefixLength` benchmark over `MatchEvery = 1, 7, 64` and
+  `Diverge = 0, 8, full` - the skip-run / log-probe workloads where deferring
+  to the BCL wins.
+- A full-scan `Span<T>.Replace` benchmark - the workload where specialization
+  wins.

--- a/.agents/skills/framework-jit-optimization/cross-tfm-codegen.md
+++ b/.agents/skills/framework-jit-optimization/cross-tfm-codegen.md
@@ -1,0 +1,141 @@
+# Cross-TFM codegen: arithmetic, layout, allocation
+
+Techniques that apply to **both** targets - they are about the C# compiler and the
+shared codegen rules, not a specific RyuJIT version. The net481-vs-net10 split pages
+(this skill's [unrolling.md](unrolling.md), [bcl-tradeoffs.md](bcl-tradeoffs.md),
+[references/framework-span-performance.md](references/framework-span-performance.md))
+and the net10-enablement page ([modern-net.md](modern-net.md)) sit on top of these
+fundamentals.
+
+Where a topic is already covered elsewhere this page only points at it - it does not
+repeat it.
+
+## 1. Arithmetic the JIT shapes for you - and when it can't
+
+- **Division/modulo by a compile-time constant is already fast.** The JIT replaces
+  `x / 10` (literal `10`) with a multiply-by-reciprocal + shift. The trap is a
+  **runtime** divisor: `x / divisor` is a real `idiv` (20-90+ cycles, not
+  pipelined). If the divisor is reused across many values, hoist the division out of
+  the loop or precompute a reciprocal.
+- **Power-of-two: type non-negative quantities `uint`/`nuint`.** For unsigned
+  values the JIT lowers `x / 2^k` to `>> k` and `x % 2^k` to `& (2^k - 1)`. For
+  **signed** values it must emit a sign-correction sequence (`x % 8` on a possibly
+  negative `int` is *not* `x & 7`). Lengths, counts, indices, and hashes are
+  non-negative by construction - typing them `uint`/`nuint` gets the single-
+  instruction `/`, `%`, `>>` and documents the invariant. (For an open-addressed
+  table or ring buffer, force a power-of-two capacity and write `index & (capacity -
+  1)` yourself - far cheaper than `% capacity`.)
+- **`Math.DivRem` for quotient + remainder** in one division instead of computing
+  `x / y` and `x % y` separately. **`Math.BigMul`** for the full 64x64->128 (or
+  32x32->64) product without manual hi/lo juggling. Where the repo polyfills these for
+  the Framework target, prefer the helper over a hand-rolled equivalent.
+- **`unchecked` hot numeric kernels** where overflow is impossible or intended to
+  wrap; a `checked` context adds a `jo` per op. Do not disable checks where they
+  catch real bugs.
+
+## 2. Bit manipulation: use the intrinsic helper, not bit-twiddling
+
+`System.Numerics.BitOperations` maps to dedicated instructions with a software
+fallback: `PopCount` (`POPCNT`), `LeadingZeroCount`/`Log2` (`LZCNT`),
+`TrailingZeroCount` (`TZCNT`), `RotateLeft`/`RotateRight` (the JIT also *recognizes*
+the `(x << n) | (x >> (w-n))` idiom and folds it), `IsPow2`, `RoundUpToPowerOf2`.
+Never hand-roll these. On `net10` it is in the BCL; on the Framework target it is
+not - use the repo's polyfill if present rather than open-coding the bit tricks. The
+branchless identities are still worth knowing because they feed bitset iteration:
+`x & (x - 1)` clears the lowest set bit, `x & -x` isolates it.
+
+## 3. Branchless: branchful is the cross-TFM-safe default
+
+For an *unpredictable* condition on `net10`, a ternary may lower to `cmov` and a
+per-element vector conditional to `Vector256.ConditionalSelect` (a branchless
+clamp/select/ReLU). **But on `net481` the JIT frequently does not emit `cmov` for
+`ushort`/`byte` stores** - see [antipatterns.md](antipatterns.md) - so a branchless
+rewrite there guarantees a store every iteration and regresses on sparse data. The
+branch predictor handles "almost never matches" extremely well. **Prefer the
+branchful form**: it wins on `net481` and is not measurably worse on `net10`. Only
+go branchless behind a `#if NET` guard with a measured win. A *predictable* branch
+(error paths, `IsSupported` checks) is nearly free - leave it branched.
+
+## 4. Memory layout (data layout, both TFMs)
+
+- **Order struct fields largest-to-smallest.** A `struct` defaults to
+  `LayoutKind.Sequential`, so declaration order is memory order and the runtime pads
+  for alignment. `{ byte; long; int }` is 24 bytes; `{ long; int; byte }` is 16.
+  Smaller hot structs mean more per 64-byte cache line and fewer misses. (A `class`
+  is `LayoutKind.Auto` - the runtime packs it; you cannot and need not reorder.)
+- **`readonly struct` + `readonly` members to avoid defensive copies.** Calling a
+  non-`readonly` member on a `readonly` field, an `in` parameter, or a `static
+  readonly` value forces the compiler to copy the whole struct first. A
+  defensive-copy analyzer (and the post-build IL-copy-inspection skill) catches
+  these; the fix is always to make the type and its members `readonly`.
+- **AoS -> SoA when you process one field across many elements.** An array of
+  `struct Particle { float X, Y, Z, ... }` strides `X` by `sizeof(Particle)` and
+  wastes bandwidth pulling whole structs through cache; separate `float[] X, Y, Z`
+  is contiguous (16 `X`s per line) and is the layout that lets the `net10` vectorizer
+  ([modern-net.md](modern-net.md)) touch it at all. A structural decision - make it
+  before writing the kernel.
+- **False sharing** in parallel code: two threads writing two different variables
+  that share a 64-byte line ping-pong the line between cores; the symptom is a
+  parallel loop that scales *negatively*. Pad genuinely-contended hot counters onto
+  their own line (`[StructLayout(LayoutKind.Explicit, Size = 128)]`). Pad only the
+  contended field - padding everything wastes cache.
+
+## 5. Zero-allocation static data
+
+- **`static ReadOnlySpan<byte> Table => [ ... ];`** - Roslyn stores the bytes as a
+  blob in the assembly and points the span at them: **no array allocation, ever**.
+  The right way to ship immutable byte tables (parse maps, transition tables). It is
+  a compiler feature, so it works on **both** targets; reliable for
+  `byte`/`sbyte`/`bool` - verify the codegen (the performance-testing skill's
+  codegen-reading page) before relying on it for wider element types.
+- **`[InlineArray(N)]`** gives a fixed-size inline buffer inside a struct with no
+  separate array and no `unsafe fixed`. It is a .NET 8+ runtime feature - available
+  on `net10`, **not** on the Framework target, so `#if NET`-guard it or keep it off
+  the shared path.
+
+## 6. `const` vs `static readonly`, and `switch`
+
+- **`const` folds; `static readonly` is a field load.** A `const` participates in
+  constant propagation - it feeds the reciprocal-division and dead-branch folding in
+  section 1 and [modern-net.md](modern-net.md). A `static readonly` is treated as an
+  invariant after init but does not constant-fold an expression through it. Hot magic
+  numbers should be `const`.
+- A **dense integer `switch`** lowers to a jump table (one indirect branch); a
+  sparse one to a branch tree. Keeping case values dense helps the table form and
+  beats an `if/else` ladder.
+
+## 7. Hot-path allocation anti-patterns
+
+Each of these allocates on a path that runs thousands of times; all apply to both
+targets. A repo's own utility types often exist to avoid several of these - a
+stack-seeded value string builder, pooled list types, and enum-flag helpers that
+sidestep `Enum.HasFlag` boxing. Prefer them on the hot path.
+
+- **LINQ on a hot path** allocates enumerators and closures and blocks BCE,
+  devirtualization, and inlining. Fine for clarity off the hot path; rewrite to loops
+  or span APIs in kernels.
+- **Capturing lambdas** allocate a display-class object per creation - per iteration
+  in a loop. Use `static` lambdas and pass state explicitly, or the struct-generic
+  pattern ([modern-net.md](modern-net.md)).
+- **`async` state machines** can allocate, and awaiting already-completed work has
+  builder overhead. Use `ValueTask`/`ValueTask<T>` for hot, usually-synchronous
+  paths; do not make trivially-synchronous methods `async`.
+- **`params object[]`** allocates per call. The `params ReadOnlySpan<T>` overload
+  (C# 13) is allocation-free - prefer it.
+- **`yield` iterators** allocate a state machine and add `MoveNext` dispatch per
+  element. For hot internal sequences return a struct enumerator or fill a `Span`.
+- **`+=` string building in a loop** is quadratic allocation. Use a stack-seeded
+  pooled string builder, or `string.Create` with a span-fill callback when the final
+  length is known.
+- **Boxing in disguise** - a struct called through a non-generic interface, a struct
+  in a non-generic collection, or `Enum.HasFlag` reached through generic code (use
+  the repo's enum-flag helpers instead) - each box is a heap allocation. Watch the
+  `Allocated` column (the performance-testing skill) and check for boxing in the IL
+  (the IL-copy-inspection skill).
+
+## See also
+
+- [modern-net.md](modern-net.md) - the `net10`-only enablement (SIMD, intrinsics,
+  struct-generic, escape analysis) built on these fundamentals.
+- The performance-testing skill's `reading-codegen.md` - confirm the JIT emitted the
+  reciprocal multiply / shift / jump table / blob load you expected.

--- a/.agents/skills/framework-jit-optimization/modern-net.md
+++ b/.agents/skills/framework-jit-optimization/modern-net.md
@@ -1,0 +1,159 @@
+# What the modern target enables (and `net481` does not)
+
+The other pages in this skill are about recovering performance on `net481`'s frozen
+RyuJIT. This page is the counterpart: the optimizations the **modern .NET target**
+(`net10`) has that Framework does not, how to use them, and - crucially - why you
+should let the modern source stay simple so the JIT applies them for you. It is the
+basis for the "split the TFMs" decision in
+[references/framework-span-performance.md](references/framework-span-performance.md)
+(Strategy D): `net10` gets the shape below, `net481` gets the tuned scalar loop.
+
+The headline rule cuts the opposite way from the rest of this skill:
+
+> On `net481` you hand-tune because the JIT will not. On `net10` you keep the
+> source simple because the JIT will - and a Framework-tuned shape often *blocks*
+> the modern JIT's own vectorizer, devirtualizer, and escape analysis.
+
+## Reach for the BCL first - it is vectorized on `net10`
+
+Unlike Framework (where delegating to the BCL is not a free vectorization win - see
+[bcl-tradeoffs.md](bcl-tradeoffs.md)), on `net10` the BCL span primitives are
+SIMD-accelerated and tuned better than almost anything you will hand-roll. Before
+writing a loop, check whether one of these already does it:
+
+- **`MemoryExtensions`** - `IndexOf`, `Contains`, `SequenceEqual`,
+  `IndexOfAny(Except)`, `CommonPrefixLength` are already vectorized. Do not
+  reimplement them.
+- **`SearchValues<T>`** - build once into a `static readonly` field, then
+  `span.IndexOfAny(values)`. It picks the optimal bitmap/range/`PSHUFB` strategy
+  for the set. `SearchValues<string>` (multi-substring) exists too.
+- **`System.Numerics.Tensors.TensorPrimitives`** - `Sum`, `Dot`, `Add`,
+  `CosineSimilarity`, and many more element-wise/reduction ops over
+  `ReadOnlySpan<T>`, FMA-aware and generic-math-based.
+
+These have **no equivalent on `net481`**, so a helper that wants speed on both
+targets often splits: BCL primitive under `#if NET`, hand-tuned scalar under
+`#else`.
+
+## The canonical hand-vectorized loop (only when the BCL has no fit)
+
+When you do need a custom kernel on `net10`, every one has the same skeleton: gate
+on hardware + length, run a `Vector256` main loop over a hoisted `ref T`, reduce
+once, then a scalar tail.
+
+```c#
+static int Sum(ReadOnlySpan<int> source)
+{
+    ref int first = ref MemoryMarshal.GetReference(source);
+    int length = source.Length;
+    int i = 0, sum = 0;
+
+    if (Vector256.IsHardwareAccelerated && length >= Vector256<int>.Count)
+    {
+        Vector256<int> acc = Vector256<int>.Zero;
+        int lastBlock = length - Vector256<int>.Count;
+        for (; i <= lastBlock; i += Vector256<int>.Count)
+        {
+            acc += Vector256.LoadUnsafe(ref first, (nuint)i);
+        }
+
+        sum += Vector256.Sum(acc);
+    }
+
+    for (; i < length; i++)
+    {
+        sum += Unsafe.Add(ref first, i);
+    }
+
+    return sum;
+}
+```
+
+- `Vector256.IsHardwareAccelerated` is a **JIT-time constant** - on hardware
+  without AVX (or, critically, when this same source compiles for `net481` where
+  the type is absent) the whole `if` block must be `#if NET`-guarded; the types live
+  in `System.Runtime.Intrinsics`, which is .NET 5+ only.
+- The find-first-match variant replaces the reduction with
+  `Vector256.Equals(block, needle).ExtractMostSignificantBits()` and, when the mask
+  is non-zero, `BitOperations.TrailingZeroCount(mask)` for the position. This is the
+  portable `PMOVMSKB` idiom behind `Span.IndexOf`.
+- The `ref T` hoist + `Unsafe.Add` tail is the same pattern this skill's
+  [references/framework-span-performance.md](references/framework-span-performance.md)
+  prescribes for Framework - it is the one shape that is good on both.
+
+**Drop to `System.Runtime.Intrinsics.X86` / `.Arm` only** for an instruction the
+portable `Vector128/256/512` layer cannot express (`PSHUFB`/`Vector128.Shuffle` for
+in-register table lookup, `PEXT`/`PDEP`, `PCLMULQDQ`, `Crc32`). Every intrinsic
+class exposes `IsSupported`, which the JIT folds away, so a widest-path-first ladder
+(`Avx512F` -> `Avx2` -> `AdvSimd` -> scalar) has no runtime dispatch cost - but each
+path multiplies test surface, so keep a scalar fallback and differential-test it
+against the vector path on awkward lengths (0, 1, width-1, width, width+1).
+
+## The struct-generic zero-cost abstraction
+
+The single most powerful `net10` pattern, and the one the BCL leans on
+(`TensorPrimitives`, `Span.Sort`). The runtime **monomorphizes value-type
+generics**: a generic method over a `struct` that implements an interface gets the
+interface calls devirtualized and inlined per instantiation, collapsing the
+abstraction to nothing.
+
+```c#
+interface IOp { int Apply(int x); }
+readonly struct AddOne : IOp { public int Apply(int x) => x + 1; }
+
+static void Map<TOp>(Span<int> data, TOp op) where TOp : struct, IOp
+{
+    for (int i = 0; i < data.Length; i++)
+    {
+        data[i] = op.Apply(data[i]);   // devirtualized + inlined to `+ 1`
+    }
+}
+```
+
+This is how you write "one kernel, many operations" without virtual-call tax. It
+works on `net481` too (the runtime has always monomorphized value-type generics),
+but the weaker Framework inliner is less reliable about inlining the devirtualized
+call - measure both.
+
+## Let the JIT do the rest - shapes that light up on `net10`
+
+These cost nothing to adopt and the modern JIT rewards them; `net481` benefits from
+some but not all.
+
+- **`sealed`** classes and overrides devirtualize unconditionally. Keep hot types
+  `sealed` (a common repo rule for non-derived internal/private types). Dynamic PGO
+  additionally does *guarded* devirtualization on monomorphic call sites - so keep a
+  hot call site type-stable. `net481` has no PGO.
+- **Escape analysis -> stack allocation (.NET 10).** A small `new T[n]` that
+  provably does not escape the method is stack-allocated (and may be scalar-replaced
+  into registers), with no GC tracking. You get this for free by keeping allocations
+  local - do not pool what the JIT will stack-allocate; check codegen first (the
+  performance-testing skill's codegen-reading page). `net481` does not do this.
+- **Canonical loop shapes keep bounds-check elimination.** `for (int i = 0; i <
+  span.Length; i++)` lets the JIT prove `span[i]` in range. Caching `.Length` into a
+  local can *defeat* BCE on `net10` - the opposite of the (also unnecessary) habit.
+  Slice both operands to a common length so each access is provably safe.
+- **Tiering / OSR / PGO** mean first calls run unoptimized and long loops re-JIT
+  mid-flight; this is a *measurement* concern, not a coding one - see the traps in
+  the performance-testing skill's codegen-reading page.
+
+## Do not freeze the modern source against Framework's JIT
+
+The anti-pattern that this page exists to prevent: pinning, `Unsafe`-walking, or
+manually unrolling the **`net10`** path just to share one implementation with
+`net481`. Every such shape is something the modern JIT could have vectorized or
+stack-allocated and now cannot. The
+[references/framework-span-performance.md](references/framework-span-performance.md)
+within-noise test is the rule: if the simple `net10` shape is within ~5% of the
+Framework-tuned shape on `net10`, split the TFMs and keep `net10` simple. The 5% you
+might lose today is far smaller than the future vectorization wins you forfeit by
+freezing the source.
+
+## See also
+
+- [references/framework-span-performance.md](references/framework-span-performance.md)
+  - the Strategy A-E hierarchy and the TFM-split decision this page feeds.
+- [cross-tfm-codegen.md](cross-tfm-codegen.md) - arithmetic, branchless, memory
+  layout, and allocation anti-patterns that apply to *both* targets.
+- The performance-testing skill's `reading-codegen.md` - confirm the JIT actually
+  vectorized / devirtualized / stack-allocated what you expected.

--- a/.agents/skills/framework-jit-optimization/overlay.md
+++ b/.agents/skills/framework-jit-optimization/overlay.md
@@ -1,0 +1,42 @@
+---
+core: framework-jit-optimization
+core-pin: v0.10.0
+---
+
+# madowaku overlay - framework-jit-optimization
+
+Repository-specific companion to the vendored
+[framework-jit-optimization](SKILL.md) skill. The `SKILL.md` and its sibling
+pages are a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **The Framework target is `net472`** (tests and perf use `net481`); the main
+  library also builds `net10.0` and `net10.0-windows10.0.22000.0`. Code must
+  behave correctly on every target - see [AGENTS.md](../../../AGENTS.md).
+- **net472-only code lives under**
+  [madowaku/Framework/](../../../madowaku/Framework/), which is net472-scoped by
+  construction - no `#if NETFRAMEWORK` inside it (see
+  [interop.instructions.md](../../../.github/instructions/interop.instructions.md)).
+- **Enum flags**: never use `Enum.HasFlag`; it boxes on net472. Use the Touki
+  enum extension methods (`AreFlagsSet`, `IsOnlyOneFlagSet`, `AreAnyFlagsSet`,
+  `SetFlags`, `ClearFlags`).
+
+## Cross-references
+
+- [`performance-testing`](../performance-testing/SKILL.md) - the harness that
+  proves a Framework codegen win or regression on both JITs.
+- [`scratch-buffer-strategy`](../scratch-buffer-strategy/SKILL.md) - the
+  net481/net10 buffer-strategy crossovers.
+- [`cswin32-interop`](../cswin32-interop/SKILL.md) - the interop surface and the
+  net472 polyfill layout most hot paths cross.
+
+## Updating
+
+Pull upstream changes with `gh skill update framework-jit-optimization` (review
+the diff, re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/framework-jit-optimization/references/framework-span-performance.md
+++ b/.agents/skills/framework-jit-optimization/references/framework-span-performance.md
@@ -1,0 +1,487 @@
+# Span performance on .NET Framework (net472+)
+
+How to write span-based helpers that stay fast on `net472` / `net481`
+without giving up the simpler, safer shape that lets net10 ride future
+runtime improvements. Sourced from BenchmarkDotNet experiments and
+disassembly captures in a multi-targeted library's perf project.
+
+The numbers and disassembly in this document were pulled from a Raptor
+Lake i9-14900K running .NET 10 and .NET Framework 4.8.1. The shapes
+generalize to any net472+ target - there is one RyuJIT for desktop
+Framework and it has not received vectorization or PGO work in years.
+
+This is the general field manual. A consuming repo may keep a detailed
+case-study companion (e.g. a specific `OrdinalIgnoreCase` valley
+write-up) in its own docs.
+
+---
+
+## 1. Why spans are slow on net472+
+
+`ReadOnlySpan<T>` and `Span<T>` are **not the same type** on .NET
+Framework as they are on modern .NET. The layout differs, and the JIT
+that compiles span code is RyuJIT 4.8, not RyuJIT 10.
+
+### 1.1 "Slow span" layout
+
+On modern .NET, `Span<T>` is a `ref struct` containing exactly **one
+byref** (a managed `ref T`) and a length:
+
+```csharp
+// modern .NET (conceptual)
+public readonly ref struct Span<T>
+{
+    private readonly ref T _reference;
+    private readonly int _length;
+}
+```
+
+`_reference` is a true managed pointer the JIT can keep in a register.
+Indexing `span[i]` compiles to a single indexed load (`movzx eax, word
+ptr [reg + i*2]` for `Span<char>`).
+
+On .NET Framework (and any "slow span" target - `netstandard2.0` via the
+`System.Memory` NuGet, `net472`, `net481`) `Span<T>` is approximately:
+
+```csharp
+// .NET Framework (System.Memory package, conceptual)
+public readonly ref struct Span<T>
+{
+    private readonly Pinnable<T> _pinnable;   // managed object or null
+    private readonly IntPtr      _byteOffset; // offset within _pinnable
+    private readonly int         _length;
+}
+```
+
+A managed `ref T` cannot be stored in a struct field on Framework
+because the runtime predates the byref-in-struct feature. The span has
+to carry the object reference *and* a byte offset separately.
+
+The cost shows up every time you index the span. Disassembly of
+`a[i]` on net481:
+
+```asm
+M02_L00:
+    cmp       qword ptr [rcx], 0   ; Pinnable null?  (raw-pointer path?)
+    jne       short M02_L01
+    mov       rax, [rcx+8]         ; no -> load byte offset
+    movsxd    r10, r8d
+    shl       r10, 1
+    add       rax, r10             ; raw + i*2
+    jmp       short M02_L02
+M02_L01:
+    mov       r11, [rcx]           ; load Pinnable object pointer
+    cmp       [r11], r11d          ; null-check / GC liveness fence
+    lea       r10, [r11+8]         ; skip object header
+    mov       rax, [rcx+8]         ; byte offset
+    add       r10, rax             ; combine
+    movsxd    r11, r8d
+    mov       rax, r11
+    shl       rax, 1
+    add       r10, rax             ; index by 2
+    xchg      rax, r10
+M02_L02:
+    movzx     eax, word ptr [rax]  ; finally load a[i]
+```
+
+**~8 µops per character on net481 vs 1 µop on net10.** The same dance
+repeats for `b[i]`, so a `for (int i = 0; i < n; i++)` loop walking two
+spans pays ~16 µops *just to load the operands*, before any compare or
+fold work.
+
+### 1.2 No `Vector128`/`Vector256` intrinsics
+
+Framework RyuJIT does not recognize the `System.Runtime.Intrinsics`
+APIs. `Vector<T>` (the old "agnostic" SIMD type) still works but is
+significantly slower than the modern intrinsics. The BCL itself does
+not vectorize most string/span operations when running on Framework -
+even calls like `MemoryExtensions.Equals(span, span, OrdinalIgnoreCase)`
+fall through to a scalar per-character loop.
+
+This means **delegating to the BCL is not a free vectorization win on
+Framework** the way it is on modern .NET. If you're writing a helper
+specifically for Framework speed, you usually need to write the loop
+yourself.
+
+### 1.3 Prologue `rep stosd` zero-init (the GC-frame carve-out)
+
+Framework RyuJIT **honors `[SkipLocalsInit]`** - but only for the locals
+it is allowed to leave dirty. The desktop CLR still force-zeros every
+**GC-tracked** frame slot regardless of the `localsinit` flag, so the
+garbage collector can safely report it. A managed reference, an
+`object`-containing struct, a `Span<T>` / `ReadOnlySpan<T>` (it carries a
+managed byref), and a pinned `fixed` pointer's slot are all GC-tracked.
+
+A span-walking helper that takes spans and pins them has a GC-tracked
+frame, so it is zeroed in the prologue **even with `[SkipLocalsInit]`
+applied** - this is the GC carve-out, not the attribute being ignored:
+
+```asm
+; A pinning span helper, net481 RyuJIT, [SkipLocalsInit] applied
+    sub       rsp, 58
+    ...
+    mov       ecx, 0C              ; 12 dwords = 48 bytes
+    xor       eax, eax
+    rep stosd                      ; still emitted: GC slots, not the flag
+```
+
+Proven by A/B disassembly on both TFMs (a `stackalloc` vs non-GC-frame vs
+GC-frame benchmark in the repo's perf project):
+
+| 48-byte frame / 4 KB `stackalloc` | net481 default | net481 `[SkipLocalsInit]` |
+|---|---:|---:|
+| `stackalloc byte[4096]` (no GC refs) | 52.99 ns | **1.78 ns** - loop gone |
+| 48-byte non-GC struct | 5.84 ns | **1.28 ns** - `rep stosd` gone |
+| 48-byte `object`-containing struct | 8.58 ns | 8.66 ns - `rep stosd` stays |
+
+So on net481 the attribute removes zeroing for non-GC locals and
+`stackalloc` (a 4 KB clear drops ~30x) and is a no-op only for GC-tracked
+frames. The cost a span helper still pays - an ~88-byte frame with a
+48-byte GC-slot zero-init, ~3 ns/call - is real, but it is the GC
+carve-out and `[SkipLocalsInit]` cannot remove it. Modern .NET applies
+the same carve-out. For the buffer-zeroing decisions that follow from
+this, see the `scratch-buffer-strategy` skill (zeroed `stackalloc` vs
+`[SkipLocalsInit]` vs a pool rental, and the net481/net10 crossovers).
+
+### 1.4 Conservative inliner, no cross-assembly generic inlining
+
+Framework RyuJIT is significantly more conservative than modern .NET
+about:
+
+- Inlining anything with non-trivial structure.
+- Inlining generic methods across assemblies.
+- Inlining methods called through interfaces (no dynamic devirt).
+- Inlining anything containing a `try`/`catch` or `finally`.
+
+The practical consequence: `MemoryMarshal.GetReference<T>(span)` does
+not inline on Framework. Every call becomes an actual `call qword ptr
+[...]` indirection. Modern .NET inlines it to a single register move.
+
+---
+
+## 2. The strategy hierarchy
+
+Apply in this order. Stop at the first strategy that gets you within
+noise of the modern .NET measurement, because each step trades safety
+or maintainability for speed.
+
+### 2.1 Strategy A: write it the safe way, measure both TFMs
+
+Always start here. Use `for (int i = 0; i < span.Length; i++) span[i]`,
+foreach over `ReadOnlySpan<T>`, or whatever idiomatic shape the
+algorithm wants. Benchmark on **both** net10 and net481.
+
+Three outcomes:
+
+1. **Both TFMs within target.** Done - ship it.
+2. **net10 fine, net481 slow.** Continue to Strategy B.
+3. **Both slow.** Algorithmic issue. The strategies in this document
+   only help with constant-factor JIT/runtime overhead.
+
+The reason for starting here is **portability across runtime evolution**.
+The simpler the source, the more future RyuJIT improvements (auto-vector,
+better inliner, dynamic PGO) the code accrues for free on modern .NET.
+Code written for Framework's JIT often *prevents* the modern JIT from
+applying its own optimizations.
+
+### 2.2 Strategy B: hoist `ref T` out of the loop with `MemoryMarshal.GetReference` + `Unsafe.Add`
+
+The single biggest win for span-walking loops on Framework. Compute the
+slow-span pointer dance **once** outside the loop and walk a real `ref T`
+inside it.
+
+```csharp
+// Before - pays the slow-span tax per character on net481
+for (int i = 0; i < a.Length; i++)
+{
+    char x = a[i];
+    char y = b[i];
+    // ...
+}
+
+// After - pays it once at method entry
+ref char pa = ref MemoryMarshal.GetReference(a);
+ref char pb = ref MemoryMarshal.GetReference(b);
+int n = a.Length;
+for (int i = 0; i < n; i++)
+{
+    char x = Unsafe.Add(ref pa, i);
+    char y = Unsafe.Add(ref pb, i);
+    // ...
+}
+```
+
+Measured wins on net481 (a Span vs ref-vs-pinned A/B/C harness,
+same-case ASCII input):
+
+| Length | `span[i]` loop | `ref` + `Unsafe.Add` | Δ |
+|---:|---:|---:|---:|
+| 5  | 19.92 ns | 20.04 ns | ±0% |
+| 10 | 27.20 ns | 21.99 ns | **−19%** |
+| 20 | 46.67 ns | 27.04 ns | **−42%** |
+| 64 | 105.81 ns| 59.70 ns | **−44%** |
+
+On net10 the same change is a 14-16% win at short lengths and zero at
+long lengths - modern RyuJIT was already keeping the operand in a
+register, but `Unsafe.Add` saves the bounds check the indexer would
+otherwise emit.
+
+**This pattern is safe** in the C# sense - no `unsafe` block, no
+pinning, no GC concerns. `Unsafe.Add` on a managed `ref T` is GC-aware:
+the runtime tracks the byref the same way it tracks the original span
+reference, and a moving GC updates both.
+
+The one cost: `MemoryMarshal.GetReference` does **not** inline on
+net481 - it's a non-inlined `call`. That ~2 ns per call (~4 ns total
+for two operands) is why the L=5 row above is a wash. Continue to
+Strategy C only if you need to recover that.
+
+### 2.3 Strategy C: `fixed` (pinning)
+
+When the call-frame cost of `MemoryMarshal.GetReference` dominates
+(very short inputs, very hot path), drop to `fixed` to inline the pin
+fixup at the call site.
+
+```csharp
+public static unsafe bool Equals(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
+{
+    if (a.Length != b.Length) return false;
+    fixed (char* pa = a)
+    fixed (char* pb = b)
+    {
+        int n = a.Length;
+        for (int i = 0; i < n; i++)
+        {
+            char x = pa[i];
+            char y = pb[i];
+            // ...
+        }
+    }
+    return true;
+}
+```
+
+Measured (same dataset, net481):
+
+| Length | `span[i]` | `ref` + `Unsafe.Add` | `fixed` (pinned) | Pinned vs Span |
+|---:|---:|---:|---:|---:|
+| 5  | 19.92 ns | 20.04 ns | 17.72 ns | **−11%** |
+| 10 | 27.20 ns | 21.99 ns | 21.04 ns | **−23%** |
+| 20 | 46.67 ns | 27.04 ns | 28.33 ns | −39% |
+| 64 | 105.81 ns| 59.70 ns | 65.79 ns | −38% |
+
+Pinning beats `Unsafe.Add` at short lengths because `fixed` generates
+the pin fixup inline (no `GetReference` call). It loses to `Unsafe.Add`
+at L ≥ 20 because every additional iteration the pinned pointer pays
+nothing the `ref T` doesn't, and the `fixed` block has a small
+GC-frame-update cost on entry/exit that `Unsafe.Add` avoids.
+
+**Pinning is explicit `unsafe`.** That is a feature, not a drawback -
+the keyword forces a reviewer to look at the pointer arithmetic. Treat
+`Unsafe.Add` as "safe but easy to misread" and `fixed` as "unsafe and
+obviously unsafe". Both ship the same machine code shape; the
+difference is what shows up at the call site for a human reviewer.
+
+**Pinning is preferred over `Unsafe.As`/`Unsafe.AsRef`/`Unsafe.AsPointer`
+tricks** that try to launder a managed reference into a raw pointer
+without `fixed`. Those tricks are equally unsafe in terms of runtime
+semantics (you're still working with raw pointers and ignoring the GC),
+but they hide the danger behind a `static class Unsafe` import.
+`fixed (char* p = span)` says exactly what it does.
+
+### 2.4 Strategy D: TFM-conditional implementations
+
+For helpers that:
+
+1. Live on a hot path used by many call sites
+2. Have a simple modern-.NET implementation that's within noise of any
+   Framework-tuned version on net10
+3. Pay a measurable Framework tax with the simple shape
+
+…provide **two implementations**, one per TFM, with `#if NET` /
+`#else`. The principle is:
+
+> The modern .NET implementation should be as simple as the algorithm
+> allows. The Framework implementation can use pinning or unsafe code
+> to recover the per-character cost. Never let Framework's JIT
+> limitations dictate the modern .NET source shape.
+
+Template:
+
+```csharp
+public static bool Equals(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
+{
+    if (a.Length != b.Length) return false;
+
+#if NET
+    // Modern .NET: simple, idiomatic. RyuJIT keeps span data in
+    // registers; future runtime versions can auto-vectorize this loop.
+    for (int i = 0; i < a.Length; i++)
+    {
+        if (!EqualOneChar(a[i], b[i])) return false;
+    }
+    return true;
+#else
+    // .NET Framework: pin and walk raw pointers. Recovers the
+    // slow-span tax (12 µops/char -> 1 µop/char).
+    return EqualsPinned(a, b);
+#endif
+}
+
+#if !NET
+private static unsafe bool EqualsPinned(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
+{
+    fixed (char* pa = a)
+    fixed (char* pb = b)
+    {
+        int n = a.Length;
+        for (int i = 0; i < n; i++)
+        {
+            if (!EqualOneChar(pa[i], pb[i])) return false;
+        }
+        return true;
+    }
+}
+#endif
+```
+
+This pattern lets the modern .NET source remain a target for the JIT's
+own optimizer - when .NET 12 or 13 adds a new vectorization pass, the
+simple loop picks it up automatically. The Framework implementation
+stays frozen at "whatever runs well on RyuJIT 4.8", because RyuJIT 4.8
+is itself frozen.
+
+The **within-noise** test for whether to split:
+
+> If a unified implementation written with pinning/Unsafe is within
+> ~5% of the simple `span[i]` shape on **net10** at the input sizes
+> the helper sees in production, prefer to split. The 5% you might
+> theoretically lose on net10 is far smaller than the future
+> vectorization wins you forfeit by freezing the source against
+> Framework's JIT.
+
+### 2.5 Strategy E: kill the call frame (force-inline)
+
+Orthogonal to A-D, but worth listing. Framework's per-call overhead
+(~6 ns: 88-byte frame + 48-byte `rep stosd` + epilogue) is irreducible
+*within a called function*. The only way to delete it is to not be a
+called function.
+
+```csharp
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
+public static bool Equals(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
+{
+    // Tiny dispatcher - inlines into the caller.
+    if (a.Length != b.Length) return false;
+    if (a.Length < SomeThreshold) return EqualsCore(a, b);
+    return BclEquals(a, b);
+}
+```
+
+The dispatcher inlines and the per-call frame for `Equals` disappears
+on Framework. The work-doing method (`EqualsCore`) stays out-of-line
+to avoid bloating every call site. On net481 each eliminated call
+frame is worth ~5-6 ns, which is significant for short-input hot
+paths.
+
+**Caveat**: `AggressiveInlining` is a *hint*. Framework's JIT will
+refuse if the method is too large, contains a try/catch/finally, or
+touches `MarshalByRefObject`. Keep the dispatcher trivial.
+
+---
+
+## 3. Cost summary
+
+The fixed costs on net481 RyuJIT, gathered in one place so you can
+quickly estimate how much a given strategy might save:
+
+| Cost | Approx ns | Notes |
+|---|---:|---|
+| Function-call frame (88 B stack + 48 B `rep stosd` + epilogue) | ~5-6 | Per call. The 48 B zero is the GC-tracked slots; `[SkipLocalsInit]` can't remove those (see 1.3). |
+| Non-inlined `MemoryMarshal.GetReference<T>(span)` | ~2 | Per call. Doubled if you walk two spans. |
+| Slow-span indexer `span[i]` | ~1.5 µops × ~2.5 cycles | Per character. Compare to ~0.3 cycles on net10. |
+| `vzeroupper` in prologue | ~1 µop | Emitted whenever the JIT sees AVX state needs clearing. |
+| 5 callee-saved register pushes (`MemoryExtensions.Equals` shape) | ~2 | Per call into a "heavyweight" BCL helper. |
+
+A "typical" Framework cost for a span-walking helper called once at L=10
+is something like: **6 (call frame) + 4 (two GetReference calls if used) + 10
+(10 × per-char load via slow span) + 1 (vzeroupper) + 5 (epilogue & misc) =
+~26 ns.** Strategy B drops this to **6 + 4 + 3 + 1 + 5 = ~19 ns**.
+Strategy C drops it further to **6 + 0 + 3 + 0 + 4 = ~13 ns** (pinning
+inlines the pointer setup but adds a small fixed pin-fixup cost).
+
+---
+
+## 4. Decision flowchart
+
+```text
+Write the helper the simple safe way (Strategy A).
+Benchmark on net10 AND net481.
+
+  net10 OK, net481 OK? ──── ship it.
+                  │
+                  no
+                  ▼
+  Hoist `ref T = MemoryMarshal.GetReference(span)` (Strategy B).
+  Re-bench.
+                  │
+                  ▼
+  net481 OK now? ─── good. Is the unified Strategy-B code within
+                  │   noise of the Strategy-A code on net10?
+                  │
+                  ├── yes ─── ship unified.
+                  │
+                  └── no ──── split TFMs (Strategy D):
+                              net10  = Strategy A (simple).
+                              net481 = Strategy B (ref+Unsafe.Add).
+                  │
+                  no (net481 still hot)
+                  ▼
+  Pin with `fixed` (Strategy C). Re-bench.
+                  │
+                  ▼
+  net481 OK now? ─── split TFMs (Strategy D):
+                              net10  = Strategy A (simple).
+                              net481 = Strategy C (pinned).
+                  │
+                  no
+                  ▼
+  Profile for call-frame overhead. Force-inline a dispatcher
+  (Strategy E). Re-bench.
+                  │
+                  ▼
+  Still hot? ──── algorithm issue. Strategies A-E exhaust the
+                  constant-factor recovery options.
+```
+
+---
+
+## 5. Anti-patterns to avoid
+
+- **`unsafe` for cleverness, not necessity.** If Strategy A or B
+  meets the target, do not introduce `fixed` "for consistency" or
+  "because we're already using `Unsafe.Add`". Every `unsafe` block is
+  a permanent maintenance cost.
+- **Writing Framework-tuned code into the modern .NET path.** If you
+  pin / Unsafe-Add on net10 just to share one implementation with
+  Framework, you may be preventing future RyuJIT auto-vectorization
+  from kicking in. Measure on net10 with a simpler shape; if it's
+  competitive, prefer the split.
+- **`[SkipLocalsInit]` as a fix for span-helper frames.** It does *not*
+  help there: a span / `fixed` helper's frame is GC-tracked, and the GC
+  carve-out zeroes those slots regardless of the flag (see 1.3). It
+  *does* suppress zeroing for non-GC locals and `stackalloc` (a 4 KB
+  clear drops ~30x on net481), so credit it there - just not as a
+  mitigation for the span-walking helpers this doc is about.
+- **`Unsafe.AsPointer(ref MemoryMarshal.GetReference(span))` instead of
+  `fixed`.** Same machine semantics, harder for a reviewer to spot the
+  pinning requirement (there isn't one - the pointer is bare, and a
+  moving GC will invalidate it). If you need a raw pointer, use
+  `fixed`. If you only need a `ref T`, use `MemoryMarshal.GetReference`
+  with `Unsafe.Add`.
+- **`stackalloc` to avoid spans.** `stackalloc` returns a `Span<T>`
+  on modern .NET and an `IntPtr` cast-shimmed thing on Framework via
+  polyfill. Allocating on the stack does not help with the slow-span
+  indexer tax - it's the *span type* that's slow, not the backing
+  storage. (`stackalloc` is still the right answer for buffer
+  ownership; just don't expect it to fix span-indexer performance.)

--- a/.agents/skills/framework-jit-optimization/specialization.md
+++ b/.agents/skills/framework-jit-optimization/specialization.md
@@ -1,0 +1,134 @@
+# Primitive specialization in generic methods
+
+Use `typeof(T) == typeof(...)` plus `Unsafe.As<T, TPrimitive>(ref value)` to fork
+generic code into per-primitive fast paths that the JIT can fully eliminate when
+`T` is something else. For value-type `T`, the comparison is a JIT-time constant:
+every other branch becomes dead code.
+
+## Pattern
+
+```c#
+[MethodImpl(MethodImplOptions.AggressiveInlining)]
+public unsafe void Replace(T oldValue, T newValue)
+{
+    if (Equal(oldValue, newValue))
+    {
+        return;
+    }
+
+    if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
+    {
+        // The `& 0xFFFF` is load-bearing on net481 RyuJIT - see
+        // "Signed-primitive constant-propagation pitfall" below.
+        ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+        ushort newShort = (ushort)(Unsafe.As<T, ushort>(ref newValue) & 0xFFFF);
+        // ... tight ushort* loop ...
+        return;
+    }
+
+    if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
+    {
+        byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+        byte newByte = (byte)(Unsafe.As<T, byte>(ref newValue) & 0xFF);
+        // ... tight byte* loop ...
+        return;
+    }
+
+    // Fallback for everything else.
+    ref T current = ref MemoryMarshal.GetReference(span);
+    // ...
+}
+```
+
+## Why `Unsafe.As<T, TPrimitive>(ref value)`
+
+A regular cast `(ushort)(object)oldValue` boxes. `Unsafe.As<T, ushort>(ref oldValue)`
+is a no-op reinterpret - the JIT sees the constant `typeof(T) == typeof(ushort)`
+test before it, knows the cast is valid, and emits a direct load.
+
+## Bit-equality equivalence classes
+
+`IEquatable<T>.Equals` for primitive integer types is just bit equality, so a
+single typed pointer loop covers a whole class:
+
+| C# type pair | Underlying width | Use one loop with cast type |
+| --- | --- | --- |
+| `byte` / `sbyte` | 8 bits | `byte*` |
+| `char` / `short` / `ushort` | 16 bits | `ushort*` |
+| `int` / `uint` | 32 bits | `uint*` |
+| `long` / `ulong` / `IntPtr` (on 64-bit) | 64 bits | `ulong*` |
+
+`float` / `double` / `decimal` are **not** members of these classes - their
+`IEquatable` semantics differ from bit equality (NaN, negative zero,
+denormalized flags). Don't fold them in.
+
+For methods constrained to `where T : IComparable<T>` (e.g. `IndexOfAnyInRange`),
+keep the primitives as their signed/unsigned variants because comparison
+operators differ. See your repo's `IndexOfAnyInRange`-style polyfill in the
+Framework-only tree for the full
+byte/sbyte/char/short/ushort/int/uint/long/ulong specialization.
+
+## `[MethodImpl(MethodImplOptions.AggressiveInlining)]`
+
+Always put this on the generic entry method when you specialize:
+
+- The `net481` JIT's default heuristics are conservative. Without the attribute,
+  the wrapper method itself is a JIT-time call, defeating the whole point.
+- Measured impact on a tight scalar `ref T` loop at length 16:
+  `1.82&times; &rarr; 1.07&times;` vs the dedicated-overload baseline. The
+  attribute is doing real work, not just hinting.
+
+The inlining attribute is also why we don't need separate `extension(Span<char>)`
+overloads - the generic version with the `typeof` ladder, when inlined,
+generates code identical to a hand-written `Span<char>` overload.
+
+## Verifying the JIT actually elides the dead branches
+
+For `T = int`, the `typeof(T) == typeof(char)` branch should become unreachable.
+You can confirm with a debugger by setting a breakpoint inside it - on a
+Release build with the attribute applied, the JIT will refuse to set the
+breakpoint because the code was eliminated.
+
+If the elision is failing (e.g. you forget `[AggressiveInlining]`, or `T` is
+itself a generic in some outer context where `typeof(T)` isn't a JIT-time
+constant), you'll see all branches in the disassembly - and your benchmark
+ratio will reflect it. Add the attribute, or hoist the call site so `T` is
+concrete.
+
+## Signed-primitive constant-propagation pitfall
+
+If the specialization compares the reinterpreted value against bytes loaded
+from memory (the typical `*ptr == oldByte` pattern in `Replace` / `IndexOf`),
+**always mask in the int domain** when narrowing through `Unsafe.As`:
+
+```c#
+byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+```
+
+Without the mask, `[AggressiveInlining]` plus a literal signed argument
+(`(sbyte)-1`, `(short)-1`) on net481 RyuJIT produces wrong results in
+**Release** (Debug passes). The caller's int-promoted constant
+(`-1` &rarr; `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
+loop's `cmp` immediate as a 32-bit value. The `movzx`-loaded byte is in
+`[0, 0xFF]`, so `cmp ecx, 0FFFFFFFF` is unconditionally false - the loop
+runs, finds nothing, returns silently.
+
+The cast alone (`(byte)Unsafe.As<...>`) does not fix it; RyuJIT's constant
+tracker doesn't model the IL `conv.u1` as truncating. The explicit `& 0xFF`
+mask forces the high bits to zero in the propagated constant, so the compare
+immediate becomes the correct byte even when the JIT carries the int forward.
+Confirmed by disassembly (a dedicated `Unsafe.As`-narrowing replace benchmark in
+the repo's perf project).
+
+Symmetric tests using only `byte` or `char` will not catch this (their
+int-promoted form already has zero upper bits). Always include `sbyte` and
+`short` with negative values in the test matrix for any
+`Unsafe.As<T, byte>` / `Unsafe.As<T, ushort>` specialization.
+
+## See also
+
+- [unrolling.md](unrolling.md) - what to put inside the per-primitive
+  block.
+- [bcl-tradeoffs.md](bcl-tradeoffs.md) - whether to specialize at all,
+  vs delegate to a BCL primitive.

--- a/.agents/skills/framework-jit-optimization/unrolling.md
+++ b/.agents/skills/framework-jit-optimization/unrolling.md
@@ -1,0 +1,132 @@
+# Loop unrolling on `net481`
+
+The only unroll form that wins consistently on `net481` (and is harmless on
+`net10`) is **unroll-by-4 with constant-offset indexed reads + a single pointer
+increment per iteration**. Three close variants all regress.
+
+## Use this form
+
+```c#
+fixed (T* p = span)
+{
+    ushort* ptr = (ushort*)p;
+    int length = span.Length;
+    ushort* end = ptr + length;
+    ushort* unrollEnd = ptr + (length & ~3);
+
+    while (ptr < unrollEnd)
+    {
+        if (ptr[0] == oldShort) ptr[0] = newShort;
+        if (ptr[1] == oldShort) ptr[1] = newShort;
+        if (ptr[2] == oldShort) ptr[2] = newShort;
+        if (ptr[3] == oldShort) ptr[3] = newShort;
+        ptr += 4;
+    }
+
+    while (ptr < end)
+    {
+        if (*ptr == oldShort) *ptr = newShort;
+        ptr++;
+    }
+}
+```
+
+Two key choices:
+
+1. **Indexed reads from a fixed base.** `ptr[0]`, `ptr[1]`, `ptr[2]`, `ptr[3]`
+   compile to four loads with constant offsets from one base register. The
+   four loads have no dependency on each other, so the CPU can issue them in
+   parallel.
+2. **Single `ptr += 4` per iteration.** One arithmetic op at the end of the
+   chunk instead of one per element.
+
+Measured: 14-36% faster than the scalar baseline at every size on both
+runtimes.
+
+## Don't use these
+
+### `*ptr; ptr++` four times in a row
+
+```c#
+// BAD: serializes the loads through the increment chain.
+if (*ptr == oldShort) *ptr = newShort; ptr++;
+if (*ptr == oldShort) *ptr = newShort; ptr++;
+if (*ptr == oldShort) *ptr = newShort; ptr++;
+if (*ptr == oldShort) *ptr = newShort; ptr++;
+```
+
+Every load now depends on the previous `ptr++`. The JIT does not recover the
+parallelism by recognizing the pattern. Measured: 0.84&times; vs 1.12&times;
+ratio at length 256 on `net481` - the `ptr++` form is actually slower
+than the un-unrolled scalar baseline.
+
+### Integer-indexed body
+
+```c#
+// BAD: forces the JIT to recompute base + i*sizeof + offset*sizeof per load.
+for (int i = 0; i < unrollEnd; i += 4)
+{
+    if (ptr[i + 0] == oldShort) ptr[i + 0] = newShort;
+    if (ptr[i + 1] == oldShort) ptr[i + 1] = newShort;
+    if (ptr[i + 2] == oldShort) ptr[i + 2] = newShort;
+    if (ptr[i + 3] == oldShort) ptr[i + 3] = newShort;
+}
+```
+
+The `net481` JIT does not hoist the `ptr + i` calculation. Each `ptr[i + k]`
+becomes `lea` + `mov`. **Worse than the scalar baseline at length 4096
+(1.22&times;).** Always advance the pointer instead.
+
+### Unroll-by-8
+
+```c#
+// BAD on net481, fine on net10.
+while (ptr < unrollEnd)
+{
+    if (ptr[0] == oldShort) ptr[0] = newShort;
+    // ...repeat for 1..7...
+    ptr += 8;
+}
+```
+
+Wins at length 16 (small loop, fewer iterations). **Regresses 1.3-1.6&times;
+at length 256+** on `net481`. Most likely the larger method body trips a
+register-allocation or loop-alignment threshold. The .NET 10 JIT recovers but
+`net481` does not.
+
+## Backward unroll for `LastIndexOf`-style methods
+
+```c#
+fixed (T* p = span)
+{
+    ushort* start = (ushort*)p;
+    int length = span.Length;
+    ushort* ptr = start + length;
+    ushort* unrollStart = start + (length & 3);
+
+    while (ptr > unrollStart)
+    {
+        ptr -= 4;
+        if (ptr[3] != target) return (int)(ptr - start) + 3;
+        if (ptr[2] != target) return (int)(ptr - start) + 2;
+        if (ptr[1] != target) return (int)(ptr - start) + 1;
+        if (ptr[0] != target) return (int)(ptr - start) + 0;
+    }
+
+    while (ptr > start)
+    {
+        ptr--;
+        if (*ptr != target) return (int)(ptr - start);
+    }
+}
+```
+
+Note: the `ptr -= 4` happens **before** the four reads (so the indices walk
+3, 2, 1, 0 within the chunk, returning the highest matching index first to
+preserve the "last occurrence" semantics).
+
+## Tail loop
+
+Always pair the unrolled body with a scalar tail that handles 0-3
+elements. `length & ~3` rounds the unroll boundary down to a multiple of 4;
+the remainder is `length & 3` elements walked one at a time.

--- a/.agents/skills/github-actions-cost-optimization/SKILL.md
+++ b/.agents/skills/github-actions-cost-optimization/SKILL.md
@@ -1,0 +1,105 @@
+---
+compatibility: Requires access to the repository's GitHub Actions workflows; precise estimates require current GitHub billing rates and representative job durations.
+description: Audit and reduce GitHub Actions runner usage and normalized cost without weakening required validation. Use when asked to reduce CI cost, spend, minutes, or job count; optimize workflow triggers, matrices, runner selection, caches, or artifact retention; eliminate duplicate Actions runs; or decide which checks should be automatic versus scheduled or manual. Not for application runtime performance, which belongs in a performance-testing workflow.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/github-actions-cost-optimization
+    github-pinned: 85325dbeb5d5c3e9be39b9f7725a25d971b77d8a
+    github-ref: 85325dbeb5d5c3e9be39b9f7725a25d971b77d8a
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 1fac6778d86ec0879641e2b593e881f49b43c648
+    maturity: canary
+    portability: portable
+    related: engineering-baseline, security-review
+    requires: none
+    risk: local-write
+name: github-actions-cost-optimization
+---
+
+# GitHub Actions cost optimization
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Reduce the cost and latency of GitHub Actions while preserving the checks that
+make a change safe to merge and release. Optimize the repository's full change
+lifecycle, not one conspicuous job: duplicate triggers, repeated setup, matrix
+fan-out, retries, and retained storage can outweigh the longest individual step.
+
+This skill applies to requests such as "reduce our CI spend", "why does this
+workflow use so many minutes?", "move expensive checks out of every PR", and
+"choose cheaper runners without losing coverage". It should not trigger for
+"make this parser faster" or "reduce allocations in this method"; those are
+application performance questions.
+
+## Non-negotiable rule
+
+State the validation invariants before proposing savings. A cheaper workflow
+that no longer tests the merge candidate, a supported platform, a release
+configuration, or a security boundary is not an optimization. Treat changes to
+CodeQL frequency, untrusted-code permissions, branch protection, and merge
+bypass paths as security or governance decisions, not accounting details.
+
+For public repositories, standard GitHub-hosted runners may have no invoiced
+minute charge. Still report normalized list-price cost and runner usage so
+alternatives remain comparable and the workflow stays economical if repository
+visibility or billing policy changes. Keep actual invoiced cost distinct from
+that normalized comparison. Public and private repositories can receive
+different hardware for the same runner label; when they do, label the normalized
+number as a synthetic rate-weighted comparison, not a visibility-change forecast.
+
+## Workflow
+
+1. Read [audit.md](audit.md). Inventory workflows, triggers, required checks,
+   merge paths, runner types, matrices, setup duplication, storage, and recent
+   durations. Identify every automatic run caused by one logical change.
+2. Write down the load-bearing invariants and classify each check as automatic
+   blocking, scheduled/manual breadth, or release-only. Do not reclassify a check
+   merely because its runner is expensive.
+3. Read [cost-model.md](cost-model.md). Calculate the current per-PR, per-merge,
+   and periodic cost from current official rates and observed job durations.
+   State assumptions and show both actual and normalized cost where they differ.
+4. Read [optimizations.md](optimizations.md). Rank changes by savings,
+   confidence, and validation risk. Prefer removing work over making redundant
+   work slightly faster.
+5. Implement the smallest coherent set of workflow changes. Keep repository-
+   specific commands, required status names, platform obligations, and ruleset
+   details in the consuming repository's overlay.
+6. Validate workflow syntax, local build/test equivalents, required-context
+   behavior, and at least one hosted run for every retained native platform.
+   Compare observed durations with the estimate and record any gap.
+
+## Required output
+
+Report:
+
+- the current and proposed job/trigger topology;
+- observed durations, runner hardware, invocation assumptions, and the rate
+  source/date;
+- actual and normalized cost per PR, merged change, and periodic run;
+- validation invariants preserved automatically and breadth moved elsewhere;
+- expected savings, residual risks, and the hosted checks still required;
+- workflow files changed and deterministic validation performed.
+
+Do not present a precise percentage without exposing its inputs. Do not claim
+that a manual or scheduled workflow preserves coverage unless it has a named
+owner, trigger, and occasion or cadence.
+
+## Remote boundary
+
+Workflow edits are local and reversible. Changing repository rulesets, required
+status checks, budgets, merge-queue settings, or Actions retention settings is a
+remote operation: propose the exact change and wait for explicit approval.
+Committing, pushing, and opening a pull request remain separate approval
+boundaries defined by the consuming repository.
+
+## Sub-pages
+
+- [audit.md](audit.md) - inventory, validation invariants, and evidence
+  collection.
+- [cost-model.md](cost-model.md) - actual versus normalized cost calculations
+  and the reporting table.
+- [optimizations.md](optimizations.md) - ordered savings levers, guardrails, and
+  validation traps.

--- a/.agents/skills/github-actions-cost-optimization/audit.md
+++ b/.agents/skills/github-actions-cost-optimization/audit.md
@@ -1,0 +1,139 @@
+# Audit GitHub Actions usage
+
+Build an evidence-backed picture before editing a workflow. The audit has two
+outputs: the current job topology and the validation invariants that topology is
+supposed to enforce.
+
+## 1. Inventory local workflow topology
+
+Read every workflow under `.github/workflows/`, including reusable and release
+workflows. Record one row per job, after expanding matrix legs conceptually:
+
+| Field | What to record |
+| ----- | -------------- |
+| Workflow and job | Display name, job id, and matrix leg names |
+| Trigger | `pull_request`, `push`, `merge_group`, tag, schedule, dispatch, or caller |
+| Filters | Branch, tag, and path filters plus job-level `if` expressions |
+| Runner | Exact label, architecture, operating system, and standard/larger/self-hosted class |
+| Dependencies | `needs`, reusable workflow calls, and aggregate status jobs |
+| Work | Restore, build, tests, coverage, analysis, perf, AOT, pack, publish, or scripts |
+| Repetition | Checkout, SDK setup, restore, cache, and artifact transfer repeated in sibling jobs |
+| Storage | Cache keys/paths and uploaded artifact size and retention |
+| Controls | Concurrency group, cancellation policy, permissions, and timeout |
+
+Check for trigger overlap. A pull request that runs once before merge and again
+on the resulting default-branch push consumes two workflow lifecycles. Tag
+pushes can match both branch and release workflows. A reusable workflow is billed
+to its caller, so include it in the caller's topology rather than treating it as
+free shared infrastructure.
+
+Do not infer behavior from names. Confirm what each command compiles or runs,
+whether `--no-build` actually reuses prior output, and whether a cache path
+matches the tool's configured package/cache directory.
+
+## 2. Inventory remote merge and governance paths
+
+Read the repository rulesets or branch protection when access permits. Otherwise
+mark each item unverified and ask for the missing facts:
+
+- required status-check names and whether they are tied to a GitHub App;
+- pull-request and review requirements;
+- merge queue use and whether workflows handle `merge_group`;
+- administrator, team, automation, or deploy-key bypass paths;
+- whether direct pushes, merge commits, or branch updates can reach the default
+  branch without testing the exact merge candidate;
+- release environments, protected tags, and publishing approvals;
+- Actions budgets, artifact/log retention, and cache limits.
+
+This determines whether a default-branch `push` run is duplicate confirmation or
+the only validation for a bypass path. Do not remove it based only on the presence
+of a `pull_request` trigger.
+
+Required checks and path filters need special care. If an entire required
+workflow is skipped because no filtered path matched, GitHub can leave its check
+pending and block the merge. Prefer an always-created aggregate check, job-level
+conditional work, or a ruleset design that does not require a path-filtered
+workflow.
+
+## 3. State validation invariants
+
+List what must remain true before merge and release. Derive this from supported
+platforms, packaging promises, security posture, and repository guidance, not
+from the current matrix alone. Common invariants include:
+
+- Release configuration builds and tests the merge candidate;
+- legacy target frameworks compile or execute on a compatible host;
+- platform-specific source and native interop execute on each supported native
+  operating system or architecture that cannot be represented elsewhere;
+- coverage, API compatibility, formatting, generated-file, and lock-file gates
+  continue to fail the required aggregate check;
+- performance gates run in a stable environment and cannot reuse stale output;
+- trim and Native AOT paths publish and execute for the support contract they
+  protect;
+- package creation and release authentication are tested before publishing;
+- untrusted pull-request code never receives write tokens or secrets;
+- code scanning runs at the cadence and merge boundary required by the security
+  model.
+
+Classify each invariant:
+
+| Class | Meaning |
+| ----- | ------- |
+| Automatic blocking | Every merge candidate must pass it |
+| Scheduled/manual breadth | Important regression coverage with a named cadence or operator |
+| Release-only | Must pass before a release, but not every change |
+
+Record the owner and trigger for every non-automatic invariant. "Available
+manually" without an owner or occasion is deferred indefinitely, not preserved
+coverage.
+
+## 4. Collect representative execution evidence
+
+Use Actions usage/performance metrics when available. They expose workflow and
+job minutes, runner type, average runtime, queue time, and failure rate. The
+displayed usage metrics do not apply billing multipliers, so join them to current
+runner rates in the cost model.
+
+Without organization metrics, inspect recent runs with GitHub CLI:
+
+```shell
+gh run list --workflow WORKFLOW --limit 20
+gh run view RUN_ID --json event,startedAt,updatedAt,jobs
+```
+
+For each material job, collect successful, failed, and canceled samples over a
+representative period. Prefer at least 10 recent ordinary runs when the history
+exists. Report the median for a typical estimate and a high percentile (for
+example p75) for a conservative estimate. Keep queue time separate from runner
+execution time.
+
+Include:
+
+- reruns after flaky or infrastructure failures;
+- time consumed before superseded runs are canceled;
+- cache-hit and cache-miss samples;
+- pull-request updates per merged change;
+- scheduled, bot, merge-queue, and post-merge invocations;
+- jobs created only to emit required status contexts.
+
+Do not substitute workflow wall-clock duration for runner usage. Parallel jobs
+reduce elapsed feedback time while still consuming and billing each runner.
+
+## 5. Produce the baseline topology
+
+End the audit with:
+
+1. A diagram or table showing which logical change causes each workflow and job.
+2. The automatic, periodic, and release validation invariants.
+3. Unverified remote assumptions that could make an optimization unsafe.
+4. The duration samples and invocation frequencies used by the cost model.
+5. Obvious waste hypotheses, each paired with a check that could disprove it.
+
+Examples of falsifiable hypotheses:
+
+- "The default-branch run duplicates PR validation" is disproved by an allowed
+  direct-push or bypass path.
+- "This Linux job can move to ARM64" is disproved by an unavailable toolchain,
+  native dependency, or architecture-sensitive test.
+- "The cache saves restore time" is disproved when cache-hit and no-cache
+  durations are equivalent or the configured path is never populated.

--- a/.agents/skills/github-actions-cost-optimization/cost-model.md
+++ b/.agents/skills/github-actions-cost-optimization/cost-model.md
@@ -1,0 +1,160 @@
+# Model GitHub Actions cost
+
+Use current official billing rules and observed job durations. Do not preserve a
+copied price table as timeless policy: runner SKUs and rates change.
+
+## Sources
+
+Record the access date and use GitHub's current documentation:
+
+- [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)
+  for standard and larger runner rates and billing granularity;
+- [GitHub Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+  for plan allowances, public-repository treatment, and artifact/cache storage;
+- [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+  for visibility-specific CPU, memory, architecture, and image specifications;
+- [Actions usage metrics](https://docs.github.com/en/enterprise-cloud@latest/organizations/collaborating-with-groups-in-organizations/viewing-usage-metrics-for-github-actions)
+  for organization-level job and workflow evidence.
+
+At the time of analysis, verify rather than assume these rules:
+
+- whether each job's partial minute is rounded up independently;
+- whether the runner is standard, larger, or self-hosted;
+- whether repository visibility makes standard hosted minutes free;
+- whether plan allowances make the next minute non-billable but still consume a
+  finite quota;
+- current artifact, cache, and custom-image storage treatment.
+
+## Two cost views
+
+Always distinguish:
+
+1. **Actual invoiced cost.** What the owner is expected to pay under current
+   visibility, plan allowance, budgets, runner class, and storage usage.
+2. **Normalized list-price cost.** A synthetic rate-weighted measure: observed
+  job duration multiplied by current published runner rates before
+  public-repository or plan allowances.
+
+For a public repository on standard hosted runners, actual minute cost may be
+zero while normalized cost is nonzero. Report both. Normalized cost makes runner
+choices comparable, exposes resource use, and remains useful if visibility or
+billing policy changes.
+
+Runner labels do not always identify equivalent hardware across visibility. For
+example, GitHub can assign more CPU and memory to a standard public
+`ubuntu-latest` or `windows-latest` job than to the same label in a private
+repository. In that case:
+
+- call the normalized result a **synthetic rate-only comparison**;
+- record both hardware specifications beside the rate;
+- do not present the number as what making the repository private would cost;
+- forecast a visibility change only from durations measured on equivalent paid
+  hardware, or report a runtime range that accounts for the hardware change.
+
+Comparing alternatives measured on the same public runner remains useful, but
+the rate-weighted result ranks their observed usage rather than predicting a
+different runner's elapsed time.
+
+Do not label a self-hosted runner free. GitHub may not charge hosted-runner
+minutes, but infrastructure, maintenance, scaling, and incident response still
+have a cost. Model those separately when they matter.
+
+## Job-level calculation
+
+When current GitHub policy rounds each job up to a whole minute:
+
+```text
+billedMinutesPerJob = ceiling(observedRunnerSeconds / 60)
+normalizedJobCost = invocations * billedMinutesPerJob * currentRunnerRate
+```
+
+Apply the rounding to every matrix leg and aggregate job independently. Do not
+round the sum of raw seconds once at workflow level. This is why six 15-second
+jobs can cost six billed minutes while one sequential 90-second job costs two.
+
+Use runtime after a runner starts; queue time affects feedback latency but is not
+runner execution. Setup, checkout, restore, and cleanup run on the runner and do
+count. Canceled and failed jobs consume the time used before they stop.
+
+If GitHub changes billing granularity, replace the `ceiling` function with the
+current rule and cite it in the report.
+
+## Lifecycle calculation
+
+Calculate at least three scopes:
+
+```text
+perPullRequest = sum(PR update and rerun job costs)
+perMergedChange = perPullRequest + merge-queue + default-branch + deployment jobs
+monthlyPeriodic = scheduled frequency * cost per scheduled run
+```
+
+State invocation assumptions explicitly. Useful variables include:
+
+- average pull-request updates before merge;
+- percentage of pull requests merged;
+- bot/dependency pull-request volume;
+- flaky rerun rate;
+- cancellation delay for superseded runs;
+- releases and manual full-matrix runs per month.
+
+Report both a typical estimate (median durations and ordinary update count) and a
+conservative estimate (high-percentile durations plus observed reruns). Do not
+claim precision beyond the quality of the history.
+
+## Storage calculation
+
+Runner minutes and retained storage are separate. Inventory:
+
+- uploaded artifacts and their `retention-days`;
+- repository-level log/artifact retention;
+- cache size, key cardinality, churn, and eviction;
+- custom images used by larger runners;
+- package storage if the workflow publishes artifacts externally.
+
+GitHub bills applicable storage over time, commonly in GB-hours converted to
+GB-months. Deleting an artifact stops future accrual but does not erase storage
+already accrued. Use the current billing page for allowances and rates.
+
+Caching is an optimization only when its time savings exceed restore/upload
+overhead and storage pressure. Compare cache-hit, cache-miss, and no-cache runs.
+Key caches on dependency inputs and runner compatibility; a cache pointed at a
+different directory than the tool uses has zero benefit.
+
+## Reporting table
+
+Use one row per expanded job:
+
+| Workflow / job | Trigger | Runner / hardware / SKU | Runs per scope | p50 / p75 | Billed min | Rate | Normalized cost |
+| -------------- | ------- | ----------------------- | -------------- | --------- | ---------- | ---- | --------------- |
+| Example | PR | current label and specs | measured | measured | calculated | dated source | calculated |
+
+Then summarize:
+
+| Scope | Current actual | Current normalized | Proposed actual | Proposed normalized | Change |
+| ----- | -------------- | ------------------ | --------------- | ------------------- | ------ |
+| Pull request | | | | | |
+| Merged change | | | | | |
+| Monthly periodic | | | | | |
+
+Calculate reduction as:
+
+```text
+reductionPercent = (currentNormalized - proposedNormalized) / currentNormalized * 100
+```
+
+If current normalized cost is zero, report the absolute duration/job reduction
+instead of an undefined percentage.
+
+## Sanity checks
+
+- The sum includes every matrix leg and every tiny aggregate job.
+- PR and default-branch triggers are modeled separately.
+- Public-repository free usage is not presented as zero resource consumption.
+- Visibility-specific runner hardware is recorded; a synthetic public-duration
+  by private-rate number is not presented as a private-repository forecast.
+- Larger runners are not assumed free for public repositories.
+- Canceled, failed, scheduled, release, and manual runs are either modeled or
+  explicitly excluded.
+- Rates have a source and access date.
+- The proposed estimate uses the same assumptions as the baseline.

--- a/.agents/skills/github-actions-cost-optimization/optimizations.md
+++ b/.agents/skills/github-actions-cost-optimization/optimizations.md
@@ -1,0 +1,153 @@
+# Optimize GitHub Actions safely
+
+Apply changes in this order. Earlier steps remove unnecessary work and usually
+carry less validation risk than deleting matrix dimensions.
+
+## 1. Stop runs that should not start
+
+- Cancel superseded pull-request runs with a concurrency key stable for that
+  pull request. A run id is unique and therefore cannot cancel anything.
+- Remove the default-branch `push` trigger only when rulesets prove every path to
+  the branch validates an equivalent merge candidate. Keep it when direct or
+  bypass pushes remain possible.
+- Avoid overlapping branch, tag, and release workflows.
+- Use path filters for optional workflows whose absence cannot block a required
+  status. For required checks, ensure the context is always emitted.
+- Group dependency updates when repository policy permits so one compatible
+  batch pays one CI lifecycle instead of many.
+- Add `merge_group` when a merge queue requires testing the synthetic merge
+  candidate; do not count a PR-head test as equivalent.
+
+## 2. Remove repeated setup and rounding overhead
+
+Every job pays for runner startup, checkout, SDK/tool setup, restore, and current
+job-level billing granularity. Consolidate sequential work that needs the same
+runner and artifacts when the saved setup and rounded minutes outweigh the lost
+parallelism.
+
+Good consolidation candidates include build plus tests, multiple target
+framework test invocations on one compatible host, and performance gates that
+can reuse a verified Release build. Preserve separate jobs when they provide
+material wall-clock savings, isolation, permissions boundaries, or genuinely
+different runners.
+
+Do not split tiny script checks into many jobs merely for presentation. A cheap
+aggregate required check should be one job when one stable context is enough.
+
+## 3. Choose the cheapest compatible runner
+
+- Use a slim one-core Linux runner for short scripts and aggregate status jobs
+  when its toolset and speed are sufficient.
+- Prefer standard Linux for portable build/test work.
+- Consider Linux ARM64 only after restore, toolchain, native dependency, and test
+  compatibility are demonstrated. Architecture substitution is a test-coverage
+  decision as well as a price decision.
+- Keep Windows or macOS where native APIs, legacy frameworks, packaging, signing,
+  filesystem semantics, or supported-platform behavior requires them.
+- Compare larger runners by total job cost, not minute rate alone. A faster,
+  more expensive runner can be cheaper if measured runtime falls enough.
+
+Cross-compiling proves compilation for a target; it does not replace executing
+native behavior on that target.
+
+## 4. Make the automatic matrix load-bearing
+
+Run Release tests automatically because Release code generation is what ships.
+Keep Debug automatic only when it detects a distinct class of regressions that
+the project has chosen to gate.
+
+For operating-system, architecture, target-framework, runtime-identifier, AOT,
+and SDK matrices:
+
+1. Map every leg to a stated invariant.
+2. Keep merge-blocking legs for common or high-risk behavior.
+3. Move expensive breadth to a named scheduled/manual workflow or a release gate
+   only when delayed detection is acceptable.
+4. Give periodic breadth a cadence and owner so it cannot silently rot.
+
+Do not call a reduced automatic matrix "equivalent" to the full matrix. Report
+what remains automatic and what becomes delayed.
+
+## 5. Fix restore and cache behavior
+
+- Restore once per job and use `--no-restore` or the tool's equivalent only when
+  the following command truly supports it.
+- Point the cache at the actual configured package directory. If an environment
+  variable redirects that directory, cache the redirected path.
+- Include operating system, architecture, lock files, SDK/tool versions, and
+  other compatibility inputs in the key when they affect cache validity.
+- Use restore keys only when a partial match is safe.
+- Remove caches whose hit-rate or measured savings do not justify upload,
+  download, and storage churn.
+
+Never share build output across jobs without proving it cannot become stale or
+mix configurations. Rebuilding is cheaper than trusting the wrong binary.
+
+## 6. Control artifacts and logs
+
+- Upload only outputs needed by downstream jobs, diagnostics, or release.
+- Set the shortest practical `retention-days` on large transient artifacts.
+- Avoid uploading duplicate binaries from every matrix leg.
+- Keep test logs and failure diagnostics long enough to debug ordinary failures.
+- Review repository retention and cache limits as remote settings; changing them
+  requires approval.
+
+## 7. Treat security scans as security decisions
+
+Moving CodeQL or another scanner from every pull request to a schedule lowers
+runner cost but delays detection. Before doing so, record:
+
+- whether the repository handles untrusted input or sensitive data;
+- whether language/compiler analyzers cover part of the same risk;
+- whether branch protection currently requires the scan;
+- scheduled cadence, alert ownership, and response expectations;
+- whether release gates need a fresh scan.
+
+Use a security-review workflow when this decision is material. Never run
+untrusted pull-request code with write permissions or repository secrets to save
+the setup cost of a separate trusted job.
+
+## 8. Preserve required-check behavior
+
+When branch protection depends on historical check names, a temporary aggregate
+job can preserve them while the underlying topology changes. The aggregate must:
+
+- use `if: always()` so it runs after failed, canceled, or skipped dependencies;
+- inspect every dependency result;
+- succeed only when all required dependencies succeeded;
+- use a cheap compatible runner and a short timeout.
+
+An aggregate that runs only after success can be skipped on failure and leave an
+ambiguous required context. An aggregate that accepts `skipped` without a
+deliberate policy can turn missing validation green.
+
+Update or remove legacy contexts only with explicit approval to change the
+remote ruleset. Required-check changes and workflow changes should be sequenced
+so merges are never accidentally unguarded.
+
+## 9. Validate in layers
+
+After each coherent edit:
+
+1. Run an Actions-aware linter and YAML/editor diagnostics.
+2. Run whitespace and repository policy checks.
+3. Execute the local build, Release tests, and any perf/AOT/package commands the
+   changed automatic jobs will use.
+4. Confirm cache paths and generated artifact locations statically.
+5. Push only with approval and observe one hosted run on every retained native
+   platform and architecture.
+6. Confirm required contexts appear and fail closed for a deliberately failed or
+   canceled dependency when practical.
+7. Replace estimated durations with hosted measurements and recalculate cost.
+
+## Common traps
+
+- A path-filtered required workflow never starts and leaves the PR pending.
+- A concurrency group includes a unique run id, so no prior run is canceled.
+- A cache saves the default directory while the build uses a redirected one.
+- A shallow checkout changes git-derived versioning such as MinVer.
+- `--no-build` reuses output from a different configuration or target.
+- A manual full matrix has no cadence or owner and quietly stops being useful.
+- Removing post-merge CI ignores an administrator or automation bypass path.
+- Replacing native execution with cross-compilation drops behavior coverage.
+- Many tiny jobs look parallel but multiply setup and rounded billing minutes.

--- a/.agents/skills/github-actions-cost-optimization/overlay.md
+++ b/.agents/skills/github-actions-cost-optimization/overlay.md
@@ -1,0 +1,45 @@
+---
+core: github-actions-cost-optimization
+core-pin: 85325dbeb5d5c3e9be39b9f7725a25d971b77d8a
+---
+
+# madowaku overlay - github-actions-cost-optimization
+
+Repository-specific companion to the vendored
+[github-actions-cost-optimization](SKILL.md) skill. The `SKILL.md` and its
+sibling pages are a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to an unreleased commit.** This skill postdates the commons `v0.10.0`
+> tag, so `core-pin` is the commit SHA
+> `85325dbeb5d5c3e9be39b9f7725a25d971b77d8a` rather than a release tag. Re-pin to
+> a tag once the commons ships one that includes this skill.
+
+## madowaku bindings
+
+- **The workflows to model** are
+  [.github/workflows/dotnet.yml](../../../.github/workflows/dotnet.yml) (build and
+  test), [.github/workflows/publish.yml](../../../.github/workflows/publish.yml)
+  (packaging `KlutzyNinja.Madowaku`), and
+  [.github/workflows/agent-files.yml](../../../.github/workflows/agent-files.yml)
+  (agent-file validation, already path-filtered).
+- **Do not weaken required validation to save minutes.** The matrix that builds
+  `net10.0`, `net10.0-windows10.0.22000.0`, and `net472` exists for correctness;
+  optimize triggers, caching, and artifact retention before dropping a leg.
+- **Application runtime performance is out of scope here** - that is
+  [`performance-testing`](../performance-testing/SKILL.md).
+
+## Cross-references
+
+- [`engineering-baseline`](../engineering-baseline/SKILL.md) - the CI domain this
+  cost lens refines.
+- [`security-review`](../security-review/SKILL.md) - keep supply-chain checks
+  (pinned actions, least privilege) intact while trimming cost.
+
+## Updating
+
+Pull upstream changes with `gh skill update github-actions-cost-optimization`
+(review the diff, re-pin `core-pin`) - ideally re-pinning to a release tag once
+one includes this skill.

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -1,0 +1,131 @@
+---
+compatibility: Requires a Release build with portable or embedded PDBs and an IL reader such as ilspycmd, ildasm, Cecil, or System.Reflection.Metadata.
+description: Find struct value copies in a method's compiled IL - defensive copies, boxing, by-value field/argument/return copies - by reading the emitted bytecode rather than predicting from source. Use when asked to "find struct copies", "where does the compiler copy this struct", "is this a defensive copy", "check for boxing in IL", "did the compiler emit a copy here", "confirm the analyzer's defensive-copy warning", or "audit a [NonCopyable] type's copies after build". Post-build, ground-truth counterpart to source-level defensive-copy analyzers - IL is post-lowering, so synthesized copies the analyzer cannot see are visible here. Not for wall-clock/allocation measurement (that is `performance-testing`) nor for JIT-emitted machine code (that is `framework-jit-optimization` + `DisassemblyDiagnoser`).
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/il-copy-inspection
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 07bce64dc12f798aeeec01aab716d26bbde5c0ed
+    maturity: canary
+    portability: portable
+    related: roslyn-analyzers, framework-jit-optimization, performance-testing, scratch-buffer-strategy
+    requires: none
+    risk: advisory
+name: il-copy-inspection
+---
+
+# Inspecting IL for struct copies
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+A struct copy is invisible in C# source but concrete in IL. This skill reads a
+method's **emitted bytecode** to find where the compiler actually copies a value
+type - defensive copies, boxing, and by-value field/argument/return copies - and
+maps each back to a source line. It is the ground-truth, post-build complement to
+the predictive, in-IDE rules of a source-level defensive-copy analyzer.
+
+## The four layers (where this sits)
+
+A struct copy can be reasoned about at four levels. Pick the layer that answers the
+question; they are complementary, not interchangeable.
+
+| Layer | Artifact | Tool / skill | What it tells you |
+| ----- | -------- | ------------ | ----------------- |
+| Source | `IOperation` (pre-lowering) | `roslyn-analyzers` (defensive-copy rules) | A copy is *predicted* from C# rules, live in the IDE |
+| **IL** | **compiled bytecode (post-lowering)** | **this skill** (`ildasm` / `ilspycmd` / Cecil) | **A copy was *emitted* by the C# compiler** |
+| Asm | JIT machine code | `framework-jit-optimization` + `DisassemblyDiagnoser` | Whether the JIT *kept* the copy or elided it |
+| Runtime | ETW / wall-clock | `performance-testing` + `filtrace` | Whether the copy *costs* measurable time / allocation |
+
+The IL layer is uniquely able to see copies the **compiler synthesizes during
+lowering** - async / iterator state-machine field hoisting, closures, thunks -
+which have no source operation and are therefore out of reach for an analyzer. It
+is also the cheapest way to *confirm* a defensive-copy prediction: if the IL has
+the defensive-copy signature, the analyzer was right.
+
+## Step 0 - is something already answering this?
+
+- **"Does my code have a defensive copy I can fix in the editor?"** -> a
+  source-level defensive-copy analyzer (`roslyn-analyzers`) already flags the
+  common cases live. Use this skill only to (a) confirm a flagged case, or (b) find
+  the synthesized copies the analyzer documents as out of scope.
+- **"Is this copy actually costing me time / allocations?"** -> `performance-testing`
+  (boxing shows as `Allocated` under `[MemoryDiagnoser]`; a hot defensive copy shows
+  in a trace).
+- **"Did the JIT keep the copy?"** -> `framework-jit-optimization` /
+  `[DisassemblyDiagnoser]`. The C# compiler may emit an IL copy that the JIT then
+  elides, so IL presence is necessary but not sufficient for a runtime cost.
+- Otherwise, read the IL (below).
+
+## Workflow
+
+1. **Build Release with a portable PDB.** Optimized IL is what ships; Debug IL has
+   extra copies and spills. The PDB's sequence points are what map IL offsets back
+   to `file:line`. Make sure the build emits a portable PDB -
+   `<DebugType>embedded</DebugType>` or `<DebugType>portable</DebugType>` in the
+   project.
+2. **Extract the method's IL.** Pick a tool from the table below. Disassemble the
+   single method of interest, not the whole assembly.
+3. **Match the copy patterns.** Scan the method body for the copy opcodes and the
+   defensive-copy temp signature. The full catalog - every opcode, the
+   `ldobj`/`stloc`/`ldloca`/`call` defensive sequence, `box`, `cpobj`, `ldfld` vs
+   `ldflda` - is in
+   [references/copy-opcodes.md](references/copy-opcodes.md).
+4. **Map IL offset to source.** Use the PDB sequence points (most disassemblers can
+   interleave source, e.g. `ilspycmd -il` with debug info, or read sequence points
+   via `System.Reflection.Metadata`) to attribute each copy to a line - the same
+   artifact-to-source drill the `performance-testing` skill does with `filtrace`.
+5. **Report** the type copied, the mechanism (defensive / box / by-value), and the
+   source line. Distinguish *intended* copies (a documented value transfer) from
+   *unintended* ones; IL alone cannot, so use the source context.
+
+## Tool options
+
+| Tool | Good for | Note |
+| ---- | -------- | ---- |
+| `ilspycmd -il <dll>` ([ICSharpCode.ILSpyCmd](https://github.com/icsharpcode/ILSpy)) | One-method IL dump, scriptable | `dotnet tool install -g ilspycmd`; cross-platform |
+| `ildasm` | Quick Windows dump | Ships with the .NET SDK / VS; Windows-centric |
+| `Mono.Cecil` | Programmatic body walking, custom rules | Best when scripting a repeatable copy audit |
+| `System.Reflection.Metadata` (`MetadataReader`, `MethodBodyBlock`) | In-proc, no extra dependency, owns the PDB sequence-point mapping | Most code; the right base for an automated pass |
+
+For a repeatable, automated audit, `Mono.Cecil` or `System.Reflection.Metadata`
+walking the method body and matching the opcode patterns from the catalog is the
+durable choice; `ilspycmd` is the fastest manual spot-check.
+
+## Constraints
+
+- **Needs a build and a PDB.** Unlike an analyzer (source only), this requires
+  compiled output. No PDB means no source-line mapping - opcodes only.
+- **IL copy != runtime cost.** The JIT may elide an emitted copy. Confirm cost at
+  the asm or runtime layer before claiming a perf impact.
+- **Generics share IL.** A copy of `T` appears once in the shared body; the real
+  cost depends on the instantiation. Note the open generic, then reason per
+  value-type substitution.
+- **Intent is lost in IL.** A by-value copy that is a deliberate transfer looks
+  identical to an accidental one. Keep the source open to classify; this is the same
+  "unintended vs intended" limit a defensive-copy analyzer's docs call out.
+
+## Cross-skill
+
+- `roslyn-analyzers` - the source-level, predictive side (defensive-copy rules).
+  This skill confirms its predictions and covers the synthesized copies it cannot
+  see.
+- `framework-jit-optimization` - the next layer down (asm); whether the JIT kept the
+  copy, and what to do about it on .NET Framework.
+- `performance-testing` - whether the copy costs measurable time / allocation.
+- `scratch-buffer-strategy` - many `[NonCopyable]` types are pooled buffers; this
+  skill audits whether one is being copied by value.
+- A consuming repository wires these cross-references and its concrete diagnostic
+  IDs and project names in its overlay.
+
+## Disambiguation
+
+"Find the copies" is ambiguous across layers. Route by artifact: **predict from
+source, live** -> `roslyn-analyzers`; **read the compiler's emitted IL** -> this
+skill; **read the JIT's machine code** -> `framework-jit-optimization`; **measure
+the runtime cost** -> `performance-testing`. This skill never runs the code and
+never measures time - it reads static bytecode.

--- a/.agents/skills/il-copy-inspection/overlay.md
+++ b/.agents/skills/il-copy-inspection/overlay.md
@@ -1,0 +1,39 @@
+---
+core: il-copy-inspection
+core-pin: v0.10.0
+---
+
+# madowaku overlay - il-copy-inspection
+
+Repository-specific companion to the vendored [il-copy-inspection](SKILL.md)
+skill. The `SKILL.md` and its `references/copy-opcodes.md` page are a **pinned
+copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **The high-value targets are the interop value types.** madowaku is dense with
+  large mutable structs passed by value at the COM boundary - `VARIANT`,
+  `SAFEARRAY`, `ComScope<T>`, `BSTR`, `PWSTR` - where a hidden defensive copy or
+  a box silently costs allocations and correctness.
+- **Read IL on both targets.** A copy the modern-.NET JIT elides can persist on
+  the `net481` RyuJIT; inspect the framework build too.
+- **Pair a finding with a benchmark** in
+  [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj) before reshaping a
+  hot type.
+
+## Cross-references
+
+- [`cswin32-com`](../cswin32-com/SKILL.md) - the struct-based COM interop that
+  produces most of madowaku's copy-sensitive types.
+- [`performance-testing`](../performance-testing/SKILL.md) - the harness that
+  quantifies the copy or box the IL reveals.
+
+## Updating
+
+Pull upstream changes with `gh skill update il-copy-inspection` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/il-copy-inspection/references/copy-opcodes.md
+++ b/.agents/skills/il-copy-inspection/references/copy-opcodes.md
@@ -1,0 +1,100 @@
+# IL copy opcode and pattern catalog
+
+Reference for the [il-copy-inspection](../SKILL.md) skill. The opcodes and patterns
+that correspond to a struct value copy in compiled IL, and how to tell each apart
+from its non-copying address-based counterpart.
+
+## The defensive-copy signature
+
+A *defensive copy* is the one the compiler inserts silently when a non-`readonly`
+instance member is invoked on a read-only struct location (an `in` parameter, a
+`readonly` field, a `ref readonly` local). It is the highest-value find because it
+is invisible in source. For `void M(in Pooled p) => p.Mutate();` where `Mutate` is
+not `readonly`, the compiler emits a **synthesized temporary**:
+
+```cil
+ldarg.1            // &p   - address of the in-parameter (no copy yet)
+ldobj      Pooled  // copy *p onto the stack
+stloc.0            // spill the copy into a compiler temp local
+ldloca.s   0       // &temp - address of the COPY
+call       instance void Pooled::Mutate()   // mutate the copy, then discard it
+```
+
+The tell is the **`ldobj` -> `stloc <temp>` -> `ldloca <temp>` -> `call instance`**
+chain on a receiver that started as an address (`ldarg`/`ldflda`/`ldsflda` of a
+read-only location). The mutation lands on the temp and is thrown away. Contrast the
+no-copy form, where a `readonly` member (or a mutable receiver) is called directly
+on the address with no intervening `ldobj`/`stloc`:
+
+```cil
+ldarg.1            // &p
+call       instance int32 Pooled::Peek()    // readonly member - no copy
+```
+
+## Explicit copy opcodes
+
+| Opcode | Meaning | Copy? |
+| ------ | ------- | ----- |
+| `ldobj <type>` | Load a value type from an address onto the stack | **Yes** - copies the value |
+| `stobj <type>` | Store a value type from the stack through an address | **Yes** |
+| `cpobj <type>` | Copy a value type from one address to another | **Yes** |
+| `box <type>` | Box a value type into a reference | **Yes** - copy + heap allocation |
+| `unbox.any <type>` | Unbox to a value on the stack | **Yes** - copies out |
+| `ldfld <field>` | Load a field **by value** | **Yes** when the field is a struct |
+| `ldflda <field>` | Load a field **address** | No - address, no copy |
+| `ldsfld` / `ldsflda` | Static field, by value / by address | `ldsfld` copies; `ldsflda` does not |
+| `ldloc` / `ldloca` | Local, by value / by address | `ldloc` of a struct copies; `ldloca` does not |
+| `ldarg` / `ldarga` | Argument, by value / by address | `ldarg` of a struct copies; `ldarga` does not |
+| `ldelem <type>` / `ldelema` | Array element, by value / by address | `ldelem` copies; `ldelema` does not |
+
+The recurring distinction is **value form vs address form**: the `...a` suffix
+(`ldflda`, `ldloca`, `ldarga`, `ldelema`, `ldsflda`) takes an address and does
+**not** copy. The non-`a` form of a struct loads a copy.
+
+## By-value argument / return / assignment
+
+- **By-value argument.** A struct pushed onto the stack (via `ldloc`/`ldfld`/etc.,
+  not `ldloca`) into a call whose parameter is not `ref`/`in`/`out` is copied into
+  the callee. The callee's signature (no `&` on the parameter type) confirms by-value.
+- **By-value return.** `ret` with a struct value on the stack returns a copy. A
+  method that returns `ref` puts an address on the stack instead - no copy.
+- **Assignment / field store.** `stfld`/`stloc`/`stsfld` of a struct value, or
+  `stobj`/`cpobj` through an address, copies into the destination.
+
+## Boxing
+
+`box <ValueType>` is the easiest copy to spot and almost always unintended for a
+resource-owning struct: it copies the value onto the GC heap. It appears whenever a
+value type is converted to `object`, an interface, or `dynamic`, or wrapped in
+`Nullable<T>` patterns. Boxing is also the one copy whose runtime cost (an
+allocation) is directly visible at the runtime layer via `[MemoryDiagnoser]`.
+
+## Caveats when reading IL
+
+- **Move vs copy is still inferred.** IL shows a copy opcode but not whether the
+  source value had another owner. A `ldloc`/`ldobj` feeding a `ret` may be a
+  deliberate transfer. Cross-reference the source line (via the PDB) before calling
+  it unintended - the same limit the source analyzer documents.
+- **The JIT may elide it.** `ldobj`/`stloc` of a small struct can be optimized away
+  by the JIT. IL presence proves the *compiler* copied; confirm a *runtime* cost at
+  the asm (`DisassemblyDiagnoser`) or trace layer.
+- **Generics emit shared IL.** The body of a generic method shows one copy of `T`;
+  whether `T` is a large struct, a small struct, or a reference type changes the
+  real cost. Record the open generic and reason per value-type instantiation.
+- **Debug vs Release.** Debug IL adds spills and temporaries that look like copies.
+  Always read optimized Release IL for a representative picture.
+- **Compiler-synthesized members.** Async/iterator state machines hoist captured
+  structs into generated fields; the copy lives in the `MoveNext` body, not the
+  user method. Disassemble the generated nested type to see it.
+
+## Mapping IL offset to source line
+
+Each IL instruction has an offset; the portable PDB's **sequence points** map offset
+ranges to `(document, startLine, startColumn)`. To attribute a copy:
+
+- With a disassembler: use a mode that interleaves source (`ilspycmd` with debug
+  info, ILSpy's "IL with C#").
+- Programmatically: open the PDB with `System.Reflection.Metadata.MetadataReader`,
+  read the method's `MethodDebugInformation.GetSequencePoints()`, and find the
+  sequence point whose IL range contains the copy opcode's offset. This is the same
+  offset-to-line mechanism a profiler uses, applied statically.

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -1,0 +1,101 @@
+---
+compatibility: Requires gh 2.90 or later for install and update operations; manual file comparison remains available without gh.
+description: Find, add, update, and share agent skills in this repo. Use when asked to "find a skill" for a task, "build a skill" or "create a skill" (this skill checks whether one already exists - in the repo, the shared commons, or a public catalog - before authoring a new one), "update a skill", or reconcile a local skill change against the upstream commons vs a repo-local overlay. Covers the find-first build path, the tiered search, and the pull/push update flow. Not for validating one agent file's syntax - that is `agent-files-review`.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/manage-skills
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: bb78d07296156a84ee9f54023145532a5275607a
+    maturity: canary
+    portability: portable
+    related: agent-files-review
+    requires: none
+    risk: remote-write
+name: manage-skills
+---
+
+# Manage skills
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+The lifecycle skill for the skills under a repo's `.agents/skills/`: discover one,
+add one, update one, and keep local changes in sync with the shared set. It turns
+"find a skill", "build a skill", and "update the skill" into actions aligned with
+the sharing model instead of ad-hoc edits.
+
+The model in one paragraph: skills are authored once as a portable **core** and
+shared through a common skills repo (the **commons**); each consuming repo holds a
+pinned, provenance-stamped **copy** plus a thin repo-specific **overlay**. The
+commons is bidirectional - a generic improvement made in any repo flows back
+upstream, while a repo-specific tweak lives only in that repo's overlay.
+
+## The three verbs
+
+| Ask | Do | Detail |
+| --- | --- | ------ |
+| "find a skill for X", "is there a skill that does X" | Tiered search (local -> commons -> public), with an applicability check for this repo. | [find.md](find.md) |
+| "build a skill for X", "create a skill" | **Run find first.** Only author new if it exists nowhere; otherwise vendor or tweak the existing one. | [build.md](build.md) |
+| "update the skill", "sync my change", "pull skill updates" | Pull upstream drift; or push a local improvement, classified common (ask before upstreaming) vs deviation (overlay). | [update.md](update.md) |
+
+These chain: `build` always begins by running `find`, and a `find` that turns up a
+local skill needing a tweak hands off to the overlay path in `build`.
+
+## The golden rule
+
+When you change a skill that was vendored from the commons: **never let a vendored
+core diverge silently.** A vendored core is a mirror of upstream. Classify the
+edit, then place it - and **nothing about upstreaming is automatic**:
+
+- **Local deviation** (the change is specific to this repo) -> move it into the
+  repo's **overlay**, and restore the vendored core to match upstream.
+- **Common** (the change helps every consumer) -> it *should* go upstream, but
+  upstreaming is not always plausible. **Ask** before attempting it; never open a
+  commons PR unprompted. If upstreamed, re-pin to the new version; if not yet,
+  keep it as a recorded *pending-upstream divergence* so it is intentional, not
+  silent.
+
+So a vendored-core edit ends in one of three **recorded** states - upstreamed,
+moved to the overlay, or a tracked pending-upstream divergence - never an
+unexplained one. The provenance frontmatter (source repo, ref, and tree SHA) plus
+the `update` drift check is what enforces this: unexplained drift is the signal
+that an improvement was written into the wrong layer. See [update.md](update.md).
+
+## Conventions every skill follows
+
+Whatever the verb, the result must satisfy the repo's authoring rules
+(`FORMAT.md`) and then pass `agent-files-review`, which owns the file-level
+checks - frontmatter, mirror sync, whitespace, and the validator and link
+checker. Don't restate those rules here.
+
+For the `SKILL.md` frontmatter check specifically, this skill bundles
+[scripts/Validate-Skills.ps1](scripts/Validate-Skills.ps1) - a dependency-free
+PowerShell port of the Agent Skills spec validator - so the check runs anywhere
+the skill is vendored, without the upstream tool. Run it on the skill directory:
+`pwsh scripts/Validate-Skills.ps1 <skill-dir>`. A commons portfolio uses
+`-RequirePortfolioMetadata` to enforce its metadata and overlay contract.
+
+For a new downstream binding, start from
+`assets/overlay.md.tmpl`, replace its skill and pin tokens, and keep every local
+path and concrete cross-reference in that overlay.
+
+## Sub-pages
+
+- [find.md](find.md) - the tiered search, the applicability check, and the
+  recommendation report.
+- [build.md](build.md) - the find-first decision tree, the security gate for
+  public sources, and authoring a new skill (born-local vs born-shared).
+- [update.md](update.md) - the pull (drift) and push (common vs deviation)
+  flows and the provenance mechanics behind the golden rule.
+
+## Disambiguation
+
+`manage-skills` operates on the **catalog lifecycle** - discover, add, vendor,
+sync. It is not `agent-files-review`, which
+validates the **syntax and conventions** of one agent file (frontmatter, mirror
+sync, whitespace). The normal order is: run `manage-skills` to bring a skill in
+or push one out, then `agent-files-review` to validate the file you ended up with.

--- a/.agents/skills/manage-skills/assets/overlay.md.tmpl
+++ b/.agents/skills/manage-skills/assets/overlay.md.tmpl
@@ -1,0 +1,21 @@
+---
+core: {{SKILL_NAME}}
+core-pin: {{CORE_PIN}}
+---
+
+# {{SKILL_NAME}} overlay
+
+Repository-specific bindings for the vendored core beside this file. Keep paths,
+project names, local examples, and concrete cross-skill links here. Do not copy
+portable workflow rules out of the core.
+
+## Bindings
+
+- Replace this line with the repository-specific paths and conventions the core
+  needs.
+
+## Updating
+
+When the core is re-pinned, update `core-pin`, review these bindings against the
+new core, and run the repository's strict skill validator and relative-link
+check.

--- a/.agents/skills/manage-skills/build.md
+++ b/.agents/skills/manage-skills/build.md
@@ -1,0 +1,85 @@
+# Build a skill
+
+Detail for the [manage-skills](SKILL.md) skill. "Build a skill for X" / "create a
+skill" does **not** start by writing a new skill. It starts by finding one.
+
+## The find-first decision tree
+
+Reinventing a skill that already exists - in this repo, the commons, or a public
+catalog - is the failure mode this path exists to prevent. Always run
+[find.md](find.md) first, then act on the result:
+
+1. **Run find.**
+2. **Already in this repo** -> do not build. If it does not quite fit, add or edit
+   the repo's **overlay** (see [update.md](update.md)), never the vendored core.
+3. **In the commons** -> do not build. Vendor it and add a thin overlay for any
+   repo-specific paths or cross-references:
+
+   ```pwsh
+   gh skill install JeremyKuhne/agent-skills <skill> --pin vX.Y.Z
+   ```
+
+   `--pin` records the exact version so later `update --all` runs skip it until
+   you deliberately re-pin. The install writes provenance frontmatter (source
+   repo, ref, and tree SHA); commit it.
+4. **In a public catalog** -> do not build from scratch. Apply the security gate
+   below. If it is good, vendor it; if it is close but imperfect, fork it into the
+   commons and vendor that. A mediocre public skill is usually worth adapting over
+   a blank start.
+5. **Nowhere** -> build new (next section).
+
+## Security gate for public sources
+
+Public skills are an instruction-injection supply chain - audits have found a
+meaningful fraction carry a critical issue (prompt injection, malicious scripts,
+exposed secrets). Before installing anything from a public source:
+
+- **Preview, do not blind-install:** `gh skill preview <owner/repo> <skill>` and
+  read the `SKILL.md`, every script, and every `references/` file - not just the
+  summary.
+- **Pin** to a tag or commit SHA; never track a moving ref.
+- **Never accept `allowed-tools` from a third party**, especially `shell` / `bash`
+  - it removes the per-command confirmation. Strip it on import and let the host
+  prompt.
+- **Prefer provenance-bearing sources** (the curated registry, verified
+  publishers) over a random repo from a blog post.
+- Treat a cloned repo's `.agents/` as untrusted code: opening it can load skills
+  into a trusted session.
+
+## Building a new skill (it exists nowhere)
+
+Author it to the repo's `FORMAT.md`:
+
+- A thin `SKILL.md` core under the size budget; push deep detail into sibling
+  `*.md` files in the same directory (the pattern this very skill uses).
+- `name` matches the directory; a "pushy" `description` with explicit trigger
+  phrasing that will auto-invoke on the right asks without over-firing.
+- Set every portfolio metadata field (`portability`, `applicability`, `binding`,
+  `risk`, `maturity`, `requires`, and `related`) using the repo's `FORMAT.md`.
+- For an overlay-aware core, include the standard loader sentence. Create a
+  downstream overlay from `assets/overlay.md.tmpl`; replace `{{SKILL_NAME}}` and
+  `{{CORE_PIN}}`, then add only repository-specific bindings.
+- Add a row to the catalog `README.md` inventory in the same change, and a
+  disambiguation entry if the trigger phrasing competes with an existing skill.
+- Validate the `SKILL.md` frontmatter with the bundled
+  [scripts/Validate-Skills.ps1](scripts/Validate-Skills.ps1) in strict portfolio
+  mode, then run the repo's remaining agent-file checks (the installed-artifact
+  link check, markdown lint, and generated catalog check).
+
+### Born-local vs born-shared
+
+Decide where the skill's home is before writing much:
+
+- **Born-local** - the skill is specific to this repo (its paths, projects, or
+  one-off workflow). Author it here under `.agents/skills/` and leave it; it never
+  goes to the commons.
+- **Born-shared** - the skill is generic and other repos will want it. Author the
+  portable core directly in the commons, then vendor it back here with an overlay.
+  Keep repo-specific paths, cross-references, and example links out of the core
+  from the start - they belong in the overlay. Leave a short prose cue in the core
+  telling the agent to read `overlay.md` when present; that stable loader contract
+  is what gets the overlay read.
+
+A skill that is mostly generic but needs a few local specifics is still
+born-shared: the generic part is the core, the specifics are the overlay. The test
+is whether another repo would want the core unchanged.

--- a/.agents/skills/manage-skills/find.md
+++ b/.agents/skills/manage-skills/find.md
@@ -1,0 +1,65 @@
+# Find a skill
+
+Detail for the [manage-skills](SKILL.md) skill. Answers "find a skill for X" /
+"is there a skill that does X" with a tiered search and a per-repo applicability
+check, then a short recommendation.
+
+## Tiered search (nearest trust first)
+
+Search in order and stop reporting once you have the picture; do not skip a tier,
+because a local hit changes the recommendation entirely.
+
+1. **Local - this repo's `.agents/skills/`.** List the skill directories and read
+   the catalog `README.md` inventory and disambiguation. A match here means the
+   skill is already present; the answer is "you have it", and the only question is
+   whether it needs an overlay tweak. No tooling required.
+
+2. **The commons.** Search the shared skills repo:
+
+   ```pwsh
+   gh skill search <terms> --repo JeremyKuhne/agent-skills
+   ```
+
+   Anything here is curated and pre-vetted. When `gh` is unavailable, browse the
+   commons repo directly and note that the install path will be manual.
+
+3. **Public catalogs.** Search the wider ecosystem - the awesome-copilot
+   collection, `anthropics/skills`, and the registry:
+
+   ```pwsh
+   gh skill search <terms>
+   ```
+
+   Public results are **untrusted by default**. Do not recommend installing one
+   without the security gate in [build.md](build.md). When `gh` is unavailable,
+   fall back to browsing the catalogs in a browser and note that the install path
+   will be manual.
+
+## Applicability check
+
+A skill existing is not the same as a skill belonging here. Before recommending a
+vendor, judge whether the skill's domain applies to **this** repo:
+
+- A domain skill (for example a CsWin32 COM skill) is irrelevant in a repo that
+  does no COM, even though it is a perfectly good skill. Say so; do not recommend
+  vendoring something that will never fire.
+- A project-gated skill (one that drives a sibling project such as a fuzz or perf
+  project) applies if the repo has that project *or should have it*. If the
+  project is missing, report that project creation as a separate prerequisite;
+  vendoring the current core does not scaffold it.
+- A repo-local skill from another repo (tied to that repo's unique structure)
+  does not transfer; flag it as out of scope.
+
+## Recommendation report
+
+Output a short summary, not a raw search dump:
+
+- **Where it exists:** local / commons / public / nowhere.
+- **Applicable here:** yes / no / only if a gated project is added, with the
+  one-line reason.
+- **Recommended action:** use it (already local) / tweak the overlay / vendor from
+  the commons / evaluate-and-vendor from public / build new / skip as
+  inapplicable.
+
+That recommendation is the hand-off into [build.md](build.md), which turns "vendor"
+or "build new" into concrete steps.

--- a/.agents/skills/manage-skills/overlay.md
+++ b/.agents/skills/manage-skills/overlay.md
@@ -1,0 +1,49 @@
+---
+core: manage-skills
+core-pin: v0.10.0
+---
+
+# madowaku overlay - manage-skills
+
+Repository-specific companion to the vendored [manage-skills](SKILL.md) skill.
+The `SKILL.md`, its sibling pages (`find.md`, `build.md`, `update.md`), the
+bundled `scripts/Validate-Skills.ps1`, and `assets/overlay.md.tmpl` are a
+**pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **The commons is `JeremyKuhne/agent-skills`; madowaku pins to `v0.10.0`**
+  (the one exception is `github-actions-cost-optimization`, which postdates that
+  tag and is pinned to a commit SHA - see its overlay).
+- **The catalog is** [.agents/skills/README.md](../README.md); add or update its
+  inventory row and disambiguation in the same change as any vendor, tweak, or
+  new skill.
+- **Born-local skills (never upstreamed):**
+  [`cswin32-com`](../cswin32-com/SKILL.md),
+  [`cswin32-interop`](../cswin32-interop/SKILL.md), and
+  [`publish-release`](../publish-release/SKILL.md). These are specific to
+  madowaku's structure and carry no `github-*` provenance; leave them out of the
+  commons.
+- **Frontmatter validation**: run the bundled
+  [scripts/Validate-Skills.ps1](scripts/Validate-Skills.ps1) on a skill
+  directory. The repo's own agent-file checks live in
+  [tools/Validate-AgentFiles.ps1](../../../tools/Validate-AgentFiles.ps1) and run
+  in [.github/workflows/agent-files.yml](../../../.github/workflows/agent-files.yml).
+- **`gh skill` is optional.** When it is unavailable, vendor by copying the
+  pinned core and stamping `metadata.github-*` provenance by hand, then author
+  the overlay from `assets/overlay.md.tmpl`.
+
+## Cross-references
+
+- [`agent-files-review`](../agent-files-review/SKILL.md) - validates the syntax
+  and conventions of the file you land; run it after any vendor or overlay edit.
+
+## Updating
+
+Pull upstream changes with `gh skill update manage-skills` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
+++ b/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
@@ -1,0 +1,509 @@
+<#
+.SYNOPSIS
+    Validates Agent Skills (SKILL.md) against the agentskills.io specification. A
+    dependency-free PowerShell check based on `agentskills/skills-ref` (frontmatter),
+    plus the spec's length recommendation and Claude's no-XML-tags rule.
+
+.DESCRIPTION
+    For each skill directory, checks the SKILL.md against the Agent Skills
+    spec (https://agentskills.io/specification):
+
+      - required fields present: name and description. Any other field (the spec's
+        optionals, client extensions, or custom keys) is allowed and not flagged.
+      - name: required; <= 64 chars; NFKC-normalized; lowercase; letters, digits,
+        and hyphens only; no leading/trailing or consecutive hyphen; matches the
+        directory name.
+      - description: required; non-empty; <= 1024 chars; no XML-style tags (the
+        name and description are injected into the agent's skill-metadata block).
+      - compatibility: if present, a string <= 500 chars.
+      - yaml: inline scalar values carry no unquoted ':' (a mapping indicator that
+        a strict parser, like the strictyaml skills-ref uses, would reject).
+      - length: SKILL.md is at most 500 lines (the spec's progressive-disclosure
+        recommendation, "Keep your main SKILL.md under 500 lines").
+
+    The length and no-XML-tags checks go beyond skills-ref, which validates
+    frontmatter only; the colon check restores parity with its strict YAML parser.
+
+    With -RequirePortfolioMetadata, also enforces this commons' portable-core
+    policy: metadata.portability/applicability/binding/risk/maturity/requires/
+    related, the optional-overlay loader cue, and overlay.md frontmatter when an
+    overlay is present.
+
+    The frontmatter parser handles inline scalars, `>`/`|` block scalars, and one
+    level of `metadata:` mapping, with `---` matched line by line. A known field
+    given a block mapping/sequence (or an unquoted-colon scalar) is rejected;
+    unknown fields may take any shape. For arbitrary YAML use the `skills-ref` tool.
+
+    Exits 0 when every skill is valid, 1 otherwise.
+
+.PARAMETER Path
+    One or more paths. Each may be a skill directory (contains SKILL.md) or a
+    parent directory whose immediate subdirectories are skills (e.g. skills/).
+    Defaults to the current directory.
+
+.PARAMETER Quiet
+    Print only failures.
+
+.PARAMETER RequirePortfolioMetadata
+    Require and validate the commons portfolio metadata and overlay contract.
+
+.EXAMPLE
+    pwsh Validate-Skills.ps1 skills/
+    Validate every skill directory under skills/.
+
+.EXAMPLE
+    pwsh Validate-Skills.ps1 skills/manage-skills
+    Validate a single skill directory.
+
+.EXAMPLE
+    pwsh Validate-Skills.ps1 skills/ -RequirePortfolioMetadata
+    Validate every commons core against the stricter portfolio policy.
+#>
+
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)] [string[]] $Path,
+    [switch] $Quiet,
+    [switch] $RequirePortfolioMetadata
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$MaxName = 64
+$MaxDescription = 1024
+$MaxCompatibility = 500
+$MaxSkillLines = 500
+$PortfolioMetadataFields = @('portability', 'applicability', 'binding', 'risk', 'maturity', 'requires', 'related')
+$AllowedPortability = @('portable', 'semi-portable', 'repo-specific')
+$AllowedApplicability = @('universal', 'git-github', 'agent-customization', 'dotnet', 'dotnet-framework', 'dotnet-project-gated', 'tool-shipped', 'repo-local')
+$AllowedBinding = @('none', 'optional-overlay', 'required-overlay')
+$AllowedRisk = @('advisory', 'local-write', 'remote-write')
+$AllowedMaturity = @('experimental', 'canary', 'stable')
+$OverlayCue = 'If `overlay.md` exists beside this file, read it before acting'
+# Spec scalar fields. If one of these is given a block mapping/sequence instead of
+# a scalar it is rejected; unknown fields and `metadata` are not shape-checked.
+$KnownScalarFields = @('name', 'description', 'license', 'compatibility', 'allowed-tools')
+
+function Get-SkillMd ([string] $dir) {
+    foreach ($n in 'SKILL.md', 'skill.md') {
+        $p = Join-Path $dir $n
+        if (Test-Path -LiteralPath $p -PathType Leaf) { return $p }
+    }
+    return $null
+}
+
+# Unwrap a YAML scalar's surrounding quotes. A single-quoted scalar un-doubles ''
+# (the YAML single-quote escape); a double-quoted scalar is stripped as-is.
+function Get-ScalarValue ([string] $value) {
+    if ($value.Length -ge 2 -and $value.StartsWith("'") -and $value.EndsWith("'")) {
+        return $value.Substring(1, $value.Length - 2).Replace("''", "'")
+    }
+    if ($value.Length -ge 2 -and $value.StartsWith('"') -and $value.EndsWith('"')) {
+        return $value.Substring(1, $value.Length - 2)
+    }
+    return $value
+}
+
+# Reject an unquoted inline scalar whose value holds a ':' followed by whitespace
+# (or a trailing ':') - a YAML mapping indicator that strict parsers (strictyaml,
+# which skills-ref uses) reject. Quoted values and flow collections ({ } / [ ]) are
+# exempt (their inner colons are valid YAML); true block scalars are handled before
+# this is reached, so a leading '>'/'|' here is plain text.
+function Test-InlineColon ([string] $key, [string] $value) {
+    if ($value -match '^["''\[{]') { return }
+    if ($value -match ':(\s|$)') {
+        throw "Invalid YAML in frontmatter: value for '$key' has an unquoted ':' (a YAML mapping indicator); quote the value or use a block scalar (>-)."
+    }
+}
+
+# Fold a YAML block scalar (the lines under a `key: >` or `key: |`) into a string:
+# common indentation stripped, '|' kept literal (newline-joined), '>' folded with
+# spaces.
+function Join-BlockScalar ([System.Collections.Generic.List[string]] $blockLines, [bool] $literal) {
+    $nonBlank = @($blockLines | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($nonBlank.Count -eq 0) { return '' }
+    $minIndent = ($nonBlank | ForEach-Object { [regex]::Match($_, '^\s*').Length } | Measure-Object -Minimum).Minimum
+    $dedented = $blockLines | ForEach-Object {
+        if ([string]::IsNullOrWhiteSpace($_)) { '' } else { $_.Substring([Math]::Min($minIndent, $_.Length)) }
+    }
+    if ($literal) { return ($dedented -join "`n").Trim() }
+    $sb = [System.Text.StringBuilder]::new()
+    $prevBlank = $true
+    foreach ($l in $dedented) {
+        if ($l -eq '') { [void]$sb.Append("`n"); $prevBlank = $true }
+        else { if (-not $prevBlank) { [void]$sb.Append(' ') }; [void]$sb.Append($l); $prevBlank = $false }
+    }
+    return $sb.ToString().Trim()
+}
+
+# Parse SKILL.md frontmatter into a case-sensitive ordered map. The `---`
+# delimiters are matched line by line. Handles inline scalars, `>`/`|` block
+# scalars, and one level of `metadata:` block mapping. A known field given a block
+# mapping/sequence is rejected; an unknown field may take any shape (unvalidated).
+# Not a general YAML parser; for arbitrary YAML use `skills-ref`.
+function Read-Frontmatter ([string] $content) {
+    $allLines = $content -split "\r?\n"
+    if ($allLines.Count -eq 0 -or $allLines[0].Trim() -ne '---') {
+        throw 'SKILL.md must start with YAML frontmatter (---)'
+    }
+    $end = -1
+    for ($k = 1; $k -lt $allLines.Count; $k++) {
+        if ($allLines[$k].Trim() -eq '---') { $end = $k; break }
+    }
+    if ($end -lt 0) { throw 'SKILL.md frontmatter not properly closed with ---' }
+
+    $map = New-Object System.Collections.Specialized.OrderedDictionary ([System.StringComparer]::Ordinal)
+    $lines = @()
+    if ($end -gt 1) { $lines = @($allLines[1..($end - 1)]) }
+    $i = 0
+    while ($i -lt $lines.Count) {
+        $line = $lines[$i]
+        if ([string]::IsNullOrWhiteSpace($line)) { $i++; continue }
+        if ($line.TrimStart().StartsWith('#')) { $i++; continue }
+        if ($line -notmatch '^\S') { throw "Invalid YAML in frontmatter near: $line" }
+
+        $idx = $line.IndexOf(':')
+        if ($idx -lt 0) { throw "Invalid YAML in frontmatter near: $line" }
+        $key = $line.Substring(0, $idx).Trim()
+        $rest = $line.Substring($idx + 1).Trim()
+
+        if ($rest -match '^[|>][+-]?\d*\s*$') {
+            $literal = $rest.StartsWith('|')
+            $i++
+            $blockLines = [System.Collections.Generic.List[string]]::new()
+            while ($i -lt $lines.Count -and ([string]::IsNullOrWhiteSpace($lines[$i]) -or $lines[$i] -match '^\s')) {
+                $blockLines.Add($lines[$i]); $i++
+            }
+            $map[$key] = Join-BlockScalar $blockLines $literal
+            continue
+        }
+
+        if ($rest -eq '') {
+            # Empty value: classify the following block (mapping, sequence, or none).
+            $j = $i + 1
+            while ($j -lt $lines.Count -and [string]::IsNullOrWhiteSpace($lines[$j])) { $j++ }
+            $hasChild = ($j -lt $lines.Count -and $lines[$j] -match '^\s')
+            $isSequence = $hasChild -and ($lines[$j] -match '^\s+-(\s|$)')
+
+            if ($hasChild -and $key -ceq 'metadata' -and -not $isSequence) {
+                $sub = New-Object System.Collections.Specialized.OrderedDictionary ([System.StringComparer]::Ordinal)
+                $i++
+                while ($i -lt $lines.Count) {
+                    if ([string]::IsNullOrWhiteSpace($lines[$i])) { $i++; continue }
+                    if ($lines[$i] -notmatch '^\s') { break }
+                    if ($lines[$i].TrimStart().StartsWith('#')) { $i++; continue }
+                    $kv = $lines[$i].Trim()
+                    $ci = $kv.IndexOf(':')
+                    if ($ci -lt 0) { throw "Invalid YAML in frontmatter near: $kv" }
+                    $sk = $kv.Substring(0, $ci).Trim()
+                    $sv = $kv.Substring($ci + 1).Trim()
+                    Test-InlineColon $sk $sv
+                    $sub[$sk] = Get-ScalarValue $sv
+                    $i++
+                }
+                $map[$key] = $sub
+                continue
+            }
+
+            if ($hasChild -and $key -cin $KnownScalarFields) {
+                $shape = if ($isSequence) { 'sequence' } else { 'mapping' }
+                throw "Field '$key' must be a scalar value, not a block $shape."
+            }
+
+            # A null value, an unknown field's nested block, or a metadata sequence:
+            # swallow any nested lines and store an empty value (shape unvalidated).
+            if ($hasChild) {
+                $i++
+                while ($i -lt $lines.Count -and ([string]::IsNullOrWhiteSpace($lines[$i]) -or $lines[$i] -match '^\s')) { $i++ }
+            }
+            else {
+                $i++
+            }
+            $map[$key] = ''
+            continue
+        }
+
+        Test-InlineColon $key $rest
+        $map[$key] = Get-ScalarValue $rest
+        $i++
+    }
+    return $map
+}
+
+# Count physical lines in SKILL.md (matches editor line numbers / Get-Content).
+function Measure-SkillLineCount ([string] $content) {
+    if ([string]::IsNullOrEmpty($content)) { return 0 }
+    $n = ($content -split "\r?\n").Count
+    if ($content.EndsWith("`n")) { $n-- }
+    return $n
+}
+
+function Test-SkillName ($name, [string] $dir) {
+    if ($null -eq $name -or $name -isnot [string] -or [string]::IsNullOrWhiteSpace($name)) {
+        "Field 'name' must be a non-empty string"
+        return
+    }
+    $name = $name.Trim().Normalize([System.Text.NormalizationForm]::FormKC)
+
+    if ($name.Length -gt $MaxName) {
+        "Skill name '$name' exceeds $MaxName character limit ($($name.Length) chars)"
+    }
+    if ($name -cne $name.ToLowerInvariant()) {
+        "Skill name '$name' must be lowercase"
+    }
+    if ($name.StartsWith('-') -or $name.EndsWith('-')) {
+        'Skill name cannot start or end with a hyphen'
+    }
+    if ($name.Contains('--')) {
+        'Skill name cannot contain consecutive hyphens'
+    }
+    $invalid = $false
+    foreach ($c in $name.ToCharArray()) { if (-not ([char]::IsLetterOrDigit($c) -or $c -eq '-')) { $invalid = $true; break } }
+    if ($invalid) {
+        "Skill name '$name' contains invalid characters. Only letters, digits, and hyphens are allowed."
+    }
+    if ($dir) {
+        $leaf = Split-Path -Leaf $dir
+        if ($leaf.Normalize([System.Text.NormalizationForm]::FormKC) -cne $name) {
+            "Directory name '$leaf' must match skill name '$name'"
+        }
+    }
+}
+
+function Test-SkillDescription ($description) {
+    if ($null -eq $description -or $description -isnot [string] -or [string]::IsNullOrWhiteSpace($description)) {
+        "Field 'description' must be a non-empty string"
+        return
+    }
+    if ($description.Length -gt $MaxDescription) {
+        "Description exceeds $MaxDescription character limit ($($description.Length) chars)"
+    }
+    if ($description -match '</?[A-Za-z][^<>]*>') {
+        "Description must not contain XML-style tags (found '$($Matches[0])'). The name and description are injected into the agent's skill-metadata XML block; reword (e.g. 'of T') or use backticks."
+    }
+}
+
+function Test-SkillCompatibility ($compatibility) {
+    if ($compatibility -isnot [string]) {
+        "Field 'compatibility' must be a string"
+        return
+    }
+    if ($compatibility.Length -gt $MaxCompatibility) {
+        "Compatibility exceeds $MaxCompatibility character limit ($($compatibility.Length) chars)"
+    }
+}
+
+function Get-MetadataValue ($metadata, [string] $key) {
+    if ($metadata -is [System.Collections.IDictionary] -and $metadata.Contains($key)) {
+        return $metadata[$key]
+    }
+    return $null
+}
+
+function Test-MetadataEnum ($metadata, [string] $key, [string[]] $allowed) {
+    $value = Get-MetadataValue $metadata $key
+    if ($null -eq $value) { return }
+    if ($value -isnot [string] -or [string]::IsNullOrWhiteSpace($value)) {
+        "metadata.$key must be a non-empty string"
+        return
+    }
+    $value = $value.Trim()
+    if ($allowed -cnotcontains $value) {
+        "metadata.$key '$value' is invalid; expected one of: $($allowed -join ', ')"
+    }
+}
+
+function Test-RelationshipMetadata ($metadata, [string] $key) {
+    $value = Get-MetadataValue $metadata $key
+    if ($null -eq $value) { return }
+    if ($value -isnot [string] -or [string]::IsNullOrWhiteSpace($value)) {
+        "metadata.$key must be 'none' or a comma-separated list of skill names"
+        return
+    }
+    $value = $value.Trim()
+    if ($value -ceq 'none') { return }
+
+    $names = @($value -split ',' | ForEach-Object { $_.Trim() })
+    if ($names.Count -eq 0 -or $names -ccontains '') {
+        "metadata.$key must be 'none' or a comma-separated list of skill names"
+        return
+    }
+    foreach ($relationshipName in $names) {
+        if ($relationshipName -cnotmatch '^[a-z0-9]+(?:-[a-z0-9]+)*$') {
+            "metadata.$key contains invalid skill name '$relationshipName'"
+        }
+    }
+    $duplicates = @($names | Group-Object | Where-Object Count -gt 1 | ForEach-Object Name)
+    if ($duplicates.Count -gt 0) {
+        "metadata.$key contains duplicate skill name(s): $($duplicates -join ', ')"
+    }
+}
+
+function Test-OverlayContract ($metadata, [string] $raw, [string] $dir) {
+    $binding = Get-MetadataValue $metadata 'binding'
+    if ($binding -isnot [string]) { return }
+    $binding = $binding.Trim()
+    if (@('none', 'optional-overlay', 'required-overlay') -cnotcontains $binding) { return }
+
+    $overlayPath = Join-Path $dir 'overlay.md'
+    $hasOverlay = Test-Path -LiteralPath $overlayPath -PathType Leaf
+
+    if (@('optional-overlay', 'required-overlay') -ccontains $binding -and -not $raw.Contains($OverlayCue)) {
+        "metadata.binding '$binding' requires this loader cue in SKILL.md: $OverlayCue"
+    }
+    if ($binding -ceq 'required-overlay' -and -not $hasOverlay) {
+        "metadata.binding 'required-overlay' requires overlay.md beside SKILL.md"
+        return
+    }
+    if ($binding -ceq 'none' -and $hasOverlay) {
+        "overlay.md exists but metadata.binding is 'none'"
+        return
+    }
+    if (-not $hasOverlay) { return }
+
+    try {
+        $overlayFrontmatter = Read-Frontmatter (Get-Content -LiteralPath $overlayPath -Raw)
+    }
+    catch {
+        "overlay.md: $($_.Exception.Message)"
+        return
+    }
+
+    foreach ($requiredOverlayField in @('core', 'core-pin')) {
+        if (-not $overlayFrontmatter.Contains($requiredOverlayField) -or
+            [string]::IsNullOrWhiteSpace([string]$overlayFrontmatter[$requiredOverlayField])) {
+            "overlay.md is missing required frontmatter field: $requiredOverlayField"
+        }
+    }
+    if ($overlayFrontmatter.Contains('core')) {
+        $directoryName = Split-Path -Leaf $dir
+        if ([string]$overlayFrontmatter['core'] -cne $directoryName) {
+            "overlay.md core '$($overlayFrontmatter['core'])' must match skill directory '$directoryName'"
+        }
+    }
+}
+
+function Test-PortfolioMetadata ($metadata, [string] $raw, [string] $dir, [bool] $required) {
+    if ($null -eq $metadata) {
+        if ($required) { 'Missing required field in frontmatter: metadata' }
+        return
+    }
+    if ($metadata -isnot [System.Collections.IDictionary]) {
+        'Field metadata must be a mapping'
+        return
+    }
+
+    if ($required) {
+        foreach ($requiredMetadataField in $PortfolioMetadataFields) {
+            if (-not $metadata.Contains($requiredMetadataField)) {
+                "Missing required portfolio field: metadata.$requiredMetadataField"
+            }
+        }
+    }
+
+    Test-MetadataEnum $metadata 'portability' $AllowedPortability
+    Test-MetadataEnum $metadata 'applicability' $AllowedApplicability
+    Test-MetadataEnum $metadata 'binding' $AllowedBinding
+    Test-MetadataEnum $metadata 'risk' $AllowedRisk
+    Test-MetadataEnum $metadata 'maturity' $AllowedMaturity
+    Test-RelationshipMetadata $metadata 'requires'
+    Test-RelationshipMetadata $metadata 'related'
+
+    $portability = Get-MetadataValue $metadata 'portability'
+    if ($portability -is [string]) { $portability = $portability.Trim() }
+    if ($required -and $portability -cne 'portable') {
+        "Commons cores must set metadata.portability to 'portable'"
+    }
+
+    Test-OverlayContract $metadata $raw $dir
+}
+
+function Test-SkillDir ([string] $dir) {
+    $errors = [System.Collections.Generic.List[string]]::new()
+
+    $resolved = Resolve-Path -LiteralPath $dir -ErrorAction SilentlyContinue
+    if (-not $resolved) { return @("Path does not exist: $dir") }
+    $dir = $resolved.Path
+    if (-not (Test-Path -LiteralPath $dir -PathType Container)) { return @("Not a directory: $dir") }
+
+    $md = Get-SkillMd $dir
+    if (-not $md) { return @('Missing required file: SKILL.md') }
+
+    $raw = Get-Content -LiteralPath $md -Raw
+    try {
+        $fm = Read-Frontmatter $raw
+    }
+    catch {
+        return @($_.Exception.Message)
+    }
+
+    if (-not $fm.Contains('name')) { $errors.Add('Missing required field in frontmatter: name') }
+    else { Test-SkillName $fm['name'] $dir | ForEach-Object { $errors.Add($_) } }
+
+    if (-not $fm.Contains('description')) { $errors.Add('Missing required field in frontmatter: description') }
+    else { Test-SkillDescription $fm['description'] | ForEach-Object { $errors.Add($_) } }
+
+    if ($fm.Contains('compatibility')) { Test-SkillCompatibility $fm['compatibility'] | ForEach-Object { $errors.Add($_) } }
+
+    $metadata = if ($fm.Contains('metadata')) { $fm['metadata'] } else { $null }
+    Test-PortfolioMetadata $metadata $raw $dir $RequirePortfolioMetadata.IsPresent |
+        ForEach-Object { $errors.Add($_) }
+
+    $lineCount = Measure-SkillLineCount $raw
+    if ($lineCount -gt $MaxSkillLines) {
+        $errors.Add("SKILL.md is $lineCount lines; keep it under the recommended $MaxSkillLines-line limit (move detail into references/ or sibling files).")
+    }
+
+    return $errors.ToArray()
+}
+
+# ---------------------------------------------------------------------------
+
+if (-not $Path -or $Path.Count -eq 0) {
+    $Path = @('.')
+}
+
+$targets = [System.Collections.Generic.List[string]]::new()
+foreach ($p in $Path) {
+    if (Get-SkillMd $p) {
+        $targets.Add((Resolve-Path -LiteralPath $p).Path)
+    }
+    elseif (Test-Path -LiteralPath $p -PathType Container) {
+        Get-ChildItem -LiteralPath $p -Directory |
+            Where-Object { Get-SkillMd $_.FullName } |
+            ForEach-Object { $targets.Add($_.FullName) }
+    }
+    else {
+        $targets.Add($p)
+    }
+}
+
+$ordered = @($targets | Sort-Object -Unique)
+if ($ordered.Count -eq 0) {
+    Write-Host 'No skills found.' -ForegroundColor Yellow
+    exit 1
+}
+
+$failed = 0
+foreach ($t in $ordered) {
+    $rel = [System.IO.Path]::GetRelativePath((Get-Location).Path, $t)
+    $errs = @(Test-SkillDir $t)
+    if ($errs.Count -eq 0) {
+        if (-not $Quiet) { Write-Host "  OK    $rel" -ForegroundColor Green }
+    }
+    else {
+        $failed++
+        Write-Host "  FAIL  $rel" -ForegroundColor Red
+        foreach ($e in $errs) { Write-Host "          - $e" -ForegroundColor Red }
+    }
+}
+
+Write-Host ''
+if ($failed -gt 0) {
+    Write-Host "$failed of $($ordered.Count) skill(s) failed validation." -ForegroundColor Red
+    exit 1
+}
+Write-Host "All $($ordered.Count) skill(s) valid." -ForegroundColor Green
+exit 0

--- a/.agents/skills/manage-skills/update.md
+++ b/.agents/skills/manage-skills/update.md
@@ -1,0 +1,95 @@
+# Update a skill
+
+Detail for the [manage-skills](SKILL.md) skill. "Update the skill" has two
+directions. The second - pushing a local improvement - is where the
+[golden rule](SKILL.md) is enforced.
+
+## Pull: take upstream changes
+
+When a vendored skill has moved upstream in the commons, pull the change:
+
+```pwsh
+# one skill
+gh skill update <skill>
+# every unpinned vendored skill
+gh skill update --all
+```
+
+`gh skill update` compares the local copy's provenance tree SHA against upstream
+and surfaces the difference as a normal diff. Review it like a dependency bump:
+read what changed, run the repo's agent-file checks (the frontmatter validator and
+the installed-artifact link checker), then re-pin when satisfied. Update the
+overlay's `core-pin` and re-review its bindings in the same change. A skill pinned
+with `--pin` is skipped by `--all`; bump its pin deliberately when you want its
+updates.
+
+Manual fallback (no `gh`): compare the local core against the commons copy at the
+recorded ref, apply the diff by hand, and update the provenance SHA.
+
+## Push: send a local improvement to the right layer
+
+When you improve a vendored skill locally, first classify the change, then decide
+where it lives. Classification does not trigger any action on its own.
+
+- **Local deviation** - specific to this repo (a repo-only tool, a local path, a
+  repo-specific example). It belongs in the **overlay**, never in the vendored
+  core. Move the change into `overlay.md` (starting from
+  `assets/overlay.md.tmpl` when needed), restore the core to match upstream, and
+  record the current pin in `core-pin`. No upstreaming question arises.
+- **Common** - generic, helps every consumer (a clearer phrasing of a portable
+  rule, a new universally-applicable check, a fixed error). It *should* go
+  upstream, but upstreaming is **never automatic** and is not always plausible:
+  the commons may be unreachable, the change may be sensitive or need discussion
+  first, or you may lack the time or rights. So **ask** before attempting it.
+
+### The upstreaming query (common changes only)
+
+Stop and ask the user whether to attempt upstreaming. **Never open a commons PR on
+your own** - it is a publish action, gated by the same rule as any push (the
+repo's contribution and publish rules). Present what the change is, why it is
+common, and the options:
+
+- **Upstream it now** - prepare the PR to the commons; *creating* it still needs an
+  explicit publish verb from the user. Once merged, re-vendor here at the new pin.
+- **Not now / not plausible** - keep the change in the local core as a *tracked
+  pending-upstream divergence*: record it (in the commit message and a short note)
+  so the drift check's later alarm is expected, not a surprise. Re-attempt
+  upstreaming when it becomes plausible; re-pinning clears the divergence.
+- **Reclassify** - if discussion shows the change is actually repo-specific, move
+  it to the overlay instead and restore the core.
+
+Default to asking even when the change looks obviously common and obviously worth
+sharing. Nothing about upstreaming happens without an explicit decision.
+
+## The golden rule and its mechanics
+
+*Never let a vendored core diverge silently.* A vendored core is a mirror of
+upstream; any edit to it is a deliberate fork that must end in one of three
+**recorded** states - never an unexplained one:
+
+- promoted upstream and the core re-pinned,
+- moved to the overlay and the core restored, or
+- kept as a **tracked pending-upstream divergence** - a common change that could
+  not be upstreamed yet, recorded so the divergence is intentional and visible.
+
+The point is *visibility*, not "resolved within the hour". A recorded divergence is
+fine; an unexplained one is the alarm. What makes this enforceable:
+
+- **Provenance frontmatter** on every vendored copy records the source repo, ref,
+  and tree SHA it was installed from.
+- **The drift check** (`gh skill update`, or the tree-SHA comparison in CI)
+  compares the local core against that recorded upstream. Unexplained drift - a
+  local core that no longer matches its pin and has no corresponding upstream PR -
+  is the alarm that an improvement was written into the wrong layer.
+
+So the discipline is mechanical: if the drift check lights up and there is no
+upstream PR in flight and no recorded pending-upstream note, the change was a local
+deviation written into the core by mistake; move it to the overlay and restore the
+core.
+
+## After any update
+
+Re-run the validators and the link check, and if the change touched the catalog
+or a skill's trigger phrasing, reconcile the catalog `README.md` (inventory row,
+disambiguation) in the same change. Then hand off to the repository's
+`agent-files-review` skill to validate the resulting files.

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -1,135 +1,151 @@
 ---
+compatibility: Requires the .NET SDK and BenchmarkDotNet; source-line profiling may require a repository-specific trace tool.
+description: Author and run BenchmarkDotNet performance tests in a multi-targeted .NET library's perf project, and translate a user's outcome-shaped performance question into a measurement. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method or source line dominates, evaluating allocations / memory usage, reading the generated code (sharplab / DisassemblyDiagnoser / HardwareCounters), or when a user asks how long something takes, how much memory it uses, where time is spent, or to help make a method faster - which this skill turns into a scenario, a benchmark, and a drill-down.
+license: MIT
+metadata:
+    applicability: dotnet-project-gated
+    binding: optional-overlay
+    github-path: skills/performance-testing
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 5a20e5995ee9e6d6d6a24131e1522f0084761e79
+    maturity: canary
+    portability: portable
+    related: framework-jit-optimization, scratch-buffer-strategy, pre-pr-self-review
+    requires: none
+    risk: local-write
 name: performance-testing
-description: Author and run BenchmarkDotNet performance tests in the madowaku.perf project. Use when adding new benchmarks, running existing ones, comparing implementations, or evaluating allocations and memory usage for code in madowaku.
-argument-hint: Describe the API or hot path you want to benchmark and whether you care most about time, allocations, or both.
 ---
 
-# Performance testing in madowaku.perf
+# Performance testing with BenchmarkDotNet
 
-The [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj) project hosts
-all [BenchmarkDotNet](https://benchmarkdotnet.org/) benchmarks for this repo.
-It multi-targets modern .NET (`$(DotNetCoreVersion)-$(WindowsPlatformVersion)`)
-and `net481`, so you can compare runtime behavior between the two JITs.
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
 
-This skill is adapted from Touki's performance-testing skill and narrowed to
-madowaku conventions.
+This skill covers authoring and running
+[BenchmarkDotNet](https://benchmarkdotnet.org/) benchmarks in a multi-targeted
+.NET library's **perf project** (`<root>.perf` by convention), and - just as
+important - turning a user's vague, outcome-shaped performance question into a
+concrete measurement and a useful answer.
 
-## 1. Authoring a benchmark
+A consuming repository wires the concrete project name, target frameworks,
+cross-skill links, and profiling tooling in its overlay. This core uses
+`<root>.perf` for the perf project and `<tfm>` for a target-framework moniker;
+the overlay supplies the real names. The two framework monikers this skill names
+directly - modern .NET (`net10.0` or whatever the repo's current version is) and
+.NET Framework (`net481`) - are the common multi-targeting pair; a single-target
+repo simply ignores the second.
 
-### File and class layout
+Note: code in a Framework-only source tree (the `Framework/` subtree by
+convention, excluded from the modern build) compiles only for the .NET Framework
+target. References to those types from a benchmark must be guarded with
+`#if NETFRAMEWORK`.
 
-- One benchmark class per file, file named after the class.
-- Namespace is always `madowaku.perf`.
-- Class is `public` and has one or more `[Benchmark]` methods.
-- Use the standard repo file header.
-- Follow [AGENTS.md](../../../AGENTS.md) coding rules (explicit types, XML docs,
-  no `var`, collection expressions where applicable).
+## Starting from a user's question
 
-### Globals already imported
+Users ask outcome questions - "how long does this take?", "how much memory does
+this use?", "where is the time going?", "help me make this faster?" - not tooling
+commands. They will not pick a scenario, write a benchmark, or capture a trace on
+their own; **translating the question into a measurement and leading them through
+it is the job.** Before reaching for the mechanics below, read
+[interpreting-requests.md](interpreting-requests.md): it maps each kind of
+question to the right workflow, says which clarifications to ask (and which to
+answer yourself from the code), walks the "make X faster" journey end to end, and
+lists the follow-ups to offer once a result is in hand. The rest of this skill is
+the *how*; that page is the *what to measure and why*.
 
-[GlobalUsings.cs](../../../madowaku.perf/GlobalUsings.cs) already provides:
+**Related skills** (a consuming repo links the ones it vendors in its overlay):
 
-- `BenchmarkDotNet.Attributes`
-- `BenchmarkDotNet.Jobs`
+- A **trace-analyzer** skill - the profiler this skill drives to find the hot
+  method or source line. The overlay names it and the concrete profiling page.
+- A **framework-JIT-optimization** skill - decisions about specialization,
+  unrolling, and BCL-delegation on the older Framework JIT that the benchmarks
+  here exist to validate.
+- A **scratch-buffer-strategy** skill - choosing between zeroed `stackalloc`,
+  `[SkipLocalsInit]`, a stack-with-pool-fallback buffer, and an `ArrayPool`
+  rental; several benchmarks exist to validate those crossovers.
+- A **pre-pr-self-review** skill - which requires a benchmark (or an explicit
+  "not measured" note) for any perf claim that drives a Framework-only code
+  change.
 
-Do not re-import those in each benchmark file.
+## The rules that always apply
 
-### Required attributes
+Five rules cover most benchmark work; the sub-pages hold the rest.
 
-Always annotate benchmark classes with `[MemoryDiagnoser]`.
-
-When comparing alternatives, set one method to baseline:
-
-```csharp
-[Benchmark(Baseline = true)]
-public int Current()
-{
-    return _value;
-}
-
-[Benchmark]
-public int Candidate()
-{
-    return _value + 1;
-}
-```
-
-### What benchmark methods must do
-
-- Return a value derived from the measured work (not `void`).
-- Keep setup outside the measured path using `[GlobalSetup]`.
-- Avoid helper indirection between benchmark method and system-under-test
-  unless you intentionally want that overhead measured.
-- For mutating operations, return a digest or sampled value from the mutated
-  data (`buffer[0]`, sum, xor, etc.) so dead-code elimination cannot erase work.
-
-## 2. Running benchmarks
-
-The benchmark entrypoint uses `BenchmarkSwitcher.FromAssembly(...)`, so all
-CLI args after `--` are forwarded to BenchmarkDotNet.
-
-### Target framework is required
-
-Because `madowaku.perf` is multi-targeted, always pass `-f`.
+1. **Pass `-f <tfm>`.** A multi-targeted perf project makes `dotnet run` fail
+   without an explicit target framework (e.g. `-f net10.0` or `-f net481`).
+2. **`-c Release` is mandatory.** Debug runs are not representative.
+3. **`[MemoryDiagnoser]` on every class.** It adds the `Allocated` column, which
+   is usually the point.
+4. **Every `[Benchmark]` method returns a value derived from the work**, never
+   `void` - otherwise dead-code elimination wipes the body and the numbers are
+   meaningless. See [authoring.md](authoring.md).
+5. **Run both TFMs** for any code that compiles for both. Results diverge: the
+   modern runtime has vectorized BCL APIs the older Framework runtime lacks.
 
 ```powershell
-# modern .NET
- dotnet run -c Release -f net10.0-windows10.0.22000.0 --project madowaku.perf -- --filter *VariantConversionPerf*
-
-# .NET Framework
- dotnet run -c Release -f net481 --project madowaku.perf -- --filter *VariantConversionPerf*
+# The canonical run, one TFM. Repeat with the other -f <tfm>.
+dotnet run -c Release -f <tfm> --project <root>.perf -- --filter *MyBenchmark*
 ```
 
-`-c Release` is mandatory for useful numbers.
+## Workflow checklist for a new benchmark
 
-### Useful switches
+1. Add a `<Name>.cs` file under the perf project with a `public` class in the
+   perf namespace. See [authoring.md](authoring.md) for layout, globals, and
+   attributes.
+2. Decorate the class with `[MemoryDiagnoser]`.
+3. Add `[Benchmark(Baseline = true)]` to the reference implementation and
+   `[Benchmark]` to each variant.
+4. Make every benchmark method **return a value** derived from the work, never
+   `void`.
+5. Avoid helper-method indirection between the benchmark and the
+   system-under-test. If overload resolution forces it, temporarily rename one
+   overload in source while measuring, then revert.
+6. Build Release: `dotnet build -c Release <root>.perf`.
+7. Smoke-test with `--job short --filter *<Name>*` on each target framework
+   individually. See [running.md](running.md).
+8. Run the full benchmark on both target frameworks (drop `--job short`).
+9. Inspect `Allocated` and `Ratio` columns; copy the Markdown report into the PR.
+   See [interpreting-results.md](interpreting-results.md).
+10. If one method dominates and you need to know which - or which *line* inside
+    it - profile it. See your repo's profiling overlay (the trace-analyzer skill).
 
-- `--job short`: quick smoke pass while iterating.
-- `--memory`: force memory diagnoser for the run.
-- `--exporters github`: emit GitHub-flavored markdown summary.
-- `--disasm`: inspect generated assembly for codegen investigations.
+When the change is driven by a profile, follow the before/after discipline in
+[interpreting-results.md](interpreting-results.md) (baseline both TFMs, re-run
+both, keep full rows, confirm the targeted frame moved).
 
-## 3. Reading memory results
+## Codegen-level optimization rules
 
-With `[MemoryDiagnoser]`, output includes:
+For decisions about *how to write* a hot path - whether to specialize a generic
+for primitives, choose between scalar/unrolled forms, defer to BCL primitives
+like `IndexOf` / `SequenceEqual`, or interpret a Framework-vs-modern divergence -
+see the framework-JIT-optimization skill. That skill is the right entry point for
+"this loop is slow on the older Framework JIT, what should I try?" questions,
+while this one is about authoring and running the benchmarks themselves.
 
-- `Gen0`, `Gen1`, `Gen2`: collections per 1000 ops.
-- `Allocated`: managed bytes per operation.
+To see *why* a result is what it is - the C# lowering, the IL, or the JIT asm
+behind a number - see [reading-codegen.md](reading-codegen.md). It covers
+sharplab, BenchmarkDotNet's `[DisassemblyDiagnoser]` / `[HardwareCounters]`, the
+`DOTNET_JitDisasm*` knobs, and the tiering/PGO traps that bite codegen
+inspection.
 
-Guidance:
+## Sub-pages
 
-- `Allocated` should be `-` or `0 B` for allocation-free paths.
-- Use `Ratio` with `Allocated` to avoid trading CPU gains for allocation
-  regressions.
-- Compare both TFMs before claiming an improvement. net481 and modern .NET can
-  differ significantly in JIT behavior.
+- [interpreting-requests.md](interpreting-requests.md) - turning a user's
+  outcome question ("how long?", "how much memory?", "where's the time?", "make
+  it faster") into a scenario, a measurement, an answer in their words, and the
+  next follow-up to offer. Start here when the request is a question, not a task.
+- [authoring.md](authoring.md) - file/class layout, the imported globals, the
+  required and optional attributes, and what a benchmark method must do.
+- [running.md](running.md) - the `-f <tfm>` requirement, filtering to a class or
+  method, the interactive picker, and useful switches.
+- [interpreting-results.md](interpreting-results.md) - before/after discipline on
+  both TFMs and reading the memory columns.
+- [reading-codegen.md](reading-codegen.md) - seeing the C# lowering, IL, and JIT
+  asm behind a number: sharplab, `[DisassemblyDiagnoser]`, `[HardwareCounters]`,
+  the `DOTNET_JitDisasm*` knobs, and the tiering/PGO inspection traps.
 
-## 4. Workflow checklist
-
-1. Add `<Name>.cs` under `madowaku.perf/` with `public class <Name>`.
-2. Add `[MemoryDiagnoser]` and a clear baseline benchmark.
-3. Ensure every benchmark returns a value tied to real work.
-4. Build Release:
-
-   ```powershell
-   dotnet build -c Release madowaku.perf/madowaku.perf.csproj
-   ```
-
-5. Smoke-test with short job on both TFMs:
-
-   ```powershell
-   dotnet run -c Release -f net10.0-windows10.0.22000.0 --project madowaku.perf -- --job short --filter *<Name>*
-   dotnet run -c Release -f net481 --project madowaku.perf -- --job short --filter *<Name>*
-   ```
-
-6. Run full benchmark if needed (remove `--job short`).
-7. Capture summary from console or artifacts and include it with perf claims.
-
-## 5. Repo-specific notes
-
-- `madowaku.perf` references both `madowaku` and `madowaku.tests` so test-only
-  fixtures can be reused in benchmark setup.
-- If benchmarking code that only exists under `madowaku/Framework/`, guard
-  references with `#if NETFRAMEWORK`.
-- Keep benchmark data realistic and derived from existing tests where possible
-  (for example, VARIANT conversion cases from `madowaku.tests`).
+Profiling a benchmark down to the hot method or source line is a repo-specific
+page supplied by the overlay (it drives the repo's trace analyzer), not part of
+this core.

--- a/.agents/skills/performance-testing/authoring.md
+++ b/.agents/skills/performance-testing/authoring.md
@@ -1,0 +1,84 @@
+# Authoring a benchmark
+
+Detail for the [performance-testing](SKILL.md) skill. Covers file/class layout,
+the globals already imported, the required and optional attributes, and what a
+benchmark method must do.
+
+## File and class layout
+
+- One benchmark class per file, file named after the class (e.g. `MyBenchmark.cs`).
+- Namespace is the perf project's namespace (`<root>.perf` by convention).
+- Class is `public` (BenchmarkDotNet requires this) and contains one or more
+  methods marked `[Benchmark]`.
+- Use the repo's standard file header.
+- Follow the repo coding style (the conventions in its `AGENTS.md` /
+  contributor guide - type-name style, null-check style, XML-doc indentation,
+  etc.).
+
+## Globals already imported
+
+A perf project usually centralizes common usings in a `GlobalUsings.cs`. Typical
+contents:
+
+- `BenchmarkDotNet.Attributes` - `[Benchmark]`, `[MemoryDiagnoser]`, `[Params]`,
+  `[GlobalSetup]`, etc.
+- `BenchmarkDotNet.Jobs` - `RuntimeMoniker`, `[SimpleJob]`.
+- The library root namespace.
+- Any per-TFM IO/compat namespaces the repo standardizes on.
+
+Check the perf project's `GlobalUsings.cs` and do not re-import what it already
+provides.
+
+## Required attributes for memory evaluation
+
+Always annotate every benchmark class with `[MemoryDiagnoser]`, regardless of its
+purpose. This adds three columns to the results table: **Gen0 / Gen1 / Gen2**
+(collections per 1000 ops) and **Allocated** (bytes per op). Without it you only
+get timings.
+
+```c#
+[MemoryDiagnoser]
+public class StringFormatting
+{
+    [Benchmark(Baseline = true)]
+    public string StringFormat() => string.Format("The answer is {0}.", _value);
+
+    [Benchmark]
+    public string CustomFormat() => MyFormatter.Format("The answer is {0}.", _value);
+}
+```
+
+Mark one method `[Benchmark(Baseline = true)]` whenever you are comparing
+alternative implementations - the report adds a **Ratio** and **RatioSD** column
+relative to that baseline.
+
+## Optional attributes
+
+- `[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]`
+  - cuts run time when iterating on a benchmark. Use only while developing;
+  remove (or revert to defaults) before checking in stable measurements.
+- `[Params(...)]` on a public field/property to run the benchmark for each value.
+- `[GlobalSetup]` for one-time setup outside the measured region.
+- `[Arguments(...)]` to pass per-method parameters.
+
+## What a benchmark method must do
+
+- **Return a value derived from the measured work, even when measuring
+  `void`-returning APIs.** Returning `void` (or a constant the JIT can prove
+  invariant) lets dead-code elimination wipe the body, producing meaningless
+  near-zero or wildly inconsistent timings. BenchmarkDotNet consumes the return
+  value to prevent that. For buffer-mutating APIs (`Span<T>.Replace`,
+  `Random.NextBytes`, `Encoding.GetBytes`) return `buffer[0]`, the last element,
+  or an XOR/sum digest of the buffer - not `buffer.Length` or any other value
+  invariant of execution. Symptoms of forgetting: "optimized" variants slower
+  than the baseline (because the baseline got eliminated), >50% StdDev between
+  runs, near-zero timings for non-trivial work. See
+  [BenchmarkDotNet good practices](https://benchmarkdotnet.org/articles/guides/good-practices.html).
+- Be cheap to call repeatedly - BenchmarkDotNet invokes it millions of times.
+- Avoid per-call setup; move setup into `[GlobalSetup]` or readonly fields.
+- Avoid wrapping the system-under-test in a helper method just to satisfy
+  overload resolution - the helper's call frame, type check, and generic
+  instantiation show up in the measurement. Either rename one overload
+  temporarily while measuring, or split into two benchmark classes.
+- Ref structs cannot be returned from `[Benchmark]` methods; consume them inside
+  the method and return a representative scalar (length or hash).

--- a/.agents/skills/performance-testing/interpreting-requests.md
+++ b/.agents/skills/performance-testing/interpreting-requests.md
@@ -1,0 +1,155 @@
+# From a user's question to a measurement
+
+Detail for the [performance-testing](SKILL.md) skill. The other sub-pages cover
+the *mechanics* - authoring a benchmark, running it, reading the columns. This
+page covers the step before all of them: turning a vague, outcome-shaped user
+question into a concrete scenario, the right measurement, and a useful answer.
+
+Users almost never ask in tooling terms. They ask "how long does this take?",
+"how much memory does this use?", "where is the time going?", or "help me make
+this faster". They do not know to capture a trace, write a benchmark, pick a
+scenario, or drill from method to line - **that translation is your job.** Lead
+them through it; do not hand back a tool and a shrug.
+
+In this page, *profile* / *the trace analyzer* refers to whatever profiling tool
+the consuming repo wires in its overlay (capture an EventPipe or ETW trace, rank
+the hot frames, drill to callers and source lines). The mechanics of that tool
+live in the overlay's profiling page; the judgment about *when* to reach for it
+lives here.
+
+## Map the question to the workflow
+
+| The user asks | They want | What you do |
+|---|---|---|
+| "How long does X take?" / "Is X fast enough?" | a latency number for a real scenario | benchmark the scenario, report `Mean` + error on both TFMs ([authoring](authoring.md), [running](running.md)) |
+| "How much memory does X use?" / "Does X allocate?" | bytes per operation | `[MemoryDiagnoser]` benchmark, report `Allocated` on both TFMs ([interpreting-results](interpreting-results.md)) |
+| "Where is the time spent?" / "Why is X slow?" | the hot method or line | profile a trace (EventPipe on the modern runtime, **ETW on .NET Framework**), rank -> callers -> lines; if a thin driver/wrapper tops the modern ranking, cross-check under ETW - inlining can misattribute self-time to the host |
+| "What's allocating?" / "What's the GC doing?" | the hot alloc site / GC pressure | the allocation or GC view of a trace |
+| "Make X faster" / "improve this method" | a *verified* improvement | the full loop below: scenario -> baseline -> profile -> change -> re-measure |
+| "Did my change help / regress anything?" | a before/after delta | baseline before, re-run after, diff both TFMs ([interpreting-results](interpreting-results.md)) |
+
+## First, nail the scenario - a method has no single "speed"
+
+Cost depends on inputs. Before writing any benchmark, decide *what* to measure.
+Read the method and answer as much as you can from the code, then ask the user
+only what the code cannot tell you. Offer a default with every question so they
+can just say "yes".
+
+Things worth pinning down:
+
+- **Inputs and sizes.** Typical case, and the worst case that matters. For a
+  span/string API: empty, small, large, and any pathological shape (all-match,
+  no-match, deep nesting). Propose a representative set.
+- **Target framework(s).** Default to **both** the modern and the Framework
+  target when the code compiles for both - results diverge and that divergence is
+  often the point. Only narrow to one if the user says so or the code is
+  `#if NET`-only.
+- **Latency vs throughput.** A per-call latency number and a bulk-throughput
+  number answer different questions; ask which they care about.
+- **A baseline to compare against.** "Fast" is meaningless alone. Compare against
+  the BCL equivalent, the previous implementation, or a stated target.
+
+**Do not stall on questions you can answer yourself.** If the inputs are obvious
+from the signature, state the scenario set you picked ("I'll measure empty, a
+32-char, and a 4 KB input on both TFMs") and proceed. Asking the user to spell
+out what you could have read is its own failure.
+
+## The "make X faster" journey - lead them through it
+
+This is the request that most needs handholding. Walk these steps out loud, one
+at a time, so the user sees the method:
+
+1. **Find the scenario.** Read the method, identify the inputs that drive cost,
+   propose a representative set. Confirm or proceed with stated assumptions.
+2. **Establish the baseline.** Write a benchmark in the perf project
+   ([authoring](authoring.md)), run it on both TFMs, and report the table. This
+   *is* the answer to "how slow is it today", and it is the thing every later
+   change is measured against. The benchmark stays in the repo as the regression
+   guard - do not throw the scenario away.
+3. **Find where the cost is.** Profile the baseline: rank -> callers -> lines for
+   CPU, or the allocation view if `Allocated` is the problem. Tell the user the
+   hot spot in plain language ("62% of the time is in the inner copy loop at
+   `Parser.cs:214`; it re-walks the segment each pass").
+4. **Form a hypothesis tied to the evidence, then change one thing.** Connect the
+   edit to what the profile showed. For *how* to write the hot path, branch to
+   the codegen skills: the framework-JIT-optimization skill for specialization /
+   unrolling / BCL-delegation, and the scratch-buffer-strategy skill for
+   stackalloc vs pool vs a stack-with-pool-fallback buffer.
+5. **Verify on both TFMs.** Re-run the baseline benchmark, diff against the saved
+   numbers, and confirm the *targeted* frame actually moved and nothing regressed
+   - especially `Allocated`, and especially the *other* TFM
+   ([interpreting-results](interpreting-results.md)). A faster wall clock with
+   the targeted frame unchanged is noise or a different win; say so.
+6. **Report and offer the next drill.** Show the before/after for both TFMs and
+   the line-level evidence, then suggest the logical follow-up.
+
+## Translate the numbers back into the user's words
+
+Do not paste a raw table and stop. Answer the question they asked:
+
+- *How long?* -> "About 180 ns per call for a typical 32-char input, rising to
+  ~12 us for a 4 KB input. That's roughly 1.4x the BCL's `string.Format` on the
+  modern runtime, and 3x faster on .NET Framework where the BCL path has no
+  vectorization."
+- *How much memory?* -> "It's allocation-free on the span path (0 B). The string
+  overload allocates one result string of N bytes and nothing else." or "It
+  allocates a 1 KB array per call - that's the buffer it never pools."
+- *Where?* -> "Two thirds of the time is in `<method>` at `<file:line>`, doing
+  `<what>`. The rest is the bounds checks the loop repeats."
+
+Always surface a **both-TFM divergence** when there is one - it is frequently the
+most actionable thing you can say.
+
+## Follow up - suggest the next question, don't wait for it
+
+After every result, the user usually has a next question they have not formed
+yet. Offer it:
+
+- After a **latency** number -> "Want the allocation profile too, or a comparison
+  against the BCL / your previous version?"
+- After a **memory** number -> "Want me to find the allocation site, or try a
+  pooled / `stackalloc` version and measure it?"
+- After a **hot spot** -> "Want me to try `<specific change the evidence
+  suggests>` and measure whether it helps?"
+- After a **hot spot whose call-tree *shape* is the interesting part** (deep
+  recursion, a fan of shallow callers, or you want to show an
+  attribution flip visually) -> "Want me to open this as an interactive flame
+  graph so you can explore it?" Offer this *after* the line-level answer, not
+  instead of it - the direct line/heat drill is the more practical result.
+- After a **shallow line/heat map** (too few samples to attribute per line) ->
+  "The trace sampled too coarsely to pin the hot lines; want me to re-capture
+  under ETW (~1 kHz) for a deeper heat map?"
+- After a **modern-runtime method ranking topped by a driver/wrapper frame** (its
+  body is mostly a call into a loop) -> "EventPipe may be crediting an inlined
+  callee's time to its host; want me to re-capture under ETW - which resolves the
+  inlinee - and diff the two?" Lengthening the run will not fix this; only ETW
+  reattributes it.
+- After an **improvement** -> "Want me to push the scenario harder (larger input,
+  worst case), or check whether the win holds on the other TFM?"
+- After a **surprising divergence** -> "The .NET Framework path is 3x slower
+  here; want me to dig into why (likely the missing vectorized BCL API)?"
+
+## Anti-patterns
+
+- **Handing back tooling instead of an answer.** "You can run a benchmark with
+  `dotnet run ...`" is a failure when the user asked "is this fast?". Run it and
+  tell them.
+- **Measuring without a scenario.** A benchmark over an unrepresentative input
+  answers a question nobody asked. Pin the scenario first.
+- **One TFM when the code targets both.** The divergence is usually the story -
+  and on .NET Framework it is often not just a different number but a different
+  *hotspot*: the Framework JIT inlines far less, so the hot frame can move
+  entirely. Profile .NET Framework directly under ETW rather than reading its
+  hotspot off the modern-runtime EventPipe trace.
+- **Trusting the modern-runtime EventPipe *method* ranking under heavy
+  inlining.** It credits an inlined callee's self-time to its physical host, so a
+  thin driver/wrapper can top the ranking while the real hot loop reads near-zero
+  - the same hotspot move, this time between *capture methods* on one TFM.
+  Cross-check under ETW when a wrapper tops the ranking; duration will not fix it.
+- **A single Mean with no error bars or allocation column.** Sub-microsecond
+  deltas are usually noise; trust `Allocated` and deltas outside `Error`/`StdDev`
+  ([interpreting-results](interpreting-results.md)).
+- **Optimizing before profiling.** "Where is the time" has an evidence-based
+  answer; guessing wastes the change.
+- **Declaring victory from a wall-clock drop alone.** Confirm the targeted cost
+  moved and nothing else regressed.

--- a/.agents/skills/performance-testing/interpreting-results.md
+++ b/.agents/skills/performance-testing/interpreting-results.md
@@ -1,0 +1,81 @@
+# Interpreting results
+
+Detail for the [performance-testing](SKILL.md) skill. Covers the before/after
+measurement discipline and reading the memory columns.
+
+## Before/after measurement discipline (both TFMs, every time)
+
+A perf change is not done until you can show it helped and harmed nothing.
+Profiling a trace answers *where* to optimize; only a before/after benchmark
+answers *whether it worked*. Treat the following as mandatory whenever a code
+change is driven by a profile:
+
+- **Capture a baseline first, on both TFMs.** Run the affected benchmark on each
+  target framework *before* touching the source and save the full result rows.
+  The line-level EventPipe profiling that guides the edit is modern-runtime-only,
+  but the change still has to be measured on .NET Framework - the older RyuJIT
+  and BCL allocate and inline differently, and a win on one TFM can be a wash or
+  a regression on the other. **Never iterate on modern-runtime line info without
+  also tracking the .NET Framework overall throughput and allocation numbers.**
+- **Re-run both TFMs after the change** and diff against the saved baseline.
+- **Record the full BenchmarkDotNet rows, not just a one-line summary.** Keep the
+  whole table - `Mean`, `Error`, `StdDev`, `Gen0`, `Gen1`, `Gen2`, `Allocated` -
+  for both the before and after runs on both TFMs. A summary like "~7% faster"
+  loses the error bars (is the delta inside the noise?) and the allocation column
+  (did the speedup trade CPU for garbage?). Save the raw output to
+  `artifacts/<name>-baseline-<tfm>.txt` and `artifacts/<name>-after-<tfm>.txt`
+  so the full diff is reproducible. Pipe the run through `Tee-Object` to keep the
+  console table.
+- **Allocation must not regress.** Compare the `Allocated` column before and
+  after on *both* TFMs. "No additional allocations" is only true if both columns
+  are unchanged.
+- **Confirm the targeted cost actually moved.** Re-capture a trace after the
+  change and check that the specific method/line the heat map flagged dropped
+  (e.g. `System.Array.Copy` self-time falling from 30 ms to 19 ms). A faster
+  wall-clock with the targeted frame unchanged usually means the win came from
+  somewhere else - or from noise.
+- **Distrust sub-microsecond deltas from a noisy machine.** A busy or thermally
+  throttled host shows variance swings; trust the `Allocated` column and a unit
+  test over a small `Mean` delta. Deltas comfortably outside the `Error`/`StdDev`
+  and consistent in direction across both TFMs are credible.
+
+Present both TFMs' before/after tables together when reporting the result, plus
+the line-level evidence that the targeted hot spot shrank.
+
+## Evaluating memory usage
+
+With `[MemoryDiagnoser]` (or `--memory`), each row of the results table includes:
+
+| Column      | Meaning                                                      |
+| ----------- | ------------------------------------------------------------ |
+| `Gen0`      | Gen0 collections per 1000 operations.                        |
+| `Gen1`      | Gen1 collections per 1000 operations.                        |
+| `Gen2`      | Gen2 collections per 1000 operations.                        |
+| `Allocated` | Managed bytes allocated per single operation.                |
+
+### Reading the numbers
+
+- **`Allocated` is the primary signal.** A method that should be allocation-free
+  must report `-` or `0 B`. Anything else is a regression.
+- A `Ratio` column appears when one method is `Baseline = true`. Use it together
+  with `Allocated` to confirm a perf change is not just trading CPU for
+  allocations (or vice versa).
+- `Gen0` ticking up while `Allocated` stays flat usually means you allocated a
+  lot of short-lived objects on previous iterations - recheck `[GlobalSetup]`.
+- Stack-only types (`Span<T>`, `ref struct`s, `stackalloc`) do not contribute to
+  `Allocated`. Boxing of value types does - watch for accidental boxing through
+  `object`, non-generic interfaces, or `string.Format`.
+- On .NET Framework the JIT and BCL allocate differently than on the modern
+  target. Always run both before declaring a win.
+
+### Where the report lives
+
+After each run BenchmarkDotNet writes artifacts under
+`BenchmarkDotNet.Artifacts/results/` next to the executable, including:
+
+- `*.md` - GitHub-friendly Markdown table (paste this into PR descriptions).
+- `*.csv` and `*.html` - for spreadsheets / browser viewing.
+- `*-report-full.json` - raw measurements; useful for diffing two runs
+  programmatically.
+
+The same table is also printed to the console at the end of the run.

--- a/.agents/skills/performance-testing/overlay.md
+++ b/.agents/skills/performance-testing/overlay.md
@@ -1,0 +1,73 @@
+---
+core: performance-testing
+core-pin: v0.10.0
+---
+
+# madowaku overlay - performance-testing
+
+Repository-specific companion to the vendored [performance-testing](SKILL.md)
+skill. The `SKILL.md` and its sibling pages (`authoring.md`, `running.md`,
+`interpreting-requests.md`, `interpreting-results.md`, `reading-codegen.md`) are
+a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift. Everything madowaku-specific lives here.
+
+> **Pinned to the commons v0.10.0 tag.** Pull later upstream changes with
+> `gh skill update performance-testing`, review the diff, then re-pin `core-pin`.
+
+## Concrete bindings for the core's placeholders
+
+- **Perf project**: the core's `<root>.perf` is
+  [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj), namespace
+  `madowaku.perf`. It multi-targets `net10.0-windows10.0.22000.0` and `net481`
+  and references both [madowaku](../../../madowaku/madowaku.csproj) and
+  [madowaku.tests](../../../madowaku.tests/madowaku.tests.csproj) so test
+  fixtures can seed benchmark setup.
+- **Target frameworks**: `<tfm>` is `net10.0-windows10.0.22000.0` or `net481`.
+  Always pass `-f`, because the project is multi-targeted.
+- **Globals**:
+  [madowaku.perf/GlobalUsings.cs](../../../madowaku.perf/GlobalUsings.cs) already
+  imports `BenchmarkDotNet.Attributes` and `BenchmarkDotNet.Jobs`. Do not
+  re-import them.
+- **Coding style**: follow [AGENTS.md](../../../AGENTS.md) (explicit types, no
+  `var`, target-typed `new()`, collection expressions, indented XML docs).
+- **Example benchmark**:
+  [madowaku.perf/VariantConversionPerf.cs](../../../madowaku.perf/VariantConversionPerf.cs)
+  shows the `[MemoryDiagnoser]` layout and realistic `VARIANT` conversion cases
+  drawn from the tests.
+
+## Running
+
+```pwsh
+# modern .NET
+dotnet run -c Release -f net10.0-windows10.0.22000.0 --project madowaku.perf -- --filter *VariantConversionPerf*
+# .NET Framework
+dotnet run -c Release -f net481 --project madowaku.perf -- --filter *VariantConversionPerf*
+```
+
+`-c Release` is mandatory. Compare both TFMs before claiming a win, since the
+net481 and modern-.NET JITs differ significantly.
+
+## madowaku specifics
+
+- Benchmarks that touch code under
+  [madowaku/Framework/](../../../madowaku/Framework/) (net472-only polyfills)
+  must guard those references with `#if NETFRAMEWORK`.
+- Prefer benchmark data derived from existing `madowaku.tests` cases (for
+  example, `VARIANT` conversion inputs) so the numbers stay realistic.
+
+## Cross-references (the core names these skills generically)
+
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) - the
+  net481-versus-net10 codegen differences these benchmarks exist to validate.
+- [`scratch-buffer-strategy`](../scratch-buffer-strategy/SKILL.md) - zeroed
+  `stackalloc` versus `ArrayPool` versus Touki `BufferScope<T>` crossovers.
+- [`il-copy-inspection`](../il-copy-inspection/SKILL.md) - reading IL to find the
+  struct copies and boxing a benchmark surfaced.
+- [`cswin32-com`](../cswin32-com/SKILL.md) and
+  [`cswin32-interop`](../cswin32-interop/SKILL.md) - the interop surface most
+  madowaku hot paths run through.
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - gates a perf claim
+  that drives a code change on a `madowaku.perf` benchmark (or an explicit "not
+  measured" note).

--- a/.agents/skills/performance-testing/reading-codegen.md
+++ b/.agents/skills/performance-testing/reading-codegen.md
@@ -1,0 +1,120 @@
+# Reading the generated code
+
+Detail for the [performance-testing](SKILL.md) skill. A benchmark says *how
+fast*; this page says *why* - it shows what the C# compiler lowered to, what IL
+was emitted, and what machine code the JIT produced. Reach for it when a
+benchmark result is surprising, when you need to confirm an optimization actually
+happened (dead-branch elision, no defensive copy, a bounds check removed), or
+when you are comparing two shapes that should differ only in codegen.
+
+Measurement and codegen inspection answer different questions and you usually
+need both: the trace says *which* code is hot, the benchmark
+([interpreting-results.md](interpreting-results.md)) says *whether* a change
+helped, and this page says *what the change did to the emitted code*. For reading
+IL specifically to find struct copies and boxing, an IL-copy-inspection skill (if
+the repo vendors one) is the deeper tool; this page is the lighter "see all three
+layers" overview.
+
+## Three layers, cheapest first
+
+1. **C# lowering** - what `foreach`, `await`, pattern matches, interpolated
+   strings, `using`, iterators, and collection expressions desugar into before
+   any IL. Answers "what does this syntax actually compile to." Many "mystery
+   allocations" (a captured closure, a hoisted display class, an iterator state
+   machine) are visible here.
+2. **IL** - the emitted bytecode. Answers "did the compiler insert a copy / box /
+   call I did not write."
+3. **JIT asm** - the machine code RyuJIT produced. Answers "did the bounds check
+   get removed, did the `typeof(T)` branch fold away, is this a `cmov` or a
+   branch." This is the layer most micro-optimizations actually target.
+
+## sharplab.io - the fastest look
+
+[sharplab.io](https://sharplab.io) compiles a snippet and shows IL, JIT asm, or
+the C# **lowering** (the "Results" dropdown -> "C#"). First stop for "what does
+this compile to." Caveats:
+
+- It runs a **current modern .NET** JIT (x64). It is representative of the modern
+  target, **not** .NET Framework - the slow-span layout, the conservative
+  inliner, and the missing vectorization on Framework RyuJIT will not show up.
+  Never use sharplab to reason about Framework codegen; use BenchmarkDotNet's
+  disassembler on a Framework run instead (below).
+- The asm view forces optimizations on, so it shows tier-1-style code, which is
+  what you want.
+
+## BenchmarkDotNet `[DisassemblyDiagnoser]` - asm next to timings
+
+The in-harness disassembler. It works on **both** TFMs (this is the only reliable
+way to see .NET Framework asm), attaching to the benchmarked process and
+disassembling the methods it measured, so the codegen lines up with the numbers.
+
+```c#
+[MemoryDiagnoser]
+[DisassemblyDiagnoser(maxDepth: 2, printSource: true)]
+public class MyBenchmark { /* [Benchmark] ... */ }
+```
+
+- `maxDepth` follows calls that many levels deep; `printSource: true` interleaves
+  the C#. Output lands in `BenchmarkDotNet.Artifacts/results/*-asm.md`.
+- Use `--filter` to a single method - the disassembly is verbose.
+- Run each TFM separately; compare the two asm dumps to see exactly what
+  Framework RyuJIT does differently (no vectorization, the slow-span operand
+  dance, the prologue `rep stosd`). This is how the framework-JIT-optimization
+  ratios get *explained*, not just measured.
+
+## `[HardwareCounters]` - *why* it is slow
+
+When two implementations have similar instruction counts but different timings,
+the cause is usually branch mispredicts or cache misses, not raw work. On Windows
+(ETW, run elevated) add the counters:
+
+```c#
+[HardwareCounters(HardwareCounter.BranchMispredictions, HardwareCounter.CacheMisses)]
+```
+
+- A branchless rewrite that does not move `BranchMispredictions` was not worth
+  it; one that trades a misprediction stall for a `cmov` shows up here. (Note a
+  Framework caveat: the older RyuJIT often does **not** emit `cmov` for
+  `ushort`/`byte` stores - confirm with the disassembler before assuming a
+  ternary went branchless.)
+- Rising `CacheMisses` points at a memory-layout problem (poor locality, a struct
+  too large per cache line, false sharing) rather than a compute one.
+
+## JIT environment knobs (.NET / CoreCLR only)
+
+For ad-hoc asm dumps outside a benchmark, set these before launching a
+modern-runtime process. They drive the runtime's integrated disassembler and do
+**not** apply to the desktop .NET Framework JIT (use `[DisassemblyDiagnoser]`
+there).
+
+| Variable | Effect |
+| --- | --- |
+| `DOTNET_JitDisasm=Type:Method` | Dump asm for matching methods to stdout. |
+| `DOTNET_JitDisasmSummary=1` | One line per compiled method - catches unexpected re-JITs. |
+| `DOTNET_JitDisasmDiffable=1` | Stable output (no addresses) for diffing across a change. |
+| `DOTNET_TieredCompilation=0` | Straight to optimized tier-1 so you inspect real codegen, not the tier-0 stub. |
+| `DOTNET_TieredPGO=0` | Deterministic codegen for analysis (re-enable for production reality). |
+
+## Tiering and PGO: the measurement traps
+
+The modern runtime compiles tier-0 (unoptimized) first and re-JITs to tier-1 once
+a method is hot; **OSR** re-JITs long-running loops mid-flight; **dynamic PGO**
+reshapes tier-1 from observed types. BenchmarkDotNet's warmup handles all of this
+for *timings*. But when you inspect codegen:
+
+- A disassembly captured too early can be the tier-0 stub. Force tier-1 with
+  `DOTNET_TieredCompilation=0`, or put
+  `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` on the method to
+  compile straight to tier-1 and get deterministic asm (it also forgoes PGO for
+  that method, so use it for inspection, not as a blanket production attribute).
+- .NET Framework has **no** tiering or PGO - what you write is compiled once. So
+  a Framework disassembly is always "final," which is why a framework-JIT skill
+  can reason about it directly.
+
+## Confirming an optimization without a disassembler
+
+For a quick yes/no - "did the JIT eliminate this branch" - you do not always need
+asm. Set a debugger breakpoint inside the branch you expect to be dead (e.g. the
+`typeof(T) == typeof(char)` arm when `T = int`) on a Release build. If the JIT
+elided it, the debugger refuses to bind the breakpoint. Cheaper than reading the
+full dump when you only need to confirm dead-code elimination.

--- a/.agents/skills/performance-testing/running.md
+++ b/.agents/skills/performance-testing/running.md
@@ -1,0 +1,66 @@
+# Running benchmarks
+
+Detail for the [performance-testing](SKILL.md) skill. The perf project's
+`Program.Main` typically uses `BenchmarkSwitcher.FromAssembly(...)` so all CLI
+arguments are forwarded to BenchmarkDotNet. Run from the repo root.
+
+For before/after discipline and reading the result columns, see
+[interpreting-results.md](interpreting-results.md). Drilling a benchmark down to
+the hot method or source line is a repo-specific page supplied by the overlay
+(the trace-analyzer skill).
+
+## Specifying the target framework is required
+
+Because the perf project is multi-targeted, **`dotnet run` requires `-f <tfm>`** -
+the SDK will not pick one for you and the run fails (NETSDK1005 or an ambiguous
+target error) if you omit it. Always pass an explicit moniker (e.g. `-f net10.0`
+or `-f net481`, or whatever the repo's current modern version resolves to).
+
+```powershell
+# Modern .NET
+dotnet run -c Release -f net10.0 --project <root>.perf -- --filter *MyBenchmark*
+
+# .NET Framework
+dotnet run -c Release -f net481 --project <root>.perf -- --filter *MyBenchmark*
+```
+
+`-c Release` is **mandatory**. Debug builds are not representative and
+BenchmarkDotNet will warn loudly.
+
+When a change touches code that compiles for both targets, **run both TFMs**. The
+results often differ dramatically - the modern runtime has vectorized BCL APIs
+that .NET Framework lacks, so a hand-tuned Framework fast path may look identical
+to the generic path on the modern runtime.
+
+## Run a single class or method
+
+```powershell
+# All benchmarks in a class
+dotnet run -c Release -f net10.0 --project <root>.perf -- --filter *MyBenchmark*
+
+# A single method
+dotnet run -c Release -f net10.0 --project <root>.perf -- --filter *MyBenchmark.Variant*
+```
+
+The trailing `*` matters: `--filter` globs the full benchmark ID
+(`Namespace.Type.Method`), so `*MyBenchmark.Variant*` also matches the
+parameterized cases (`Variant(x: 1)`, ...) that a bare `*MyBenchmark.Variant`
+would miss.
+
+## Interactive picker
+
+```powershell
+dotnet run -c Release -f <tfm> --project <root>.perf
+```
+
+With no `--filter`, BenchmarkSwitcher prints a numbered menu. Useful when
+exploring. `-f <tfm>` is still required on a multi-targeted project.
+
+## Useful extra switches
+
+- `--job short` - very fast, low-confidence run; good for smoke-testing a new
+  benchmark before committing to a full run.
+- `--memory` - enables the memory diagnoser for this run even if the class is not
+  decorated. Prefer the attribute.
+- `--exporters github` - emits a GitHub-flavored Markdown report alongside the
+  default outputs.

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -1,0 +1,178 @@
+---
+compatibility: Requires git plus the repository's build, test, and agent-file validation commands.
+description: Self-review checklist - plus an agentic review pass (a read-only reviewer persona over the diff) - before opening a PR. Use before invoking `create-pr`, when reviewing your own draft, or when a reviewer flags issues that should have been caught earlier. Codifies recurring mistakes from multi-targeted polyfill work - missing tests for new public surface, unchecked length sums, null-pointer foot-guns from `MemoryMarshal.GetReference` on empty spans, drift from `ArgumentNullException.ThrowIfNull` and `checked()` conventions, TFM phrasing errors, and stale PR descriptions.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/pre-pr-self-review
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 880e117910c69bb909f59a3dfea81cbbf33ac047
+    maturity: canary
+    portability: portable
+    related: create-pr, address-pr-feedback, security-review, performance-testing
+    requires: none
+    risk: local-write
+name: pre-pr-self-review
+---
+
+# Pre-PR self-review
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Run this checklist before invoking the `create-pr` skill. Each item is a question
+your code or PR body must answer. Update the skill whenever a reviewer flags
+something not yet listed.
+
+This skill pairs with several others a consuming repo wires concretely in its
+overlay: a `polyfill-dotnet-api` skill (the source-preference and design rules
+this checklist validates), `create-pr` (the workflow this precedes),
+`address-pr-feedback` (the follow-up that re-runs this checklist),
+`performance-testing` (benchmark authoring required when a perf claim drives a
+change), `framework-jit-optimization` (net481 RyuJIT tradeoffs cited in the
+polyfill-correctness items), `agent-files-review` (for changes under `.agents/`,
+`AGENTS.md`, or `.github/copilot-instructions.md`), and `security-review` (the
+security-specific subset - abusive-input handling, length / integer overflow,
+allocation and algorithmic DoS, argument validation, and every use of `unsafe` /
+`Unsafe.*` / `MemoryMarshal.*` / `Marshal.*` or any BCL API whose docs say
+"unsafe" or "caller must"). Invoke `security-review` alongside this checklist for
+any change that adds or modifies a member accepting caller-supplied data, or that
+touches one of those caller-validated constructs - the common case, not a niche.
+
+## Agentic review pass
+
+Before walking the checklist, run an automated review pass over the diff so the
+reviewer-bot class of findings - correctness edge cases, hand-rolled
+parser/format pitfalls, CI and supply-chain hygiene, and doc-vs-behavior drift -
+surfaces locally instead of across PR rounds. Spawn a **read-only pre-PR reviewer
+persona** (a consuming repo wires the concrete agent in its overlay) over the
+working diff, triage its findings (valid / nit / judgment call / likely false
+positive), fix the valid ones, and re-run at most once when the fixes were
+non-trivial. Keep it bounded: a same-class model nitpicks indefinitely, so two
+passes is the cap and the deterministic gates - tests, lint, the format
+validators - stay the source of truth. The checklist below is the human
+complement: the recurring, domain-specific mistakes an agent pass tends to miss.
+
+## 1. Tests cover every new branch
+
+For each new `public` (or `InternalsVisibleTo`-internal) member:
+
+- Search the test projects for the symbol; no hits = missing test.
+- Polyfills in the Framework-only tree: tests run on both TFMs. Wrap
+  polyfill-only paths (subclass fallbacks, null-receiver guards) in
+  `#if NETFRAMEWORK`.
+- Runtime type-check fast paths (`typeof(T) == obj.GetType()`): test
+  the fast path *and* a subclass override.
+- Generic primitive specializations: every specialized branch needs a
+  test. Don't rely on `byte`/`int` covering `bool`/`sbyte`/`short`/
+  `ushort`/`uint`/`long`/`ulong` - each has independent ref
+  reinterpretation.
+- Security-sensitive APIs (`FixedTimeEquals`, hex decode): cover equal,
+  differing-content, length mismatch, both empty, one empty, and a long
+  span where only the last byte differs.
+- Allocating APIs (`Concat`, `ToHexString`): include an
+  `OverflowException` test on the length sum.
+
+Test hygiene for the tests themselves - the recurring miss list
+that costs the most review rounds on coverage-only PRs:
+
+- **Test method names start with the method under test.**
+  `MethodName_StateUnderTest_ExpectedBehavior` per the repo's test
+  conventions. `ReadOnlySpan_Empty_ReturnsEmpty` is *wrong*;
+  `SliceAtNull_ReadOnlySpan_Empty_ReturnsEmpty` is right.
+- **Every `IDisposable` test local uses `using` or `try`/`finally`.**
+  A temp-folder helper, a matcher handle, a pooled-list rental - a bare
+  local leaks the resource when an assertion fails. Use the
+  `try`/`finally` pattern when the test itself exercises explicit
+  `Dispose()`.
+- **Don't hard-code `InvariantCulture` for APIs that use
+  `CurrentCulture`.** Provider-less formatting helpers generally format
+  with `CurrentCulture`. Asserting against `InvariantCulture`-formatted
+  strings makes the test locale-dependent.
+
+## 2. Polyfill / framework correctness
+
+For any change in the Framework-only tree (a polyfill or a framework-only fast
+path), walk these items (a consuming repo may keep the per-item detail and code
+patterns in a `polyfill-correctness` overlay companion):
+
+- Empty / null spans handled before `unsafe` interop (empty source,
+  empty destination, both empty; exception type cross-checked).
+- Multi-input length sums wrapped in `checked()`.
+- Throw helpers use the standard BCL exceptions, not custom types.
+- Span overloads stay allocation-free by default (document any
+  trade-off in `<remarks>`).
+- Behavior parity with the modern BCL (exception type and message
+  family, edge cases, type-exact fast paths).
+- Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT)
+  and are measured or explicitly marked unmeasured.
+
+If the change is not in the Framework-only tree, skip to &sect;3.
+
+## 3. PR description matches reality
+
+- TFM phrasing: name the polyfill's *target* TFM (the framework target,
+  e.g. `net472`) distinctly from the TFM the tests merely *run* on (e.g.
+  `net481`). Do not call a `net472`-targeted polyfill "net481-only".
+- File list, test counts, and perf numbers all reflect the *current*
+  diff. Re-run after every commit; do not paste numbers from an earlier
+  iteration.
+- **Walk each bullet of the description against the diff before
+  pushing.** If the body says "covers `Foo` with cases A/B/C", search
+  the diff for tests named `Foo_…` and confirm A, B, and C are all
+  there. Review rounds have been lost to descriptions claiming a case
+  (a `Span<char>` "null at end", a double-dispose test) that was not
+  actually in the diff.
+- "Deliberately deferred" entries match what's actually absent from
+  the working tree.
+
+## 4. Final audit before staging
+
+- `git status --short` - delete leftover probe / scratch files;
+  confirm every listed file belongs in the change set.
+- `git diff --check` - whitespace.
+- **Rebase onto the canonical `main` if the branch trails it.** Use
+  `upstream/main` when working from a fork (the canonical repo lives at
+  `upstream`), `origin/main` when cloning the canonical repo directly.
+  Recently-merged sister PRs may have introduced files this PR
+  cross-references; running off a stale base point makes those links look
+  broken to an offline link check that gates `.agents/**`, `AGENTS.md`,
+  and `*.instructions.md` changes. A PR once lost a review round to
+  exactly this.
+- For changes that touch `.agents/`, `AGENTS.md`, or
+  `.github/copilot-instructions.md`, also run the repo's agent-file link
+  checker (see the `agent-files-review` skill for options, including
+  changed-only and base-ref modes).
+- Build both TFMs.
+- Run the test suite in **both Debug and Release**. Release-mode RyuJIT
+  inlining surfaces bugs Debug doesn't - e.g.
+  `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates
+  the caller's int-promoted argument into the comparison immediate
+  (`cmp ecx, 0xFFFFFFFF` instead of `cmp ecx, 0xFF`) for negative
+  signed-primitive inputs on net481, but only in Release. Mask
+  explicitly with `& 0xFF` / `& 0xFFFF`. See the `polyfill-dotnet-api`
+  and `framework-jit-optimization` skills.
+- Stage **by path**, never `git add -A` / `git add .` when the working
+  tree spans more than one logical change. If topics are intermingled,
+  ask before staging.
+
+## 5. Failing CI is a stop, not a sprint
+
+When a build / test / CI run fails on a PR:
+
+1. Diagnose.
+2. Prepare the fix in the working tree.
+3. Describe what changed, why, and any risks.
+4. **Stop and wait for explicit approval before commit/push.**
+
+Stacked rapid-fire fix commits are how perf regressions and unrelated
+sweep-ups get into history.
+
+## 6. Update this skill
+
+If a reviewer flags something not in this checklist, add it. If the
+review touched `.agents/` files, also update via the `agent-files-review`
+workflow so the validator and any CI mirror stay in sync.

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,0 +1,43 @@
+---
+core: pre-pr-self-review
+core-pin: v0.10.0
+---
+
+# madowaku overlay - pre-pr-self-review
+
+Repository-specific companion to the vendored [pre-pr-self-review](SKILL.md)
+skill. The `SKILL.md` is a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in its frontmatter). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku recurring mistakes to self-check
+
+- **Every target must compile and behave.** madowaku builds `net10.0`,
+  `net10.0-windows10.0.22000.0`, and `net472`; a change that only builds on one
+  is not done. Guard modern-only APIs with `#if NET` and keep net472-only code in
+  [madowaku/Framework/](../../../madowaku/Framework/).
+- **`dotnet test -c Release`**, not just Debug - Release inlining surfaces the
+  `Unsafe.As`-on-a-parameter net481 RyuJIT foot-gun.
+- **No `Enum.HasFlag`** (boxes on net472); use the Touki enum extension methods.
+- **`nint` / `nuint`, never `IntPtr` / `UIntPtr`**; `HANDLE` / `HRESULT` / `BOOL`
+  and friends at interop boundaries.
+- **Interop APIs go through the generated `PInvoke` / `PInvokeMadowaku` surface**
+  (`NativeMethods.txt`), not hand-written `[DllImport]`.
+- **A perf claim needs a [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj)
+  benchmark** (or an explicit "not measured" note).
+
+## Cross-references
+
+- [`performance-testing`](../performance-testing/SKILL.md) - to satisfy the perf
+  evidence check.
+- [`security-review`](../security-review/SKILL.md) - for the unsafe / interop
+  surface the review touches.
+- [`create-pr`](../create-pr/SKILL.md) - the workflow this checklist precedes.
+
+## Updating
+
+Pull upstream changes with `gh skill update pre-pr-self-review` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -1,0 +1,134 @@
+---
+compatibility: Applies to multi-targeted .NET code where modern .NET and .NET Framework runtime costs can be measured separately.
+description: Choose how a hot path gets a short-lived scratch buffer - zeroed `stackalloc`, `[SkipLocalsInit]` + `stackalloc`, `BufferScope` of T (stack with pool fallback), or a rental from the shared `ArrayPool` of T - and apply the net481/net10 size crossovers. Use when designing or reviewing a performance-sensitive path that needs a temporary buffer, when deciding "should I rent or stackalloc?", when weighing `[SkipLocalsInit]`, or when evaluating buffer/allocation cost. Defers the backing measurements and full reasoning to the bundled references/arraypool-performance.md.
+license: MIT
+metadata:
+    applicability: dotnet-framework
+    binding: optional-overlay
+    github-path: skills/scratch-buffer-strategy
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 3ae67f801e33d4b55730633f22e27c0fa941ea99
+    maturity: canary
+    portability: portable
+    related: performance-testing, framework-jit-optimization
+    requires: none
+    risk: advisory
+name: scratch-buffer-strategy
+---
+
+# Scratch buffer strategy (net481 + net10)
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Pick the cheapest correct way to get a short-lived scratch buffer on a hot path.
+This skill is the compact decision aid; the measured numbers, the per-call
+ArrayPool autopsy, the inlining traps, and the references live in the bundled
+[references/arraypool-performance.md](references/arraypool-performance.md). Read
+that doc before quoting a number or making a non-obvious call.
+
+A multi-targeted library runs on **net481** (older RyuJIT: unvectorized `memset`,
+no tiered JIT/PGO, weaker inliner) and **net10**. Buffer costs differ enough
+between them that every decision must hold on both. Name the JIT in any writeup
+(the JIT-naming rule).
+
+## Four options, ranked for the common case
+
+1. **`[SkipLocalsInit]` + `stackalloc`** - fastest (~1-2 ns, both TFMs).
+   Requires: fixed/bounded size, stack-safe, and **every read slot written
+   first**. Put the attribute on the method that physically contains the
+   `stackalloc`.
+2. **Zeroed `stackalloc`** - safe default. Cost scales with byte count;
+   net481 zeroing is ~3.6x net10 for a **compile-time-constant** size (for a
+   runtime-variable size both TFMs zero at ~the same rate - see the doc).
+3. **`BufferScope<T>(stackalloc T[N], minimumLength)`** - variable/unbounded
+   size that is usually small. Stays on the stack for the common case, rents
+   from `ArrayPool` only on overflow. Wrapper overhead ~1 ns net481 / ~0.3 ns
+   net10. Forwards the caller's `[SkipLocalsInit]` to the stack buffer.
+   (`BufferScope<T>` ships as `Touki.Buffers.BufferScope<T>` in the
+   [`KlutzyNinja.Touki`](https://www.nuget.org/packages/KlutzyNinja.Touki) NuGet
+   package - consume that rather than rolling or supplying your own.)
+4. **`ArrayPool<T>.Shared` Rent/Return** - large, unbounded, recursive, or must
+   escape the frame. Has a fixed per-call floor that warmup never removes
+   (~10 ns/op net481, ~4 ns/op net10). Rent **once** and reuse across the loop.
+
+## Decision tree
+
+```text
+Short-lived scratch buffer on a hot path?
+|
++- Fixed/small (one frame, few KB), not recursive/looped?
+|   +- Write every slot before reading?  --> [SkipLocalsInit] + stackalloc
+|   +- Cannot guarantee that?            --> zeroed stackalloc (or zero only
+|                                            the prefix you read)
+|
++- Usually small but occasionally large (variable size)?
+|   --> BufferScope<T>(stackalloc T[N], minLen); put [SkipLocalsInit] on the
+|       CALLING method to drop the stack-buffer zeroing
+|
++- Large / unbounded / recursive / must escape frame?
+    --> ArrayPool<T>.Shared, rented once and reused
+```
+
+## Crossover thresholds (zeroed stackalloc vs a rental)
+
+For a **runtime-variable** size, zeroing a `stackalloc` is cheaper than renting
+below these sizes; above them the rental's flat floor wins (only if you can use
+the memory uninitialized):
+
+| Rental kind | net481 | net10 |
+| --- | --: | --: |
+| Warm TLS hit (first rental) | ~1.3 KB | ~190 B |
+| Locked (second same-bucket rental) | ~3 KB | ~1.8 KB |
+
+A **compile-time-constant** size zeroes far cheaper on net10, pushing its
+crossover higher. If you would have to `Clear()` the rented array, add that cost
+back to the rental side - the crossover then exceeds any sane stack size, so
+just stack-allocate.
+
+## Load-bearing facts (do not re-derive)
+
+- **net481 honors `[SkipLocalsInit]`.** The `localsinit`-flag suppression works
+  on the desktop CLR exactly as on CoreCLR; the attribute *type* is
+  source-generated downlevel by PolySharp. A 4 KB clear drops from ~53 ns to
+  ~1.7 ns on net481.
+- **Only byte count drives zeroing cost** - struct arrays zero exactly like
+  primitive arrays of the same size.
+- **A warm pool is not a free pool.** Rent/Return pays bucket-index math, a
+  one-deep TLS cache (two same-bucket rentals collide into the locked stack),
+  and a separate pool per element type - on every call, net481 ~2.5x worse.
+- **`[SkipLocalsInit]` hands you uninitialized memory.** Use it only where a
+  profile shows the clear is hot, every read slot is provably written first, and
+  no unwritten bytes can escape (info-disclosure risk). The JIT inliner does not
+  spread the attribute; net481's weaker inliner can move where zeroing lands, so
+  verify on both TFMs.
+- **`Unsafe.SkipInit` does NOT suppress the zeroing.** Common mistake: assuming
+  `Unsafe.SkipInit(out x)` makes a stack buffer un-zeroed. It compiles to a bare
+  `ret` and only satisfies C# definite-assignment so you can read an unassigned
+  local; the runtime still zeroes via the method's `.locals init` flag, which
+  only `[SkipLocalsInit]` (or `[module: SkipLocalsInit]`) removes. A "fixed
+  buffer left uninitialized with `Unsafe.SkipInit`" but *without*
+  `[SkipLocalsInit]` pays full zeroing. See
+  [references/arraypool-performance.md](references/arraypool-performance.md)
+  section 8.
+
+## Stack-safety guardrail
+
+`stackalloc` only belongs on the stack at all if it is bounded: keep a single
+frame's `stackalloc` to a few KB, and never `stackalloc` on a recursive or
+unbounded-loop path (CA2014). Default Windows managed stack is 1 MB, but library
+code may run on a 256 KB partial-trust thread. Past those limits, rent once and
+reuse instead.
+
+## Related
+
+- [references/arraypool-performance.md](references/arraypool-performance.md) -
+  the full measured tables, the ArrayPool per-call autopsy, the `BufferScope`
+  overhead numbers, the inlining trap, and references. **This is the backing
+  data; cite it.**
+- The repository's performance-testing and framework-JIT-optimization skills
+  (author/run the BenchmarkDotNet benchmarks that produced these numbers, and
+  net481 loop tuning once a buffer choice is made) - a consuming repository
+  wires the concrete cross-references in its overlay.

--- a/.agents/skills/scratch-buffer-strategy/overlay.md
+++ b/.agents/skills/scratch-buffer-strategy/overlay.md
@@ -1,0 +1,38 @@
+---
+core: scratch-buffer-strategy
+core-pin: v0.10.0
+---
+
+# madowaku overlay - scratch-buffer-strategy
+
+Repository-specific companion to the vendored [scratch-buffer-strategy](SKILL.md)
+skill. The `SKILL.md` and its bundled
+`references/arraypool-performance.md` page are a **pinned copy of the portable
+core** from [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills)
+(see the `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **Buffer helper**: the core's `BufferScope<T>` is the Touki
+  (`KlutzyNinja.Touki`) type; madowaku depends on Touki, so prefer it over a raw
+  `ArrayPool<T>` rental for scratch buffers.
+- **Crossovers apply across `net472` and modern .NET.** madowaku builds `net472`
+  in addition to `net10.0` / `net10.0-windows10.0.22000.0`, and the size
+  crossovers in `references/arraypool-performance.md` are measured on those JITs.
+- **Validate a choice** with a [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj)
+  benchmark before committing to a strategy on a hot path.
+
+## Cross-references
+
+- [`performance-testing`](../performance-testing/SKILL.md) - the harness that
+  confirms a stackalloc / rental / `BufferScope<T>` crossover.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) - the
+  net472 codegen behavior behind the crossovers.
+
+## Updating
+
+Pull upstream changes with `gh skill update scratch-buffer-strategy` (review the
+diff, re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md
+++ b/.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md
@@ -1,0 +1,518 @@
+# ArrayPool vs stack scratch: performance on net481 and net10
+
+When a hot path needs a short-lived scratch buffer, there are three ways to get
+one: `stackalloc` (zero-initialized by default), `ArrayPool<T>.Shared`
+rent/return, or a `stackalloc`/fixed buffer with the zeroing suppressed. The
+right choice depends on the buffer's size, lifetime, and - critically - which
+target framework's JIT is running. This document captures the measured costs and
+a decision procedure for choosing between them.
+
+All numbers below come from BenchmarkDotNet projects (listed in section 7),
+run in Release on a development machine against
+**.NET Framework 4.8.1 RyuJIT** and **modern .NET RyuJIT** (.NET 10). Per the
+JIT-naming rule, every claim names the JIT, because the two behave very
+differently here.
+
+For the compact decision aid (decision tree + crossover thresholds without the
+backing tables), see the [`scratch-buffer-strategy`](../SKILL.md) skill. This
+document is the data it cites.
+
+---
+
+## 1. The headline result
+
+For a fixed-size scratch buffer whose every slot is written before it is read,
+**`[SkipLocalsInit]` + `stackalloc` is the fastest option on both target
+frameworks** - faster than an `ArrayPool` rental and far faster than a
+zero-initialized `stackalloc`. The pool only wins when the buffer is large,
+unbounded, or must escape the stack frame.
+
+The single most important and most counter-intuitive fact:
+
+> **.NET Framework 4.8.1 RyuJIT honors `[SkipLocalsInit]`** for the locals it
+> governs. Suppressing the `localsinit` flag on a method removes the zeroing of
+> that method's `stackalloc` / local stack storage on net481 just as it does on
+> modern .NET. A 4 KB stack buffer drops from ~53 ns to ~1.7 ns on net481.
+
+This corrects the common assumption that Framework "always zeroes stackalloc".
+It does zero by default, but the absence of the `localsinit` flag is respected by
+the desktop runtime, so the zeroing of the attributed method's locals is fully
+suppressible. (The attribute governs only the methods it is applied to; it is not
+a claim that *no* prologue zeroing ever occurs anywhere.)
+
+---
+
+## 2. The cost of zeroing
+
+`stackalloc` without `[SkipLocalsInit]` clears the buffer on every call. That
+clear is a `memset` whose cost scales with the **byte size** of the buffer.
+
+### 2.1 Zeroing cost by size
+
+| Buffer | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| `byte[256]` (256 B) | 7.0 ns | 1.7 ns |
+| `byte[1024]` (1 KB) | 14.0 ns | 5.8 ns |
+| `byte[4096]` (4 KB) | 53.4 ns | 14.5 ns |
+
+Two things to read off this:
+
+- The cost is roughly linear in bytes once past the smallest sizes.
+- **net481 zeroing is ~3.6x more expensive than net10 zeroing** for the same
+  buffer (53 ns vs 15 ns at 4 KB). The desktop `memset` path is not vectorized
+  the way the modern runtime's is. This is why a zeroing cost that is a minor
+  line item on net10 can become the dominant per-call cost on net481.
+
+This ~3.6x gap holds for a **compile-time-constant** size, which is what these
+measurements use. For a runtime-variable `stackalloc byte[n]` net10 loses the
+vectorized clear and zeroes at nearly the same rate as net481 - see the note in
+section 3.2.
+
+### 2.2 Struct arrays zero exactly like primitive arrays
+
+A frequent worry is that an array of structs costs more to clear than an array
+of primitives. It does not - zeroing is byte-wise and ignores the element type.
+At an equal 4 KB:
+
+| Buffer | Bytes | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|--:|
+| `byte[4096]` | 4096 | 53.4 ns | 14.5 ns |
+| `int[1024]` | 4096 | 51.3 ns | 14.6 ns |
+| `Range16[256]` (4x `int`) | 4096 | 52.4 ns | 15.0 ns |
+
+The three are within noise of each other on both TFMs. **Only the byte count
+matters.** Do not restructure a struct buffer into a primitive one hoping to
+zero faster - reduce the byte count or suppress the zeroing instead.
+
+---
+
+## 3. The cost of an ArrayPool rental
+
+`ArrayPool<T>.Shared` hands back **uninitialized** memory, so it never pays the
+zeroing tax. But Rent/Return are not free, and - this is the key gotcha - the
+overhead is **per-call bookkeeping that warmup cannot eliminate**.
+
+`ArrayPoolSeedRentPerf` measures a representative multi-buffer rental shape: five
+buffers (a 28-byte frame struct x32, a 16-byte range struct x128, that range
+struct x18 twice, and an `int[57]`), rented and returned together, ~3.7 KB
+aggregate, with the pool pre-warmed 64x in `[GlobalSetup]`.
+
+| Operation | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| 5x Rent + 5x Return (`PoolRent`) | 104.3 ns | 40.6 ns |
+| equivalent zeroed `stackalloc` | 55.2 ns | 20.9 ns |
+| **pool penalty over stackalloc** | **+49 ns** | **+20 ns** |
+
+The pool is **slower than even a zeroing `stackalloc`** on both TFMs for this
+size. Roughly 10 ns per Rent/Return pair on net481, 4 ns on net10.
+
+### 3.1 Why warmup does not hide it
+
+The pool is fully warm - `[GlobalSetup]` and BenchmarkDotNet's own warmup run it
+hundreds of times - yet the cost persists, because it is steady-state work done
+on **every** call:
+
+1. **Bucket-index math per call.** `Shared` is
+   `TlsOverPerCoreLockedStacksArrayPool<T>`. Each Rent computes a bucket index
+   (a log2) from the requested length; each Return recomputes it from
+   `array.Length`. Ten times for five buffers.
+2. **The thread-local cache holds one array per bucket.** If two rentals hit the
+   same bucket - in the engine, `work` and `rest` are both `ProgramRange[18]` -
+   the second misses the TLS fast path and falls through to the per-core
+   **locked** stack (an interlocked/`Monitor` acquire). So does the second
+   return.
+3. **Separate pools per element type.** `Frame`, `ProgramRange`, and `int` are
+   three independent `ArrayPool<T>.Shared` instances with three separate per-core
+   stacks; no sharing, three sets of the above.
+4. **net481 makes all of it ~2.5x worse.** The pool internals are not inlined
+   (no tiered JIT, no dynamic PGO), the locked-stack path is heavier, and the
+   bucket math is not folded into the caller. That is why the penalty is +49 ns
+   on net481 versus +20 ns on net10.
+
+The lesson: **a warm pool is not a free pool.** Rent/Return has a fixed per-call
+floor that no amount of warmup removes.
+
+### 3.2 Where zeroing crosses the rental floor
+
+The previous tables compare a single fixed size. The more actionable question is
+"above what size does zeroing a `stackalloc` cost more than renting?" Because
+zeroing scales with the byte count while a rental is a flat per-call floor, there
+is a crossover size. `ArrayPoolCrossoverPerf` sweeps `stackalloc byte[N]` against
+a rental for `N` from 64 to 8192 bytes, separating the two rental floors:
+
+- **TLS hit** (`RentTls`): the first rental of a bucket, served from the
+  one-deep thread-local cache.
+- **Locked** (`RentLocked`): a second same-bucket rental taken while the first is
+  still checked out, so it falls to the per-core locked stack. Its marginal cost
+  is `RentLocked - RentTls`.
+
+Measured means (ns); the rental rows are essentially flat across size, the
+`ZeroStack` row rises with it:
+
+| Bytes | net481 ZeroStack | net481 RentTls | net481 RentLocked | net10 ZeroStack | net10 RentTls | net10 RentLocked |
+|--:|--:|--:|--:|--:|--:|--:|
+| 64   |   2.1 |  21.4 | 43.3 |   2.3 | 4.9 | 30.2 |
+| 128  |   3.3 |  21.3 | 42.9 |   3.7 | 4.9 | 31.1 |
+| 256  |   5.7 |  20.9 | 42.2 |   6.6 | 5.0 | 31.2 |
+| 512  |   7.3 |  21.1 | 41.8 |  12.4 | 4.9 | 30.9 |
+| 1024 |  16.0 |  20.7 | 41.6 |  22.4 | 5.0 | 30.9 |
+| 2048 |  30.9 |  20.8 | 41.6 |  33.9 | 4.9 | 31.7 |
+| 4096 |  53.8 |  20.7 | 41.9 |  56.9 | 4.8 | 30.8 |
+| 8192 | 100.2 |  20.5 | 41.0 | 103.8 | 5.0 | 31.2 |
+
+> **Why net10's `ZeroStack` here is ~4x its section 2.1 figure.** This sweep uses
+> a runtime-variable `stackalloc byte[size]` (the size is a benchmark parameter),
+> which is the realistic shape of the "should I rent?" question. RyuJIT emits its
+> fast vectorized clear only for a **compile-time-constant** size, so net10's
+> variable-size zeroing (~57 ns at 4 KB) is roughly 4x its constant-size cost
+> (~14.5 ns in section 2.1) and lands right on top of net481. For a
+> runtime-determined size the two TFMs zero at nearly the same rate; net10's
+> ~3.6x advantage applies only to constant sizes. A constant-size buffer
+> therefore pushes net10's crossover well above the figures below.
+
+The rental floors are roughly constant - net481 ~21 ns (TLS) / ~42 ns (locked),
+net10 ~5 ns (TLS) / ~31 ns (locked) - confirming a rental does not scale with
+size, only the zeroing does. The crossover sizes (where `ZeroStack` overtakes the
+flat rental line):
+
+| Rental kind | net481 crossover | net10 crossover |
+|---|--:|--:|
+| TLS hit (first rental) | ~1.3 KB | ~190 bytes |
+| Locked (second rental) | ~3 KB | ~1.8 KB |
+
+How to read it:
+
+- **Below the crossover, the zeroed `stackalloc` is cheaper** than even a warm
+  TLS rental - so for small fixed buffers, do not rent; stack-allocate and (if
+  the write-before-read invariant holds) add `[SkipLocalsInit]` to drop the
+  zeroing entirely.
+- **net10's TLS rental is remarkably cheap (~5 ns)**, so on modern .NET the bar
+  for "rent instead of zero" is low - anything past ~190 bytes that you would
+  otherwise zero is a candidate. **net481's rental is ~4x that floor (~21 ns)**,
+  so on Framework you have to be allocating roughly **1.3 KB** before a rental
+  beats zeroing, and **3 KB** before it beats zeroing if the rental collides on a
+  busy bucket.
+- **The locked (second-rental) floor is the realistic one for hot, concurrent
+  paths** where the one-deep TLS slot is frequently already drained. Against that
+  floor zeroing wins up to ~1.8 KB on net10 and ~3 KB on net481.
+- These crossovers assume the rental memory is **uninitialized-safe** (you write
+  every slot before reading). If you would have to `Clear()` the rented array,
+  add the zeroing cost back to the rental side and the crossover moves much
+  higher - usually past any sane stack size, i.e. just stack-allocate.
+
+---
+
+## 4. Suppressing the zeroing instead
+
+If the buffer is a fixed, stack-friendly size and the code writes every slot
+before reading it, the best move is to keep it on the stack and turn the zeroing
+off. There are two ways; one is clearly better.
+
+### 4.1 `[SkipLocalsInit]` on the method (preferred)
+
+Annotate the method that contains the `stackalloc` with
+`[System.Runtime.CompilerServices.SkipLocalsInit]`. The C# compiler omits the
+`localsinit` flag, and both runtimes skip the clear. Requires
+`<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` in the project.
+
+`[SkipLocalsInit]` is a **compiler + CLR** mechanism, not a BCL feature. Per the
+[C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute),
+the attribute "prevents the compiler from setting the `.locals init` flag when
+emitting to metadata," and "the `.locals init` flag causes the CLR to initialize
+all of the local variables." The desktop .NET Framework CLR honors the absence
+of that flag exactly as CoreCLR does - which is why the net481 column above
+shows the zeroing disappearing.
+
+A common source of confusion: the
+[`SkipLocalsInitAttribute` API page](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute)
+lists "Applies to: .NET 5-11" and does **not** list .NET Framework. That only
+means the attribute *type* does not ship in the Framework BCL - it says nothing
+about whether the runtime honors the flag. Because the attribute is just a
+marker the compiler reads, you supply the type yourself downlevel; you can
+source-generate it with **PolySharp** (`PolySharpIncludeRuntimeSupportedAttributes`
+in the project), so `[SkipLocalsInit]` compiles and takes effect on net481.
+
+There is a real caveat, but it does **not** apply to `stackalloc`. The attribute
+only skips zero-init that is otherwise redundant; the JIT still zeroes (and
+GC-tracks) any local that contains **managed references**, for GC safety - see
+the GC-reference note in
+[Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices).
+But `stackalloc T[]` requires `T` to be an
+[unmanaged type](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/unmanaged-types),
+and `fixed` buffers are likewise unmanaged, so a stack scratch buffer has no
+managed references and the zeroing is fully elided. The caveat would only bite
+if you applied `[SkipLocalsInit]` expecting it to skip a plain local (or a
+struct) that holds object references - that is still zeroed.
+
+| 4 KB scratch | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| zeroed `stackalloc` | 53.0 ns | 14.8 ns |
+| `[SkipLocalsInit]` `stackalloc` | **1.7 ns** | **1.3 ns** |
+
+The zeroing essentially vanishes on both TFMs - a ~30x win on net481, ~11x on
+net10. This is the cleanest option: one attribute, one code path, no pool
+bookkeeping, allocation-free.
+
+### 4.2 `BufferScope<T>`: stack buffer with a pool fallback
+
+The size sweep in section 3.2 assumes you know the size up front. Often you do
+not: the common size is small and stack-friendly, but a rare large input must
+still be handled without overflowing the stack. A stack-with-pool-fallback
+wrapper - `Touki.Buffers.BufferScope<T>` from the `KlutzyNinja.Touki` package -
+is built for exactly this: **start on a `stackalloc` buffer, transparently fall
+back to an `ArrayPool<T>` rental only when the requested capacity exceeds it**:
+
+```csharp
+[SkipLocalsInit]
+static int Process(ReadOnlySpan<char> input)
+{
+    // Common case stays on the stack; large input rents from the pool.
+    using BufferScope<char> buffer = new(stackalloc char[256], input.Length);
+    // ... use buffer as a Span<char> ...
+}
+```
+
+`BufferScope<T>` is a `ref struct` that wraps the caller's `stackalloc` span and
+only rents when `minimumLength` overflows it; `Dispose` returns the rental (and
+is a no-op on the stack-only path). Crucially, **the `stackalloc` lives in the
+caller**, so the caller's `[SkipLocalsInit]` controls whether that buffer is
+zeroed - the wrapper never clears stack memory itself.
+
+The `BufferScopeOverhead` benchmark measures the wrapper against the hand-written
+equivalent on each path. The 256-byte stack buffer either satisfies the request
+(`StackOnly`) or is overflowed by a 1024-byte request that forces a rental
+(`Rent`):
+
+| Path | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| direct `stackalloc`, `[SkipLocalsInit]` | 7.7 ns | 0.90 ns |
+| `BufferScope` stack-only, `[SkipLocalsInit]` | 8.8 ns | 1.23 ns |
+| `BufferScope` stack-only, **zeroed** (no SkipLocalsInit) | 11.6 ns | 2.26 ns |
+| direct pool Rent/Return | 25.3 ns | 4.99 ns |
+| `BufferScope` grow-to-rental | 28.6 ns | 5.20 ns |
+
+Two things to take from this:
+
+- **The wrapper overhead is small** - about +1 ns on net481 / +0.3 ns on net10
+  for the stack-only path, and +3 ns / +0.2 ns for the rental path. You are
+  paying a constructor and a `Dispose` branch on top of the underlying
+  stackalloc-or-rent cost, nothing more.
+- **`BufferScope` is `[SkipLocalsInit]`-friendly.** Compare the stack-only rows:
+  with `[SkipLocalsInit]` on the calling method the scope costs 8.8 ns (net481)
+  / 1.23 ns (net10); without it, the same scope pays the 256-byte zeroing and
+  rises to 11.6 ns / 2.26 ns. The wrapper passes the localsinit decision
+  straight through to the caller's `stackalloc`, so you keep the zeroing-
+  suppression win on the common path **and** get a safe pool fallback for the
+  rare large input. This is the recommended shape whenever the size is variable
+  or unbounded but usually small.
+
+### 4.3 Risks of skipping init (and the inlining trap)
+
+`[SkipLocalsInit]` is `unsafe` for a reason: it hands you **uninitialized
+memory**. The
+[best-practices guidance](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices)
+is to use it only where a profile shows the zeroing is hot. Specific risks:
+
+- **You must write before you read.** With the `localsinit` flag gone, a
+  `stackalloc` (or any local) contains whatever was previously on the stack.
+  Reading a slot you have not assigned yields a garbage value - and worse, it is
+  *non-deterministic*: it passes in tests where the stack happened to be zero and
+  fails in production. Only apply `[SkipLocalsInit]` to a buffer whose every read
+  slot is provably written first (e.g. you fill `[0..count]` and only ever read
+  `[0..count]`).
+- **It is a potential information-disclosure vector.** Uninitialized stack memory
+  can contain remnants of previous frames (other callers' data). If any unwritten
+  portion of the buffer can be observed - returned, copied out, hashed, or
+  serialized - you may leak unrelated data. The `<AllowUnsafeBlocks>` requirement
+  exists precisely to flag this.
+- **The attribute's scope follows inlining, which you do not fully control.**
+  `[SkipLocalsInit]` applied to a method also covers its nested local functions
+  and lambdas, but it does **not** transfer across a normal call boundary: a
+  helper you call keeps its own localsinit setting. The subtle part is the
+  interaction with the JIT inliner:
+  - If method `A` is `[SkipLocalsInit]` and the JIT **inlines** a non-attributed
+    helper `B` into `A`, `B`'s `stackalloc`/locals do **not** retroactively
+    become skip-init - the localsinit decision is fixed by the compiler per
+    method at IL-emit time, before the JIT inlines. So you cannot rely on
+    inlining to "spread" the attribute. Put `[SkipLocalsInit]` on the method that
+    physically contains the `stackalloc`.
+  - Conversely, inlining can move where the zeroing *appears* to happen. A tiny
+    `stackalloc` helper that is **not** `[NoInlining]` may be inlined into a
+    caller, and if that caller is also hot the zeroing folds into the caller's
+    prologue. This is why the benchmarks here force `[NoInlining]` on the touch
+    helpers: to measure the buffer cost in isolation rather than have the JIT
+    relocate or eliminate it. In real code the opposite is true - **let the small
+    helper inline**, and put `[SkipLocalsInit]` on whichever method ends up
+    owning the `stackalloc` after inlining (the one with the attribute, since the
+    compiler honored it there).
+  - On net481 the inliner is weaker (no tiered JIT, no dynamic PGO), so a helper
+    that inlines on net10 may stay a real call on net481, changing where the
+    zeroing lands and how much the surrounding code can be folded. Always verify
+    the win on **both** TFMs rather than assuming the net10 inlining shape
+    carries over.
+
+The safe default remains: prefer plain zeroed `stackalloc` (or `BufferScope`
+without `[SkipLocalsInit]`); reach for `[SkipLocalsInit]` only when a profile
+shows the clear is hot, the write-before-read invariant is guaranteed, and no
+unwritten bytes can escape.
+
+---
+
+## 5. Is the buffer stack-safe? Sizing guidance
+
+Suppressing the zeroing only makes sense if the buffer belongs on the stack at
+all. The constraint is the thread's stack budget. On both .NET Framework and
+modern .NET on Windows the default managed thread stack is **1 MB** (set in the
+executable's PE header; the
+[`Thread` constructor docs](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor)
+state "the default stack size (1 megabyte)" and warn against raising it). But
+library code may run on threads with smaller stacks: under partial trust on
+.NET Framework the minimum is **256 KB**
+([same docs](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor)),
+and some hosts constrain it further. The C# reference for
+[`stackalloc`](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc)
+adds two rules of its own: cap the allocation at a conservative limit (its
+example uses 1024 bytes) and **never `stackalloc` inside a loop** (analyzer
+[CA2014](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops)).
+So the working rule is **keep a single frame's `stackalloc` to a few KB and
+never put a `stackalloc` on a recursive or unbounded-loop path.**
+
+Apply this to a multi-buffer rental seed. A concrete example - the per-run seed
+of a small bytecode matching engine that rents five buffers in a single frame:
+
+| Buffer | Element size | Count | Bytes |
+|---|--:|--:|--:|
+| `Frame[]` | 28 B | 32 | 896 |
+| `ProgramRange[]` (arena) | 16 B | 128 | 2048 |
+| `ProgramRange[]` (work) | 16 B | 18 | 288 |
+| `ProgramRange[]` (rest) | 16 B | 18 | 288 |
+| `int[]` (key) | 4 B | 57 | 228 |
+| **Total** | | | **3748 (~3.7 KB)** |
+
+This is safe to keep on the stack because:
+
+- **It is a single frame, ~3.7 KB.** Well under any reasonable per-call budget.
+- **It is not on a recursive path.** The seed is allocated once per run.
+  Any bounded re-entry goes through a separate core routine that reuses
+  caller-supplied probe buffers and does **not** `stackalloc` again, so
+  the 3.7 KB never multiplies with recursion depth.
+- **Every slot is written before it is read** (the work/rest/key buffers are
+  seeded by `CopyTo` and the per-element builders; frames/arena are written
+  before use and spill to `ArrayPool` only when an adversarial input outgrows
+  the seed). So it does not depend on zero-init and is a correct candidate for
+  `[SkipLocalsInit]`.
+
+Had the aggregate been tens of KB, or had the buffer sat on the recursive
+re-entry path, the answer would flip to a pool rental (rented once and reused
+across the recursion) despite the per-call overhead, to avoid stack overflow.
+
+---
+
+## 6. Decision procedure
+
+```text
+Need a short-lived scratch buffer on a hot path?
+│
+├─ Is the size fixed and small (single frame ≲ a few KB),
+│  and NOT on a recursive / unbounded-loop path?
+│  │
+│  ├─ YES ──> stackalloc.
+│  │         Does the code write every slot before reading it?
+│  │         ├─ YES ──> add [SkipLocalsInit]. (best: ~1-2 ns, both TFMs)
+│  │         └─ NO  ──> plain zeroed stackalloc, OR zero only the
+│  │                    prefix you read. (net481 zeroing ~3.6x net10)
+│  │
+│  ├─ Usually small but occasionally large (variable / unbounded
+│  │  size, common case stack-friendly)? ──>
+│  │            BufferScope<T>(stackalloc T[N], minimumLength):
+│  │            stays on the stack for the common case, rents from the
+│  │            pool only when it overflows. Wrapper overhead ~1 ns
+│  │            net481 / ~0.3 ns net10. Put [SkipLocalsInit] on the
+│  │            CALLING method to drop the stack-buffer zeroing; the
+│  │            scope passes it through.
+│  │
+│  └─ NO (large, unbounded, recursive, or must escape the frame) ──>
+│            ArrayPool<T>.Shared, rented ONCE and reused across the
+│            loop/recursion. Accept the per-call Rent/Return floor
+│            (~10 ns/op net481, ~4 ns/op net10); minimize the number
+│            of distinct rentals and avoid two same-bucket rentals
+│            colliding in the TLS cache.
+```
+
+Key rules of thumb:
+
+- **Measure the zeroing before assuming it is the cost.** Sampling profilers
+  attribute stack zeroing to `System.Buffer.ZeroMemoryInternal` (or `memset`);
+  if that frame is hot, a `[SkipLocalsInit]` experiment is the first thing to
+  try. But scope the profile to the measured workload - warmup/JIT dilute the
+  percentage and a tiny hot frame can be over-attributed by the sampler.
+- **net481 amplifies both costs.** Constant-size zeroing is ~3.6x and pool
+  overhead ~2.5x more expensive than net10. A buffer strategy that looks free on
+  net10 can dominate on Framework; always check both TFMs.
+- **Element type does not change zeroing cost** - only byte count does.
+- **Know the crossover size before choosing rent vs zero** (section 3.2): for a
+  runtime-variable size, a zeroed `stackalloc` is cheaper than a rental below
+  roughly **190 bytes on net10 / 1.3 KB on net481** against a warm TLS rental,
+  and below roughly **1.8 KB on net10 / 3 KB on net481** against a contended
+  (locked) rental. Above those sizes a rental's flat floor wins - provided you
+  can use the uninitialized memory without clearing it. A compile-time-constant
+  size zeroes far cheaper on net10, pushing its crossover higher.
+- **A pool rental is not free even when warm.** Prefer suppressing the zeroing on
+  a stack buffer over renting, whenever the size and lifetime allow it.
+- **For variable sizes, reach for `BufferScope<T>` instead of choosing up front.**
+  It stays on the stack for the common case and rents only when overflowed, for
+  a ~1 ns (net481) / ~0.3 ns (net10) wrapper cost, and forwards the calling
+  method's `[SkipLocalsInit]` to the stack buffer.
+- **`[SkipLocalsInit]` hands you uninitialized memory - use it carefully.** Only
+  where a profile shows the clear is hot, every read slot is written first, and
+  no unwritten bytes can escape. Place it on the method that physically holds the
+  `stackalloc`; the JIT inliner will not spread it for you, and net481's weaker
+  inliner can change where the zeroing lands, so verify on both TFMs.
+
+---
+
+## 7. References
+
+- [`SkipLocalsInit` attribute - C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute) - the compiler/CLR `.locals init` mechanism.
+- [`SkipLocalsInitAttribute` class](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute) - the "Applies to: .NET 5-11" type-availability note (polyfilled downlevel by PolySharp).
+- [Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices) - `[SkipLocalsInit]` guidance and the GC-reference caveat.
+- [`stackalloc` expression](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc) - unmanaged-type requirement, undefined initial contents, sizing and loop rules.
+- [CA2014: Do not use `stackalloc` in loops](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops).
+- [`Thread` constructor](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor) - 1 MB default stack, 256 KB partial-trust minimum on .NET Framework.
+- Benchmarks backing the numbers: the `StackZeroInit`, `ArrayPoolSeedRent`, `ArrayPoolCrossover` (the size sweep in section 3.2), and `BufferScopeOverhead` (the `BufferScope` overhead in section 4.2) BenchmarkDotNet classes.
+
+---
+
+## 8. Common mistake: `Unsafe.SkipInit` does not suppress `.locals init`
+
+It is easy to assume that `Unsafe.SkipInit(out T value)` is what turns off the
+zero-initialization of a local - the name reads like "skip the init of this
+value." It does not, and a benchmark of the "uninitialized fixed-buffer scratch"
+pattern was wrong for exactly this reason until `[SkipLocalsInit]` was added.
+
+Two different mechanisms are at play, and only one of them clears memory:
+
+- **`Unsafe.SkipInit<T>(out T value)` is a compile-time trick, not a runtime
+  one.** Its body is a bare `ret` - it emits no code. Its only job is to satisfy
+  the C# compiler's *definite-assignment* analysis so you may read a local
+  without first writing it (or writing `= default`), avoiding the "use of
+  unassigned local variable" error. It never touches memory at run time.
+- **The actual zeroing comes from the method's `.locals init` flag.** The C#
+  compiler stamps that flag on every method that declares locals, and the CLR
+  honors it by zeroing **all** of the method's locals on entry - before any of
+  your code, including the `Unsafe.SkipInit` call, runs. The only way to strip
+  that flag is `[SkipLocalsInit]` on the method (or `[module: SkipLocalsInit]`).
+
+So `Unsafe.SkipInit` lets you legally *read* an unassigned local, but the runtime
+has already zeroed it. Without `[SkipLocalsInit]` on the enclosing method, a
+4 KB fixed buffer "left uninitialized" with `Unsafe.SkipInit` is still fully
+zeroed on entry, and a benchmark of that shape measures the zeroing it claims to
+avoid. The two work together: `[SkipLocalsInit]` removes the runtime clear, and
+`Unsafe.SkipInit` makes the resulting un-zeroed read well-formed at compile time.
+Neither one replaces the other.
+
+The practical rule: to actually skip the zeroing, put `[SkipLocalsInit]` on the
+method that physically contains the `stackalloc` (or fixed-buffer local). Reach
+for `Unsafe.SkipInit` only when you additionally need to read a local the
+compiler would otherwise reject as unassigned - and never treat its presence as
+evidence that the zeroing is gone.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,0 +1,95 @@
+---
+compatibility: Requires the repository's test runner; timing and allocation checks should run on every supported target framework.
+description: Security-focused review of pending changes. Audit any change that could affect safety or correctness under abusive input or unchecked preconditions - oversized values, malformed structures, integer/length overflow, catastrophic backtracking, allocation pressure, other denial-of-service shapes, and any use of `unsafe` code or the `Unsafe` / `MemoryMarshal` / `Marshal` static helpers (which trade compiler safety guarantees for speed and need extra scrutiny). Add regression tests that pin safe behavior even when the current implementation already handles the input correctly. Use when asked to "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling", or before publishing any change that adds or modifies code that parses, decodes, encodes, compiles, marshals, or reinterprets memory.
+license: MIT
+metadata:
+    applicability: universal
+    binding: optional-overlay
+    github-path: skills/security-review
+    github-pinned: v0.10.0
+    github-ref: refs/tags/v0.10.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: b5f145ccbc662182f38554418b5c8b7057c16baa
+    maturity: canary
+    portability: portable
+    related: pre-pr-self-review, performance-testing, fuzz-testing
+    requires: none
+    risk: local-write
+name: security-review
+---
+
+# Security review
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Surface and pin behavior under **malformed input** and **caller-validated
+APIs** (everything the C# compiler doesn't check for you).
+
+## When to run
+
+- The user asks for a security assessment / vulnerability review.
+- A change adds or modifies a member that accepts caller-supplied data
+  (function args, file contents, network bytes, env vars, anything
+  upstream of those).
+- A change introduces or modifies `unsafe` code, calls into
+  `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, `fixed`, raw pointers,
+  unbounded `stackalloc`, or any BCL API whose XML doc says "unsafe"
+  or "caller must". Applies even when inputs are fully internal -
+  preconditions drift across refactors.
+- A CVE in a comparable library prompts "do we have the same shape?".
+
+## The discipline in one paragraph
+
+Write tests that pin the **safe property** (terminates within a bound,
+returns a defined error for malformed input, never reads/writes past the
+buffer) - and make them pass against *current* code as a regression lock.
+Never pin observable wrong output; that locks the bug in. Test the input
+*shape*, not a specific exploit pattern. Boundary tests come in pairs (at
+the limit, just over). When a finding needs a production change, surface
+the options report and **end your turn** before patching. The full
+principles and the High/Medium/Low rubric are in [principles.md](principles.md).
+
+## Review procedure
+
+1. **Inventory.** `git status --short`; tag each new/modified member that
+   takes external input or uses a caller-validated API.
+2. **Walk each tagged member** through the [checklist.md](checklist.md)
+   categories. The largest category - `unsafe` / `Unsafe.*` /
+   `MemoryMarshal.*` and other caller-validated APIs - has its own
+   per-API table in [unsafe-apis.md](unsafe-apis.md).
+3. **Place tests in `<TypeName>.Security.cs`** beside the production type.
+4. **Add safe-property tests now; report findings that need a production
+   change before patching.** See [reporting.md](reporting.md) for the
+   options-report format and the don'ts.
+5. **Run tests on every target framework** - timing bounds and allocation
+   behavior differ across BCL versions.
+
+When attention is limited, allocate it by tier (detail in
+[checklist.md](checklist.md)):
+
+- **Critical (never skip):** length/size bounds, algorithmic complexity,
+  and the caller-validated-API audit.
+- **Standard (every member):** integer overflow, malformed structure,
+  argument validation.
+- **Conditional (when the shape matches):** allocation DoS, in-band
+  sentinels, path traversal.
+
+## Related skills
+
+Run alongside a broader pre-PR self-review before any publish. When you need
+to *measure* a worst-case input rather than just bound it with a `Stopwatch`,
+use the repository's performance-testing skill. (A consuming repository wires
+the concrete cross-references in its overlay.)
+
+## Sub-pages
+
+- [principles.md](principles.md) - the five core principles and the
+  High / Medium / Low severity rubric.
+- [checklist.md](checklist.md) - the nine audit categories with the test
+  shape each one demands.
+- [unsafe-apis.md](unsafe-apis.md) - the per-API precondition / failure /
+  test-shape table for `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, `fixed`,
+  `stackalloc`, and `[DllImport]`.
+- [reporting.md](reporting.md) - the review procedure, the options-report
+  format, and the don'ts that keep tests from pinning bugs.

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -1,0 +1,144 @@
+# Audit checklist
+
+Detail for the [security-review](SKILL.md) skill. Walk every new/modified
+member through the categories below. The question is whether the *input shape*
+or *unchecked precondition* could push the code into the failure mode, not
+whether it currently does.
+
+The largest category - `unsafe` / `Unsafe.*` / `MemoryMarshal.*` and other
+caller-validated APIs (&sect;7) - lives in [unsafe-apis.md](unsafe-apis.md).
+
+When attention is limited, allocate it by tier:
+
+- **Critical (never skip):** &sect;1, &sect;4, [unsafe-apis.md](unsafe-apis.md).
+- **Standard (every member):** &sect;2, &sect;5, &sect;9.
+- **Conditional (when the code shape matches):** &sect;3 (allocates
+  proportional to input), &sect;6 (encoder uses in-band sentinels),
+  &sect;8 (path-handling API).
+
+## 1. Length / size of inputs
+
+- Is there an upper bound? What stops a caller from passing a
+  multi-MB / multi-GB value?
+- Is the bound at the API boundary, not buried in a helper?
+- For composed inputs (list of strings, stream of records), is the
+  **total** size bounded, not just per-element?
+- Is the default safe for untrusted callers, with an opt-out for
+  trusted ones? The standard shape is a `DefaultMaxLength` constant
+  plus a `maxLength` parameter where a sentinel (e.g. `-1`) disables
+  the check.
+
+**Tests:** at-limit success, over-limit failure with documented
+error, opt-out (e.g. `-1`) disables the check.
+
+## 2. Integer / length-field overflow
+
+- Are length sums (`a.Length + b.Length`, `count * elementSize`)
+  protected by `checked()` where crafted input can overflow?
+- Are running lengths cast to a narrower type (`(char)len`,
+  `(byte)count`)? Silent truncation lets oversized fields slip
+  through and be re-read as smaller values, misdecoding downstream
+  data as structural metadata. Check the counter *before* the cast.
+
+**Tests:** boundary inside the representable range plus boundary
+outside. Specialized fast paths often bypass the affected code
+- pick an input shape that **forces the general path**.
+
+## 3. Allocation pressure / memory DoS
+
+- Does work allocate proportional to (or worse than) input size?
+- Is the worst case bounded by an explicit cap (&sect;1) or only by
+  available memory?
+- Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
+  per call (acceptable if bounded), or grow without limit (red flag)?
+
+**Tests:** a "large but legitimate" input completes within a
+`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
+Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
+allocation count.
+
+## 4. Computational complexity / algorithmic DoS
+
+- Worst-case runtime: linear, polynomial, or exponential?
+- ReDoS shape: matcher with multiple wildcards (`*`, `**`, `?(...)`,
+  alternation) that retries every wildcard on mismatch. Safe shape:
+  **fixed savepoint slots** (each new wildcard overwrites the
+  previous slot of the same kind), bounding the worst case to
+  O(n&middot;m).
+- Hashtable attacks: are user-controlled keys hashed with a
+  randomized hash (modern .NET `string.GetHashCode()` and
+  `Dictionary<,>` are per-process randomized), or a deterministic one
+  a caller could pre-image into a single bucket?
+
+**Tests** (pin the safe property):
+
+```csharp
+[Fact]
+public void Method_PathologicalInput_TerminatesPromptly()
+{
+    /* construct adversarial pattern + input */
+
+    Stopwatch sw = Stopwatch.StartNew();
+    bool result = m.IsMatch(input);
+    sw.Stop();
+
+    result.Should().Be(/* expected */);
+    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+}
+```
+
+Add one per "we use the safe algorithm" claim; the property is
+invisible to refactors, the test is the lock.
+
+## 5. Malformed structure / parser robustness
+
+- Truncated input handled gracefully (no `IndexOutOfRangeException`
+  past the end)?
+- Unmatched opens (`[`, `{`, `(`, dangling `\\` / `%`) produce a
+  defined error, not an unrelated runtime exception?
+
+**Tests:** one per malformed shape asserting the exact error type;
+empty, single-character, and "exactly the sentinel" inputs (`""`,
+`"["`, `"\\"`).
+
+## 6. Sentinel / in-band markers colliding with input
+
+- Encoder uses in-band sentinel values (opcode chars, length prefix
+  bytes, control chars)? If user input contains those same values,
+  are they distinguishable from real structure (escaping, length
+  framing, reserved noncharacter code points)?
+
+**Test:** input containing every sentinel value used as ordinary
+data; the member treats them as data.
+
+## 7. `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, and other caller-validated APIs
+
+Mandatory whenever a PR touches one of these. The compiler offloads
+safety to you; the review *is* the safety check. The per-API table
+(precondition, failure mode, required test shape) lives in
+[unsafe-apis.md](unsafe-apis.md).
+
+## 8. Path traversal / sandbox escape
+
+- API takes a root + relative input and returns paths - results
+  stay inside the root? Symlink behavior is the caller's documented
+  choice, not silently re-enabled?
+- Caller-supplied fragments concatenated without normalization?
+  `Path.Combine` honors absolute inner segments, which is a foot-gun.
+
+**Tests:** inputs with `..` segments, absolute paths, alternate
+separators, and symlink-style names; enumerator stays inside the
+configured root.
+
+## 9. Argument validation at the boundary
+
+- `ArgumentNullException.ThrowIfNull` on every reference-type
+  parameter the contract forbids `null` for.
+- `ArgumentOutOfRangeException.ThrowIfNegative` / `ThrowIfGreaterThan`
+  on numeric range checks.
+- Enum parameters: validated against the declared range, or
+  documented to accept any underlying value with explicit defaulting.
+
+**Test:** one per parameter for each forbidden violation mode. Don't
+trust the downstream BCL primitive to throw - the contract is
+yours.

--- a/.agents/skills/security-review/overlay.md
+++ b/.agents/skills/security-review/overlay.md
@@ -1,0 +1,41 @@
+---
+core: security-review
+core-pin: v0.10.0
+---
+
+# madowaku overlay - security-review
+
+Repository-specific companion to the vendored [security-review](SKILL.md) skill.
+The `SKILL.md` and its sibling pages (`checklist.md`, `principles.md`,
+`unsafe-apis.md`, `reporting.md`) are a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift.
+
+> **Pinned to the commons v0.10.0 tag.**
+
+## madowaku bindings
+
+- **The whole library is an unsafe-interop surface.** Nearly every type crosses
+  a native boundary, so the core's `unsafe` / `Unsafe.*` / `MemoryMarshal.*` /
+  `Marshal.*` triggers fire broadly. Pay closest attention to raw pointer
+  lifetime, `BSTR` / `PWSTR` ownership, `SAFEARRAY` bounds, and `VARIANT` union
+  reinterpretation.
+- **COM reference counting is a safety property.** A missing or double
+  `Release` through `ComScope<T>` / `IUnknown` is a correctness *and* a resource
+  bug; review activation and disposal paths.
+- **Cross-target behavior counts.** A pattern that is safe on modern .NET may
+  behave differently on `net472`; confirm both.
+
+## Cross-references
+
+- [`cswin32-com`](../cswin32-com/SKILL.md) and
+  [`cswin32-interop`](../cswin32-interop/SKILL.md) - the interop patterns whose
+  misuse the review is guarding against.
+- [`performance-testing`](../performance-testing/SKILL.md) - for a ReDoS or
+  algorithmic-complexity concern, quantify it with a benchmark.
+
+## Updating
+
+Pull upstream changes with `gh skill update security-review` (review the diff,
+re-pin `core-pin`). Keep madowaku-specific additions here.

--- a/.agents/skills/security-review/principles.md
+++ b/.agents/skills/security-review/principles.md
@@ -1,0 +1,44 @@
+# Core principles and severity
+
+Detail for the [security-review](SKILL.md) skill.
+
+## Core principles
+
+1. **Test safe properties, even when current code is already
+   correct.** A safe property = the method terminates within a stated
+   bound, returns a defined error for malformed input, returns the
+   documented default for empty input, doesn't read/write past the
+   buffer, or doesn't crash. These tests must pass against current
+   code; commit them as the regression lock.
+2. **Never write a test that pins observable wrong output.** A test
+   asserting "this silently truncates" locks the bug in. If current
+   code is wrong, skip the test until the fix lands and pin the
+   *corrected* output then.
+3. **Test the shape, not the specific exploit.** "Input at the
+   declared limit" lasts forever; "exact pattern that triggered CVE-X"
+   decays.
+4. **Boundary tests come in pairs.** One at the limit (succeeds), one
+   just over (fails in a defined way).
+5. **Surface findings before patching production code.** When a
+   finding needs a production change, output the options report,
+   **end your turn, and do not produce the patch or any failing test
+   on that turn**. Resume after the user replies with an approval
+   verb (`go`, `apply A`, `fix it`). Passing safe-property tests
+   (principle 1) may ship on the same turn as the report; failing
+   tests may not.
+
+## Severity rubric
+
+Label every finding before the report.
+
+- **High** - memory corruption, OOB read/write, type confusion,
+  lifetime escape, RCE, disclosure of secrets/addresses, auth bypass.
+  Fix on the same PR.
+- **Medium** - DoS (CPU, memory, stack, FDs), crashing unhandled
+  exception, parser accepting malformed input as valid, ambiguous
+  parsing that smuggles a different shape past validation. Usually
+  fix on the same PR; deferral needs a documented mitigation.
+- **Low** - silent truncation still bounded by a downstream BCL
+  slice check, documented contract violations on edge cases,
+  non-sensitive error-message leakage. Safe to defer; still pin the
+  *corrected* behavior with a regression test once the fix lands.

--- a/.agents/skills/security-review/reporting.md
+++ b/.agents/skills/security-review/reporting.md
@@ -1,0 +1,62 @@
+# Review procedure and reporting
+
+Detail for the [security-review](SKILL.md) skill.
+
+## Review procedure
+
+1. **Inventory.** `git status --short` and read every new/modified
+   file. Tag each member that takes external input or uses a
+   caller-validated API.
+2. **Walk each tagged member through the tiered categories** in
+   [checklist.md](checklist.md). The test you'd write to prove it's
+   fine is the deliverable.
+3. **Place tests in `<TypeName>.Security.cs` partial-class files**
+   beside the production type. Create one if it doesn't exist.
+4. **Add safe-property tests now (principle 1); commit failing /
+   wrong-output tests only with the fix.**
+5. **If a test fails against current code, stop and report.** Don't
+   patch without surfacing first.
+6. **Run tests on every TFM.** Timing bounds and allocation behavior
+   differ across BCL versions.
+
+## Options report format
+
+When the report contains any finding that requires a production-code
+change: output the report and **end your turn**. Don't produce the
+patch, don't produce a failing test, don't run further tool calls
+beyond what's needed to classify the finding. Resume only after the
+user replies with an approval verb (`go`, `apply Option A`, `fix it`,
+or similar). Passing safe-property tests (principle 1) may be added
+on the same turn; they don't change production behavior.
+
+```text
+### Finding #N -- <one-line summary>
+
+<which file(s), which lines, what the failure mode is>
+**Severity:** High / Medium / Low (per rubric)
+
+**Option A -- <approach>**
+- <change shape, ~LoC>
+- Pro: ...
+- Con: ...
+
+**Option B -- ...**
+
+**My recommendation:** <one of the above, with rationale.>
+```
+
+Low-severity findings can be deferred entirely; Medium/High deferrals
+need an explicit reason in the PR body.
+
+## Don'ts
+
+- **Don't patch production code without surfacing the finding first.**
+- **Don't pin observable wrong output in a test.** That locks the bug
+  in. Either ship the corrected-behavior test *alongside* the fix, or
+  skip the test until the fix lands. Safe-property tests (principle 1)
+  are not this case.
+- **Don't claim "safe by construction" without a regression test.**
+  The safe property is invisible to a future refactor.
+- **Don't assume `internal` / `InternalsVisibleTo` members are out of
+  scope.** Tests reach them; refactors promote them. Audit them on
+  the same basis as `public`.

--- a/.agents/skills/security-review/unsafe-apis.md
+++ b/.agents/skills/security-review/unsafe-apis.md
@@ -1,0 +1,30 @@
+# Caller-validated APIs (`unsafe`, `Unsafe.*`, `MemoryMarshal.*`)
+
+Detail for &sect;7 of the [security-review](SKILL.md) audit
+[checklist.md](checklist.md). Mandatory whenever a PR touches one of these.
+The compiler offloads safety to you; the review *is* the safety check.
+
+For each use site answer:
+
+1. What precondition does the API require? (Read the XML doc.)
+2. Where in the calling code is it established? If it's a *different*
+   method, what stops a future refactor from desyncing them?
+3. Is the precondition still satisfied when the input is empty,
+   `null`, zero-length, or `default`? (Empty is the most common
+   blow-up.)
+
+Walk every use site against this table; rows are independent.
+
+| API pattern | Precondition (compiler does NOT check) | Failure mode if violated | Required test shape |
+| ----------- | -------------------------------------- | ------------------------ | ------------------- |
+| `MemoryMarshal.GetReference(span)` / `GetPinnableReference` / `Unsafe.AsPointer(ref span[0])` / `GetArrayDataReference` | Returned `ref` only valid when `span.Length > 0`; empty span yields the managed-null sentinel. | Crash or wild read at null. | `Method_EmptyInput_DoesNotDereferenceNullReference` returns documented default with no exception. |
+| `Unsafe.Add(ref T, int)` | Index `< span.Length` (or backing buffer element count). | OOB read leaks adjacent-page memory; OOB write corrupts heap. | One test at the last in-range index (loop guard's last iteration is the off-by-one site). |
+| `Unsafe.ReadUnaligned<T>` / `WriteUnaligned<T>` | `ref byte` points at `sizeof(T)` valid bytes; alignment is your problem. | OOB read or torn write. | Boundary tests at exactly `sizeof(T)` bytes and one less. |
+| `Unsafe.As<TFrom, TTo>(ref TFrom)` / `Unsafe.As<T>(object)` | `sizeof(TTo) <= sizeof(TFrom)`; GC reference layout matches. | Reads garbage past source; corrupts GC heap if reference layout differs. **Older-JIT pitfall:** on .NET Framework RyuJIT, an `[AggressiveInlining]` method that reinterprets a signed-primitive parameter via `Unsafe.As<T, byte>(ref param)` can propagate the caller's int-promoted negative value into the comparison immediate; mask explicitly. | One test per primitive width including signed/negative values; mask with `& 0xFF` / `& 0xFFFF` if needed. |
+| `Unsafe.SkipInit<T>(out T)` | Caller fully initializes every reachable field before any read. | Stale-pointer foot-gun for ref fields; uninitialized read otherwise. | Test every code path that reads from the skip-init local. |
+| `MemoryMarshal.Cast<TFrom, TTo>` / `AsBytes` | Result length is `source.Length * sizeof(TFrom) / sizeof(TTo)`; partial elements vanish silently. | Caller treats a truncated result as the full payload. | Partial-element case (source length doesn't divide evenly). |
+| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime &le; referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
+| `fixed (T* p = ...)` | `p` valid only inside the `fixed` block. | Dangling pointer after GC relocates. | Manual review: `p` not stashed in a field, passed to `async`/iterator continuations, or returned. |
+| `stackalloc T[n]` | `n` small and bounded. | Stack-overflow DoS if `n` comes from input. | Max-allowed size succeeds; one element more is rejected before `stackalloc` runs. Use a pooled / growable scratch-buffer helper when the input could exceed the stack budget. |
+| `[DllImport]` / `LibraryImport` | Marshaller attrs (`[MarshalAs]`, `SizeConst`, `string` vs `IntPtr`) silently change buffer sizes / ownership. | Buffer overrun, double-free, type confusion across the managed/native boundary. | Cross-check signature against native docs; re-verify on every TFM. |
+| Any BCL API whose XML doc contains "unsafe" or "caller must" | Whatever the doc specifies. | Whatever the doc warns about. | Edge case where the precondition *almost* holds (one byte short, off-by-one alignment). |

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -8,6 +8,11 @@
   "MD032": false,
   "MD033": false,
   "MD041": false,
+  // MD060 (table-column-style) is disabled to match the commons lint profile the
+  // vendored skill cores under .agents/skills/ are authored to; their tables use
+  // a pipe-spacing style MD060's "compact" default rejects, and vendored cores
+  // must not be hand-edited (that would drift from their pinned upstream).
+  "MD060": false,
   "no-trailing-spaces": true,
   "no-hard-tabs": true
 }


### PR DESCRIPTION
## Summary

Reconciles madowaku's `.agents/skills/` against the shared [`JeremyKuhne/agent-skills`](https://github.com/JeremyKuhne/agent-skills) commons and vendors the skills that apply here.

## Reconciled existing skills

- **`cswin32-com`, `cswin32-interop`, `publish-release`** — confirmed born-local (not in the commons); kept as-is. Reworded `cswin32-com`'s description to drop the `<T>` generics, which the skill-metadata spec validator rejects as XML-style tags.
- **`performance-testing`** — replaced the local adaptation with the pinned `v0.10.0` vendored core; the `madowaku.perf` specifics (project, `GlobalUsings`, `VariantConversionPerf`, TFMs, `#if NETFRAMEWORK` note) now live in its `overlay.md`.

## Vendored (14)

Each is a byte-exact, provenance-stamped core plus a thin madowaku overlay.

| Applicability | Skills |
| --- | --- |
| universal | `code-comprehension`, `manage-skills`, `pre-pr-self-review`, `security-review` |
| git-github | `address-pr-feedback`, `create-pr`, `github-actions-cost-optimization` |
| agent-customization | `agent-files-review` |
| dotnet | `engineering-baseline`, `il-copy-inspection` |
| dotnet-framework | `dotnet-polyfills`, `framework-jit-optimization`, `scratch-buffer-strategy` |
| project-gated | `performance-testing` (madowaku.perf exists) |

All pinned to commons **`v0.10.0`**, except **`github-actions-cost-optimization`**, which postdates that tag and is pinned to commit **`85325db`** (flagged in its overlay and the README to re-pin when a release ships).

**Excluded** (project-gated on projects madowaku lacks): `fuzz-testing`, `roslyn-analyzers`.

## Supporting changes

- Rewrote `.agents/skills/README.md` — born-local vs vendored split, a vendoring-model section, and disambiguation for the new overlaps.
- Disabled `MD060` in `.markdownlint.jsonc` so the vendored core tables lint clean without hand-editing the pinned cores.

## Validation

- Byte-accurate core integrity vs the pinned upstream: **0 mismatches**.
- Skill spec validator **17/17**; strict portfolio + overlay contract **14/14**.
- `tools/Validate-AgentFiles.ps1` passes; markdownlint **0 errors** across all 75 agent files; offline link check clean.

Docs-only change — no C# or build impact. `gh skill` was unavailable locally, so cores were vendored offline (byte-identical to `gh skill install --pin v0.10.0`) with hand-stamped provenance for the two skills no sibling had.