### PR TITLE
Improve CsWin32 composition skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -28,8 +28,8 @@ change will upstream them to the commons and re-vendor them here with a pin.
 
 | Skill | Trigger phrasing |
 | ----- | ---------------- |
-| [cswin32-interop](./cswin32-interop/SKILL.md) | "replace `[DllImport]` with CsWin32", the generated `PInvoke.*` / `HANDLE` / `HRESULT` / `BOOL` types, `NativeMethods.txt` / `NativeMethods.json`, blittable signatures, TFM / Windows-interop gating |
-| [cswin32-com](./cswin32-com/SKILL.md) | struct-based COM with `ComScope`, activate via `CoCreateInstance` / a class factory, `delegate* unmanaged` vtables, manual COM structs (WMI / Fusion / CLR hosting), `IComIID` across TFMs, migrating off `[ComImport]`, mocking struct COM |
+| [cswin32-interop](./cswin32-interop/SKILL.md) | "replace `[DllImport]` with CsWin32", generated `PInvoke.*` / Win32 types, "which package owns this helper?", split a public owner from downstream extenders, native allocator ownership, byte/element sizes, `NativeMethods.*`, blittable signatures, TFM gating |
+| [cswin32-com](./cswin32-com/SKILL.md) | struct-based COM with `ComScope`, caller-owned CCW references, `Advise` / `Unadvise`, activation, raw vtables, manual COM structs, `IComIID` across TFMs, cross-assembly CCWs, mocking struct COM |
 
 ### Born-local
 

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: cswin32-com
-description: 'Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across target frameworks, manually defining COM interfaces not in Win32 metadata (WMI, Fusion, CLR hosting/metadata), COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.'
-argument-hint: 'Describe the COM interface or activation pattern you are working with.'
+description: 'Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across target frameworks, connection-point Advise/Unadvise ownership, caller-owned CCW references, manually defining COM interfaces not in Win32 metadata (WMI, Fusion, CLR hosting/metadata), COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.'
 license: MIT
 compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; Windows COM APIs.
 metadata:
@@ -36,7 +35,8 @@ that vtable methods also follow live in the paired **cswin32-interop** skill.
    pointer, and free every COM `BSTR` out-param (`SysFreeString` / `FreeBSTR`,
    or a repo-provided scoped `BSTR` wrapper). Never write the pre-`ComScope`
    `T* p; try { ... } finally { p->Release(); }` shape; it leaks on every early
