### PR TITLE
Update Touki to 0.4.0-alpha.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="KlutzyNinja.Touki" Version="0.3.0-alpha.1" />
+    <PackageVersion Include="KlutzyNinja.Touki" Version="0.4.0-alpha.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.Build" Version="17.14.8" />

--- a/madowaku/Windows/Win32/Foundation/Error.cs
+++ b/madowaku/Windows/Win32/Foundation/Error.cs
@@ -189,7 +189,7 @@ public static unsafe class Error
             FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_ALLOCATE_BUFFER
             | FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_FROM_SYSTEM;
 
-        if (args == null || args.Length == 0)
+        if (args is null || args.Length == 0)
         {
             flags.SetFlags(FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_IGNORE_INSERTS);
         }


### PR DESCRIPTION
## Summary

- Update `KlutzyNinja.Touki` from `0.3.0-alpha.1` to `0.4.0-alpha.1`, the latest prerelease published on NuGet.org.
- Adopt the pattern-matching null check now enforced by Touki analyzer `TOUKI0001` in `Error.FormatMessage`.

A newer `0.4.0-alpha.1.7` build exists only on the local Touki feed, so this change deliberately uses the latest version available to CI and external consumers.

## Validation

- `dotnet build madowaku/madowaku.csproj -c Release` — all production TFMs passed (`net472`, `net10.0`, `net10.0-windows10.0.22000.0`).
- `dotnet test madowaku.slnx -c Debug` — 492 passed, 0 failed.
- `dotnet test madowaku.slnx -c Release` — 492 passed, 0 failed.
- NuGet assets resolve `KlutzyNinja.Touki/0.4.0-alpha.1`.