### PR TITLE
Enable NuGet trusted publishing

### DIFF
--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -20,12 +20,13 @@ MinVer is referenced directly in
 `<MinVerTagPrefix>v</MinVerTagPrefix>`; there is no `Directory.Build.targets`
 and no per-project override (only one package ships).
 
-The publish workflow fires when a `v*.*.*` tag is pushed.
-[publish.yml](../../../.github/workflows/publish.yml) validates the tag against
-a SemVer-with-`v`-prefix regex (and rejects non-tag refs) as its first step, so
-a malformed tag such as `v.0.1.0-alpha.3` fails fast before any pack/push. The
-`v*.*.*` trigger glob is *not* the guard &mdash; it matches the stray dot too;
-the validation step is what stops a typo. See the "Tag-format guard" section in
+The publish workflow fires when a `v*.*.*` tag is pushed. It can also publish an
+existing tag through `workflow_dispatch` after a transient or authentication
+failure. [publish.yml](../../../.github/workflows/publish.yml) validates the tag
+against a SemVer-with-`v`-prefix regex as its first step, so a malformed tag such
+as `v.0.1.0-alpha.3` fails fast before any pack/push. The `v*.*.*` trigger glob
+is *not* the guard &mdash; it matches the stray dot too; the validation step is
+what stops a typo. See the "Tag-format guard" section in
 [versioning.md](versioning.md).
 
 **Approval scope.** "Publish a release" authorizes preparing the tag and

--- a/.agents/skills/publish-release/release-steps.md
+++ b/.agents/skills/publish-release/release-steps.md
@@ -21,9 +21,15 @@ Pushing the tag triggers the publish workflow. Watch the run:
 
 The workflow restores, builds Release, packs, and pushes every `.nupkg` it
 finds in `./artifacts` to nuget.org with