-   return. See [lifetime.md](lifetime.md).
+    return. A pointer passed to a retaining API remains caller-owned until the
+    caller releases its reference. See [lifetime.md](lifetime.md).
 3. **Activate** via a class-factory helper or `CoCreateInstance` with
    `IID.Get<T>()` - not `&localGuid`. See [Activation](#activation).
 4. **Call** via `scope.Pointer->Method(...)`. Pass `ComScope<T>` directly where
@@ -50,9 +50,9 @@ that vtable methods also follow live in the paired **cswin32-interop** skill.
    [comiid-and-cls.md](comiid-and-cls.md) has the `IComIID` story that governs
    which TFMs `ComScope<T>` works on.
 7. **Compose across packages** at the owner boundary. The owner implements
-  generated partial hooks and publishes shared COM structs; extenders add
-  behavior with extension blocks or uniquely named CCW providers. See
-  [ccw-composition.md](ccw-composition.md).
+    generated partial hooks and publishes shared COM structs; extenders add
+    behavior with extension blocks or uniquely named CCW providers. See
+    [ccw-composition.md](ccw-composition.md).
 
 ## Activation
 

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -35,8 +35,8 @@ that vtable methods also follow live in the paired **cswin32-interop** skill.
    pointer, and free every COM `BSTR` out-param (`SysFreeString` / `FreeBSTR`,
    or a repo-provided scoped `BSTR` wrapper). Never write the pre-`ComScope`
    `T* p; try { ... } finally { p->Release(); }` shape; it leaks on every early
-    return. A pointer passed to a retaining API remains caller-owned until the
-    caller releases its reference. See [lifetime.md](lifetime.md).
+   return. A pointer passed to a retaining API remains caller-owned until the
+   caller releases its reference. See [lifetime.md](lifetime.md).
 3. **Activate** via a class-factory helper or `CoCreateInstance` with
    `IID.Get<T>()` - not `&localGuid`. See [Activation](#activation).
 4. **Call** via `scope.Pointer->Method(...)`. Pass `ComScope<T>` directly where
@@ -50,9 +50,9 @@ that vtable methods also follow live in the paired **cswin32-interop** skill.
    [comiid-and-cls.md](comiid-and-cls.md) has the `IComIID` story that governs
    which TFMs `ComScope<T>` works on.
 7. **Compose across packages** at the owner boundary. The owner implements
-    generated partial hooks and publishes shared COM structs; extenders add
-    behavior with extension blocks or uniquely named CCW providers. See
-    [ccw-composition.md](ccw-composition.md).
+   generated partial hooks and publishes shared COM structs; extenders add
+   behavior with extension blocks or uniquely named CCW providers. See
+   [ccw-composition.md](ccw-composition.md).
 
 ## Activation
 

--- a/.agents/skills/cswin32-com/ccw-composition.md
+++ b/.agents/skills/cswin32-com/ccw-composition.md
@@ -1,9 +1,9 @@
 # Cross-assembly CCW composition
 
-Detail for [cswin32-com](SKILL.md). Read this with the paired interop skill's
-[owner/extender composition](../cswin32-interop/composition.md) page when one
-package owns the generated COM structs and another package adds COM-callable
-wrappers or helper behavior.
+Detail for [cswin32-com](SKILL.md). The paired interop skill owns the general
+owner/extender package model; this page covers the COM-specific boundary when
+one package owns generated COM structs and another adds COM-callable wrappers or
+helper behavior.
 
 ## The owner owns generated partial hooks
 
@@ -112,6 +112,16 @@ by the test bridge in [migration-and-testing.md](migration-and-testing.md). A
 path that calls `Marshal.GetComInterfaceForObject` depends on built-in COM
 interop and is not a NativeAOT path; use `ComWrappers` for the AOT-capable CCW
 implementation.
+
+When a manual lifetime wrapper is generic on its vtable type, use that **exact
+same vtable type** in allocation and every callback that recovers the object or
+updates its reference count. Do not substitute a layout-compatible generated
+vtable type in `GetObject`, `AddRef`, or `Release`; generic type identity is part
+of the wrapper contract even when the current native layouts happen to match.
+
+Every AddRef'd pointer returned by a CCW helper is caller-owned. Scope it when
+passing it to `Advise` or another retaining API, and pair successful connection
+cookies with `Unadvise`; see [lifetime.md](lifetime.md).
 
 ## Validation
 

--- a/.agents/skills/cswin32-com/lifetime.md
+++ b/.agents/skills/cswin32-com/lifetime.md
@@ -30,6 +30,30 @@ scope.Pointer->DoThing(...);
   `IEnumXxx::Next`, a factory method, an app-local `STDAPI Get*` (declare the
   `[DllImport]` with `T** pp`, not `out T*`, so the implicit operator binds).
 
+## Passing pointers to retaining APIs
+
+A helper that creates a CCW or queries an interface normally returns one owned,
+AddRef'd pointer. Passing that pointer to `Advise`, `SetClientSite`, or another
+API that retains it does **not** transfer the caller's reference. The retaining
+API adds its own reference; scope and release the caller's reference after the
+call:
+
+```csharp
+using ComScope<IEventSink> sink = new(GetComPointer<IEventSink>(managedSink));
+source.Pointer->Advise(sink.Pointer, &cookie).ThrowOnFailure();
+```
+
+The same scope is appropriate for a borrowed call such as a verb or callback:
+it keeps the pointer valid through the call and releases it immediately after.
+Do not leave the acquired pointer as an unscoped local merely because the callee
+also keeps a reference.
+
+A successful cookie-producing subscription is a second lifetime edge. Store the
+cookie and call `Unadvise(cookie)` before releasing the source object. Use a
+`try`/`finally` in disposal so failure to disconnect cannot prevent releasing the
+source pointer. If subscription failure is deliberately non-fatal, initialize
+the cookie to zero and skip disconnect when no cookie was issued.
+
 ## Ownership transfer out of a helper
 
 A helper that acquires a pointer can return `ComScope<T>` directly; intermediate

--- a/.agents/skills/cswin32-com/overlay.md
+++ b/.agents/skills/cswin32-com/overlay.md
@@ -62,6 +62,14 @@ cannot provide real CCW vtables. Shared imported COM structs and lifecycle
 helpers likewise stay in madowaku; downstream packages add behavior with
 extension blocks or use uniquely named implementation-only CCW provider types.
 
+The thirtytwo migration exercised this boundary with a local `IDispatchCcw`
+provider while runtime pointers remained madowaku's imported `IDispatch`. It
+also exposed a recurring ownership rule: pointers returned by an extender's CCW
+helper are AddRef'd caller references. Wrap them in madowaku `ComScope<T>` when
+passing them to `Advise`, `SetClientSite`, or borrowed calls such as `DoVerb`.
+For successful subscriptions, store the cookie and call `Unadvise` before
+disposing the source pointer.
+
 ## Manual structs and CLS compliance
 
 - **Manual COM structs** for interfaces not in Win32 metadata (e.g. CLR

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -54,9 +54,9 @@ it - see the paired **cswin32-com** skill, whose vtable methods follow the same
    so every `[DllImport]` and every COM vtable method must be blittable. The
    full rule set is in [blittable-signatures.md](blittable-signatures.md).
 7. **Audit ownership and size units.** Generated wrappers do not decide which
-  allocator frees an output, whether a COM reference remains caller-owned, or
-  whether a length is bytes or elements. Record and test those contracts using
-  [ownership-and-units.md](ownership-and-units.md).
+    allocator frees an output, whether a COM reference remains caller-owned, or
+    whether a length is bytes or elements. Record and test those contracts using
+    [ownership-and-units.md](ownership-and-units.md).
 
 ## The Windows-interop compile gate
 

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: cswin32-interop
-description: 'Guides CsWin32 P/Invoke interop in a multi-targeted .NET library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across owner/extender packages with extensionReceiver, gating Windows-only code across target frameworks, or choosing between CsWin32 and [LibraryImport]. Paired with the cswin32-com skill for the struct-based COM layer.'
-argument-hint: 'Describe the Windows API or interop code you are migrating or adding.'
+description: 'Guides CsWin32 P/Invoke interop in a multi-targeted .NET library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, gating Windows-only code across target frameworks, or choosing between CsWin32 and [LibraryImport]. Paired with the cswin32-com skill for the struct-based COM layer.'
 license: MIT
 compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; projects Windows APIs.
 metadata:
@@ -11,7 +10,7 @@ metadata:
   risk: local-write
   maturity: canary
   requires: none
-  related: cswin32-com, dotnet-polyfills, scratch-buffer-strategy
+  related: cswin32-com, dotnet-polyfills, scratch-buffer-strategy, security-review
 ---
 
 # CsWin32 P/Invoke interop
@@ -54,6 +53,10 @@ it - see the paired **cswin32-com** skill, whose vtable methods follow the same
 6. **Keep signatures blittable.** CsWin32 is configured `allowMarshaling: false`,
    so every `[DllImport]` and every COM vtable method must be blittable. The
    full rule set is in [blittable-signatures.md](blittable-signatures.md).
+7. **Audit ownership and size units.** Generated wrappers do not decide which
+  allocator frees an output, whether a COM reference remains caller-owned, or
+  whether a length is bytes or elements. Record and test those contracts using
+  [ownership-and-units.md](ownership-and-units.md).
 
 ## The Windows-interop compile gate
 
@@ -105,5 +108,11 @@ task.
 - [composition.md](composition.md) - composing one public `PInvoke` across an
   owner package and downstream extender, including constants, XML docs, and
   package verification.
+- [library-layering.md](library-layering.md) - placing generic utilities,
+  shared Win32 support, domain extensions, and applications in a directed
+  package stack, with migration and release ordering.
+- [ownership-and-units.md](ownership-and-units.md) - matching native allocators
+  and deallocators, caller-owned COM references, failure cleanup, and
+  byte-versus-element conversions.
 - [gating.md](gating.md) - multi-TFM / multi-platform guards, `CA1416`, a
   stack-first scratch buffer, and verifying the guarded build.

--- a/.agents/skills/cswin32-interop/composition.md
+++ b/.agents/skills/cswin32-interop/composition.md
@@ -4,6 +4,8 @@ Detail for [cswin32-interop](SKILL.md). Use this model when one package owns the
 public CsWin32 projection and another package adds APIs to that same callable
 surface. This is different from sharing one internal projection with friend
 assemblies: each layer runs CsWin32, but only one layer owns the receiver type.
+For the broader managed-foundation / Win32-owner / domain-extender package
+stack and release order, see [library-layering.md](library-layering.md).
 
 ## Choose the ownership boundary first
 
@@ -66,6 +68,10 @@ into the extender assembly.
   friendly generated overload can become ambiguous with a downstream helper;
   call the raw pointer overload explicitly or rename the helper rather than
   introducing another facade.
+- Re-audit native ownership whenever a helper or call shape moves between
+  layers. Generated overloads do not preserve allocator, COM reference, or
+  byte/element obligations by themselves; use
+  [ownership-and-units.md](ownership-and-units.md).
 
 ## Generated XML documentation diagnostics
 
@@ -90,4 +96,6 @@ compiles at least:
 Restore into a clean package cache when reusing a local version number. This
 catches missing transitive dependencies, stale packages, duplicate generated
 types, inaccessible receivers, and composition that worked only through project
-references.
+references. Inspect the packed dependency graph too: an extender that directly
+uses a foundation library should declare it directly, even when the owner also
+depends on it.

--- a/.agents/skills/cswin32-interop/library-layering.md
+++ b/.agents/skills/cswin32-interop/library-layering.md
@@ -1,0 +1,91 @@
+# Support-library layering
+
+Detail for [cswin32-interop](SKILL.md). A public CsWin32 composition surface works
+best as one layer in a directed package stack, not as the place where every
+shared helper accumulates.
+
+## The four layers
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Managed foundation | Cross-domain buffers, pooling, collections, enum helpers, compiler/runtime polyfills, and other utilities that remain useful without a public Win32 API. | The canonical public `Windows.Win32.PInvoke` or public Win32 type identity. |
+| Win32 composition owner | The public `PInvoke`, shared generated Win32 types, Windows-specific lifetime/ownership helpers, common COM wrappers, and owner-only generated hooks. | Product- or domain-specific UI and workflow behavior. |
+| Domain extender | Additional generated APIs projected through `extensionReceiver`, domain wrappers, and extension members on owner-provided types. | Duplicate owner types, cross-assembly partial declarations, or a competing public `PInvoke`. |
+| Consumer | Application behavior that calls the composed surface. | Another generated projection unless it is intentionally a separate namespace/ABI domain. |
+
+The conceptual layer order is foundation -> owner -> extender -> consumer;
+package references point back down that stack. An extender may also reference
+the foundation directly when its source uses that surface. Declare that
+dependency explicitly rather than relying on the owner's transitive dependency.
+
+A foundation package may use platform interop internally. The boundary is its
+**public ownership contract**: an internal generated `PInvoke` does not compete
+with the composition owner, while a public `Windows.Win32.PInvoke` does.
+
+## Decide where a helper belongs
+
+Move a helper toward the lowest reusable layer that can own it without importing
+higher-level policy:
+
+- A pooled scratch buffer, allocation-free flag operation, or downlevel BCL
+  polyfill belongs in the managed foundation.
+- A `HANDLE` close helper, `HRESULT` mapping, `PWSTR` ownership operation,
+  `ComScope<T>`, `SAFEARRAY`/`VARIANT` support, or owner-side CCW hook belongs in
+  the Win32 owner when multiple extenders can use it.
+- A windowing framework, accessibility model, dialog abstraction, or
+  domain-specific COM adapter belongs in the extender.
+- An implementation-only vtable provider needed by one extender stays there
+  under a unique name; it does not justify a duplicate imported interface.
+
+Before promoting code, remove dependencies on the higher layer and ask whether
+its public namespace and exception/ownership contract make sense for every
+consumer of the lower layer. "Used by two projects" is not enough if both uses
+carry the same product policy.
+
+## API identity and compatibility
+
+Moving a public type from an extender assembly into the owner is not merely a
+source relocation. Even with the same namespace and type name, its assembly
+identity changes. Treat the move as a binary and often source breaking change
+unless the old assembly provides type forwarding and compatible facade members.
+Also call out removed static facades, renamed nested types, and changed extension
+lookup in release notes.
+
+Do not leave both definitions public during migration. Two assemblies exporting
+the same fully qualified type create ambiguity instead of compatibility.
+
+## Release order and package metadata
+
+Publish from the bottom up:
+
+1. publish the managed foundation when its required surface changed;
+2. publish the Win32 owner against that foundation;
+3. restore the owner from the real feed into the extender, then publish the
+   extender;
+4. validate an application that references only the top-level package.
+
+Keep the owner and extender on compatible CsWin32 versions and language levels.
+If the owner is prerelease, the extender package must also be prerelease; NuGet
+warns when a stable package depends on a prerelease package. Inspect the packed
+extender nuspec to confirm the owner and foundation dependency versions before
+publishing.
+
+## Migration sequence
+
+For an existing library that duplicates owner candidates:
+
+1. inventory generated types, hand-authored partials, helpers, and static
+   facades; classify each into the four layers;
+2. add the shared public surface and generated hooks to the owner, with direct
+   tests, and publish it first;
+3. restore that published owner into an empty package root using normal feeds;
+4. configure `extensionReceiver`, remove duplicate types, and convert downstream
+   augmentation to extension blocks or uniquely named provider types;
+5. audit every raw pointer and native buffer while changing call shapes; moving
+   ownership does not preserve caller obligations automatically;
+6. pack the extender and build a clean-cache consumer that references only the
+   extender package.
+
+For the final restore, use `--no-cache` and a fresh `--packages` directory. Check
+`project.assets.json`, the package's `.nupkg.metadata` source, and the nuspec so a
+locally cached rehearsal package cannot masquerade as the published dependency.

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -53,6 +53,34 @@ existing madowaku `PInvoke` surface. If absent, add the API / constant / enum to
 `NativeMethods.txt` and verify its generated shape under
 `artifacts/obj/madowaku/.../generated/Microsoft.Windows.CsWin32/...`.
 
+## Concrete support-library stack
+
+The portable core's [library layering](library-layering.md) maps to this fleet
+as follows:
+
+- **Touki is the managed foundation.** It owns cross-domain helpers such as
+  `BufferScope<T>`, allocation-free enum operations, and downlevel runtime
+  polyfills. Touki may use an internal CsWin32 projection for implementation,
+  but it does not publish the fleet's canonical Win32 type identity.
+- **madowaku is the Win32 composition owner.** It publishes `PInvoke`, generated
+  Win32 types, common ownership helpers, `ComScope<T>`, `AgileComPointer<T>`,
+  and shared `SAFEARRAY` / `VARIANT` behavior. Windows-specific helpers that are
+  useful across domain libraries belong here.
+- **Domain libraries are extenders.** They reference madowaku, generate their
+  additional APIs with `extensionReceiver`, and keep UI frameworks, adapters,
+  and product policy local. An extender that directly uses Touki buffers or
+  enum helpers references Touki directly instead of relying on transitivity.
+
+Choose Touki when the API remains useful without a public `Windows.Win32`
+surface. Choose madowaku when the helper owns a shared Win32 projection,
+allocator/lifetime contract, or COM abstraction. Keep behavior in the extender
+when it encodes one domain's windowing, accessibility, dialog, or control model.
+
+Release bottom-up: Touki first when its public surface changes, then madowaku,
+then the extender. Restore each published prerelease from nuget.org into an
+empty package root before moving to the next layer; a local package cache does
+not prove the dependency can be consumed externally.
+
 ## Generation mode: keep the source generator
 
 CsWin32 0.3.298 supports `<CsWin32RunAsBuildTask>true</CsWin32RunAsBuildTask>`,
@@ -100,7 +128,10 @@ the [cswin32-com](../cswin32-com/overlay.md) overlay.
   all TFMs before pushing - net472 RyuJIT and Release-mode inlining surface bugs
   Debug does not. For a downstream extender change, also pack both layers and
   compile a clean-cache consumer that references only the extender package and
-  calls one madowaku-owned and one extender-owned `PInvoke` member.
+  calls one madowaku-owned and one extender-owned `PInvoke` member. The
+  [thirtytwo owner/extender migration](https://github.com/JeremyKuhne/thirtytwo/pull/20)
+  validated this flow with madowaku `0.4.0-alpha.1`, including nuspec inspection
+  and a consumer that had no local madowaku source.
 
 ## Cross-references
 

--- a/.agents/skills/cswin32-interop/ownership-and-units.md
+++ b/.agents/skills/cswin32-interop/ownership-and-units.md
@@ -1,0 +1,116 @@
+# Native ownership and size units
+
+Detail for [cswin32-interop](SKILL.md). Generated signatures make calls easier to
+write; they do not infer who owns an output or whether a length is bytes,
+characters, or elements. Read the native contract before choosing a wrapper.
+
+## Record the ownership contract before calling
+
+For every pointer or handle output, identify all four facts:
+
+1. who allocates or increments the reference;
+2. whether the result is owned or borrowed;
+3. which operation releases it;
+4. whether failure guarantees the output is initialized.
+
+Common pairs include:
+
+| Acquired value | Release operation |
+| --- | --- |
+| AddRef'd COM interface | `IUnknown::Release` (normally through `ComScope<T>`) |
+| COM task allocator memory, including many Shell PIDLs | `CoTaskMemFree` |
+| `LocalAlloc` memory | `LocalFree` |
+| `BSTR` | `SysFreeString` / `Marshal.FreeBSTR` |
+| Owned Win32 handle | The API-specific close function, such as `CloseHandle` |
+| Borrowed pointer/handle | No release; keep the owner alive for the whole use |
+
+Do not infer the deallocator from the projected pointer type. Two `PWSTR` values
+can have different allocators depending on the API that returned them.
+
+## Cleanup must cover failure paths
+
+A native API may leave an output untouched when it fails. If cleanup runs in a
+`finally`, initialize the actual native output storage to null and prefer the raw
+pointer overload so that initialization cannot be hidden by a convenience
+wrapper:
+
+```csharp
+ITEMIDLIST* itemIdList = null;
+HRESULT result;
+fixed (char* pathPointer = path)
+{
+    result = PInvoke.SHParseDisplayName(
+        pathPointer,
+        null,
+        &itemIdList,
+        0,
+        null);
+}
+
+try
+{
+    result.ThrowOnFailure();
+    // Consume itemIdList.
+}
+finally
+{
+    PInvoke.CoTaskMemFree(itemIdList);
+}
+```
+
+Freeing null is safe for the matching Windows allocators. Inspect generated
+convenience-overload source before relying on its failure initialization or
+ownership behavior.
+
+## A retained COM pointer is still caller-owned
+
+A helper that returns an AddRef'd COM pointer gives the caller one reference.
+Passing it to a method such as `Advise`, `SetClientSite`, or another retaining
+API does not transfer that caller reference. The callee adds its own reference
+when its contract retains the pointer; the caller still releases its reference:
+
+```csharp
+using ComScope<IEventSink> sink = new(GetComPointer<IEventSink>(managedSink));
+source->Advise(sink.Pointer, &cookie).ThrowOnFailure();
+```
+
+Pair every successful cookie-producing `Advise` with `Unadvise(cookie)` before
+releasing the source object. Scope borrowed-call pointers too: even when the
+callee retains nothing, the scope keeps the pointer valid for the call and
+releases the caller reference afterward.
+
+## Length parameters: bytes are not elements
+
+Read each length parameter's native documentation. A managed buffer abstraction
+usually reports **elements**, while many NT and Win32 APIs accept and return
+**bytes**. Convert explicitly with checked arithmetic:
+
+```csharp
+uint capacityInBytes = checked((uint)buffer.Length * sizeof(char));
+
+// Native call writes requiredBytes.
+int requiredElements = checked(
+    (int)(((ulong)requiredBytes + sizeof(char) - 1) / sizeof(char)));
+buffer.EnsureCapacity(requiredElements);
+```
+
+Use ceiling division for a required **capacity** because an odd byte count still
+needs another element. For a payload length that must contain whole elements,
+validate divisibility when malformed native data is possible, then divide
+exactly. Also distinguish whether a returned byte count includes a header,
+terminator, or only payload; size the whole native buffer but slice only the
+payload field.
+
+## Review and test shapes
+
+When adding or migrating an interop call, cover the branches that expose the
+contract:
+
+- success and native failure, including cleanup after each;
+- null/default output and double-dispose or repeated cleanup when supported;
+- a result large enough to force buffer growth;
+- a malformed or odd-sized payload when the input is not trusted;
+- a retaining COM call followed by explicit disconnect and owner disposal.
+
+A happy-path build cannot detect a leaked reference, the wrong allocator, or a
+byte/element mismatch that only appears beyond the initial buffer.

--- a/.agents/skills/dotnet-polyfills/overlay.md
+++ b/.agents/skills/dotnet-polyfills/overlay.md
@@ -31,6 +31,20 @@ portable core** from
   centralized in
   [Directory.Packages.props](../../../Directory.Packages.props).
 
+## Touki's place in the composition stack
+
+Touki is the fleet's broad managed foundation, below madowaku's Win32
+composition layer. Put a helper in Touki when it is a general buffer,
+collection, enum, text, compiler-support, or downlevel-runtime facility whose
+public contract does not require the canonical `Windows.Win32` surface. Put it
+in madowaku when it owns a shared Win32 type, native allocator/deallocator pair,
+COM lifetime abstraction, or generated `PInvoke` behavior.
+
+Madowaku references Touki directly. A downstream library also references Touki
+directly when its own source uses Touki APIs, even though madowaku depends on it
+transitively. This keeps package metadata honest and allows each layer to evolve
+without accidentally turning madowaku into a facade for generic utilities.
+
 ## Cross-references
 
 - [`cswin32-interop`](../cswin32-interop/SKILL.md) - the CsWin32 interop rules and


### PR DESCRIPTION
## Summary

### Portable CsWin32 cores

- add a four-layer support-library model: managed foundation, Win32 composition owner, domain extender, and consumer
- document helper placement, direct package dependencies, bottom-up prerelease publishing, clean-cache restore provenance, and public type assembly-identity changes
- add native allocator/deallocator, failure cleanup, caller-owned COM reference, and byte-versus-element guidance
- document retaining COM APIs, `Advise`/`Unadvise`, and exact generic vtable identity for manual CCW lifetime wrappers
- remove the COM core's artifact-escaping cross-skill link so each core installs in isolation
- align frontmatter with the commons' pinned `skills-ref@0.1.5` validator

### Madowaku bindings

- map Touki to the broad managed-foundation layer and madowaku to the shared Win32/COM owner layer
- clarify when downstream extenders reference Touki directly and how the layers are released in dependency order
- record the validated thirtytwo owner/extender migration, package-consumer proof, CCW provider pattern, and reference-counting lessons
- update the local skill catalog trigger guidance

## Validation

- strict `Validate-Skills.ps1 -RequirePortfolioMetadata` passed for both cores
- `skills-ref@0.1.5 validate` passed for both cores
- markdownlint passed across all changed skill documentation
- repository agent-file validator passed
- isolated-install link checks passed without overlays or sibling skills
- portable-core scan found no madowaku, Touki, thirtytwo, repository paths, or HTML entities
- `git diff --check`

## Follow-up

The portable cores are ready to propose to `JeremyKuhne/agent-skills`, but this PR does not modify that repository because its current working tree already contains unrelated local changes. The commons also has a small documentation/tool mismatch: `FORMAT.md` lists `argument-hint` as optional while the pinned `skills-ref@0.1.5` validator rejects it.