-`dotnet nuget push --skip-duplicate` using the `NUGET_API_KEY` repo secret
-(an API key, not OIDC). Only `KlutzyNinja.Madowaku` packs &mdash; the test and
-perf projects set `<IsPackable>false</IsPackable>`, so they produce no package.
+`dotnet nuget push --skip-duplicate`. The job has `id-token: write`, exchanges
+its GitHub OIDC token through `NuGet/login@v1`, and passes the returned
+short-lived API key to `dotnet nuget push`. The trusted publishing policy on
+nuget.org is bound to owner `JeremyKuhne`, repository `madowaku`, and workflow
+file `publish.yml` (the filename only, not `.github/workflows/publish.yml`), with
+the optional environment left blank. The action's required `user` input is the
+NuGet profile name `JeremyKuhne`, not an email address. Only
+`KlutzyNinja.Madowaku` packs &mdash; the test and perf projects set
+`<IsPackable>false</IsPackable>`, so they produce no package.
 
 > **The tag format is guarded.** [publish.yml](../../../.github/workflows/publish.yml)
 > validates the tag against the SemVer-with-`v`-prefix regex (and rejects
@@ -40,15 +46,13 @@ stream.
 
 ### Re-running the publish for an existing tag (`workflow_dispatch`)
 
-If a transient failure (NuGet outage, network blip) leaves a tag pushed but
-not published, [publish.yml](../../../.github/workflows/publish.yml) also
-accepts a manual `workflow_dispatch`. This workflow takes **no inputs** &mdash;
-instead, in the Actions UI choose **Run workflow** and select the **tag** ref
-(not a branch) from the ref dropdown. The job checks out that exact ref with
-`fetch-depth: 0`, so MinVer derives the intended version from the tag.
-
-Select the **tag**, not `main` or a branch: dispatching against a branch makes
-MinVer compute a `*.<height>` fallback and would publish a wrong version.
+If a transient or authentication failure leaves a tag pushed but not published,
+[publish.yml](../../../.github/workflows/publish.yml) accepts a manual
+`workflow_dispatch`. Run the workflow from `main` and enter the existing release
+tag in the required `tag` input. The job validates that input, checks out the
+annotated tag with full history, and verifies `HEAD` matches the tag before
+building, so MinVer derives the intended version without moving or recreating
+the tag.
 
 ## 2. Create the GitHub release
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,29 +6,50 @@ on:
   push:
     tags: ['v*.*.*']        # fires on v0.1.0, v0.1.0-rc.1, etc.
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish
+        required: true
+        type: string
 
 jobs:
   publish:
     name: ".NET / Publish"
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
     steps:
     - name: Validate tag format
       shell: pwsh
       env:
+        EVENT_NAME: ${{ github.event_name }}
         REF: ${{ github.ref }}
-        TAG: ${{ github.ref_name }}
       run: |
-        if (-not $env:REF.StartsWith('refs/tags/')) {
+        if ($env:EVENT_NAME -eq 'push' -and -not $env:REF.StartsWith('refs/tags/')) {
             throw "Publish must run from a tag ref, got '$($env:REF)'."
         }
         $pattern = '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$'
-        if ($env:TAG -cnotmatch $pattern) {
-            throw "Tag '$($env:TAG)' is not a valid version (expected v<major>.<minor>.<patch>[-prerelease])."
+        if ($env:RELEASE_TAG -cnotmatch $pattern) {
+          throw "Tag '$($env:RELEASE_TAG)' is not a valid version (expected v<major>.<minor>.<patch>[-prerelease])."
         }
-        Write-Host "Tag '$($env:TAG)' is valid."
+        Write-Host "Tag '$($env:RELEASE_TAG)' is valid."
     - uses: actions/checkout@v5
-      with: { fetch-depth: 0 }
+      with:
+        fetch-depth: 0
+        ref: ${{ env.RELEASE_TAG }}
+    - name: Verify checked out release tag
+      shell: pwsh
+      run: |
+        $tagCommit = git rev-list -n 1 $env:RELEASE_TAG
+        $headCommit = git rev-parse HEAD
+        if (-not $tagCommit -or $tagCommit -ne $headCommit) {
+          throw "Tag '$($env:RELEASE_TAG)' points to '$tagCommit', but HEAD is '$headCommit'."
+        }
+        Write-Host "Publishing tag '$($env:RELEASE_TAG)' at '$headCommit'."
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -40,11 +61,16 @@ jobs:
       run: dotnet build -c Release --no-restore
     - name: Pack
       run: dotnet pack -c Release --no-build -o ./artifacts
+    - name: NuGet login
+      id: login
+      uses: NuGet/login@v1
+      with:
+        user: JeremyKuhne
     - name: Publish to NuGet
       run: |
         Get-ChildItem -Path ./artifacts -Filter *.nupkg | ForEach-Object {
             dotnet nuget push $_.FullName `
-                --api-key ${{ secrets.NUGET_API_KEY }} `
+                --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
                 --source https://api.nuget.org/v3/index.json `
                 --skip-duplicate
         }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,30 +19,36 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
     steps:
-    - name: Validate tag format
+    - name: Resolve and validate release tag
+      id: release
       shell: pwsh
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        REF: ${{ github.ref }}
       run: |
-        if ($env:EVENT_NAME -eq 'push' -and -not $env:REF.StartsWith('refs/tags/')) {
-            throw "Publish must run from a tag ref, got '$($env:REF)'."
+        if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+          $event = Get-Content -Raw $env:GITHUB_EVENT_PATH | ConvertFrom-Json
+          $releaseTag = [string]$event.inputs.tag
+        } else {
+          if (-not $env:GITHUB_REF.StartsWith('refs/tags/')) {
+            throw "Publish must run from a tag ref, got '$($env:GITHUB_REF)'."
+          }
+          $releaseTag = $env:GITHUB_REF_NAME
         }
+
         $pattern = '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$'
-        if ($env:RELEASE_TAG -cnotmatch $pattern) {
-          throw "Tag '$($env:RELEASE_TAG)' is not a valid version (expected v<major>.<minor>.<patch>[-prerelease])."
+        if ($releaseTag -cnotmatch $pattern) {
+          throw "Tag '$releaseTag' is not a valid version (expected v<major>.<minor>.<patch>[-prerelease])."
         }
-        Write-Host "Tag '$($env:RELEASE_TAG)' is valid."
+        Write-Host "Tag '$releaseTag' is valid."
+        "tag=$releaseTag" >> $env:GITHUB_OUTPUT
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0
-        ref: ${{ env.RELEASE_TAG }}
+        ref: ${{ steps.release.outputs.tag }}
     - name: Verify checked out release tag
       shell: pwsh
+      env:
+        RELEASE_TAG: ${{ steps.release.outputs.tag }}
       run: |
         $tagCommit = git rev-list -n 1 $env:RELEASE_TAG
         $headCommit = git rev-parse HEAD

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,10 @@ jobs:
       shell: pwsh
       run: |
         if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+          if ($env:GITHUB_REF -ne 'refs/heads/main') {
+            throw "Manual publish must run from 'refs/heads/main', got '$($env:GITHUB_REF)'."
+          }
+
           $event = Get-Content -Raw $env:GITHUB_EVENT_PATH | ConvertFrom-Json
           $releaseTag = [string]$event.inputs.tag
         } else {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,18 @@ jobs:
       env:
         RELEASE_TAG: ${{ steps.release.outputs.tag }}
       run: |
-        $tagCommit = git rev-list -n 1 $env:RELEASE_TAG
+        $verificationRef = "refs/release-tags/$($env:RELEASE_TAG)"
+        git fetch --force --no-tags origin "refs/tags/$($env:RELEASE_TAG):$verificationRef"
+        if ($LASTEXITCODE -ne 0) {
+          throw "Unable to fetch tag '$($env:RELEASE_TAG)' for verification."
+        }
+
+        $tagType = git cat-file -t $verificationRef
+        if ($tagType -ne 'tag') {
+          throw "Release tag '$($env:RELEASE_TAG)' must be annotated, but its object type is '$tagType'."
+        }
+
+        $tagCommit = git rev-list -n 1 $verificationRef
         $headCommit = git rev-parse HEAD
         if (-not $tagCommit -or $tagCommit -ne $headCommit) {
           throw "Tag '$($env:RELEASE_TAG)' points to '$tagCommit', but HEAD is '$headCommit'."


### PR DESCRIPTION
## Summary

- replace the expired long-lived NuGet API key with GitHub OIDC and `NuGet/login@v1`
- grant the publish job only `contents: read` and `id-token: write`
- add a validated `workflow_dispatch` tag input so the existing `v0.4.0-alpha.1` release can be recovered without moving or recreating its tag
- update the release skill to document trusted publishing and the existing-tag recovery flow

## Validation

- `dotnet test -c Release --no-restore` — 515 passed across net481 and net10
- `pwsh tools/Validate-AgentFiles.ps1`
- markdownlint passed for the publish-release skill
- the workflow parses as YAML
- tag-guard cases passed for tag push, manual recovery, malformed input, and invalid branch push
- `git diff --check`

After merge, recover the failed release with:

```powershell
gh workflow run publish.yml --ref main -f tag=v0.4.0-alpha.1
```