### PR TITLE
Prepare CsWin32 skills for promotion

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -28,8 +28,11 @@ change will upstream them to the commons and re-vendor them here with a pin.
 
 | Skill | Trigger phrasing |
 | ----- | ---------------- |
-| [cswin32-interop](./cswin32-interop/SKILL.md) | "replace `[DllImport]` with CsWin32", generated `PInvoke.*` / Win32 types, "which package owns this helper?", split a public owner from downstream extenders, native allocator ownership, byte/element sizes, `NativeMethods.*`, blittable signatures, TFM gating |
-| [cswin32-com](./cswin32-com/SKILL.md) | struct-based COM with `ComScope`, caller-owned CCW references, `Advise` / `Unadvise`, activation, raw vtables, manual COM structs, `IComIID` across TFMs, cross-assembly CCWs, mocking struct COM |
+| [cswin32-interop](./cswin32-interop/SKILL.md) | "replace `[DllImport]` with CsWin32", generated `PInvoke.*` / Win32 types, "which package owns this helper?", split a public owner from downstream extenders, native allocator ownership, byte/element sizes, `NativeMethods.*`, blittable signatures, compile-time / runtime / analyzer guards |
+| [cswin32-com](./cswin32-com/SKILL.md) | struct-based COM with `ComScope`, caller-owned CCW references, `Advise` / `Unadvise`, activation, raw vtables, manual COM structs, `IComIID` across .NET 10 and .NET Framework, cross-assembly CCWs, mocking struct COM |
+
+`cswin32-com` declares `cswin32-interop` as a hard dependency; promote and
+install the pair together even though invocation remains surface-specific.
 
 ### Born-local
 
@@ -90,10 +93,10 @@ resulting files.
 Both touch CsWin32. They are mutually exclusive by **surface**:
 
 - **P/Invoke functions, Win32 structs/enums/constants, `HANDLE`/`HMODULE`/
-  `HRESULT`/`BOOL`, TFM gating, the `ComWrappers` polyfill, the
+  `HRESULT`/`BOOL`, platform and TFM guards, the `ComWrappers` polyfill, the
   public `PInvoke` owner/extender surface** &rarr; `cswin32-interop`.
-- **COM interfaces &mdash; `ComScope<T>`, `IComIID` (emitted across all
-  TFMs), `IID.Get<T>()`, manual struct-based interfaces (CLR hosting,
+- **COM interfaces &mdash; `ComScope<T>`, `IComIID` (emitted on .NET 10 and
+  .NET Framework), `IID.Get<T>()`, manual struct-based interfaces (CLR hosting,
   metadata, etc.), `delegate* unmanaged` vtables, `CoCreateInstance` /
   `CoGetClassObject`** &rarr; `cswin32-com`.
 

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: cswin32-com
-description: 'Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across target frameworks, connection-point Advise/Unadvise ownership, caller-owned CCW references, manually defining COM interfaces not in Win32 metadata (WMI, Fusion, CLR hosting/metadata), COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.'
+description: 'Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across .NET 10 and .NET Framework, connection-point Advise/Unadvise ownership, caller-owned CCW references, manually defining COM interfaces not in Win32 metadata (WMI, Fusion, CLR hosting/metadata), COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.'
 license: MIT
-compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; Windows COM APIs.
+compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; Windows COM APIs across .NET 10 and .NET Framework. Cross-assembly extension-block examples require C# 14.
 metadata:
   portability: portable
   applicability: dotnet
   binding: optional-overlay
   risk: local-write
   maturity: canary
-  requires: none
-  related: cswin32-interop, security-review, il-copy-inspection
+  requires: cswin32-interop
+  related: security-review, il-copy-inspection
 ---
 
 # CsWin32 struct-based COM interop
@@ -25,30 +25,50 @@ CCW bridge; runtime calls still use the generated struct. This skill covers the
 COM-specific layer; the general P/Invoke layer and the blittable-signature rules
 that vtable methods also follow live in the paired **cswin32-interop** skill.
 
+## Helper conventions
+
+Examples use `ComScope<T>` for a disposable scope that owns one AddRef'd COM
+reference and `IID.Get<T>()` for a support helper that returns a `Guid*` to
+`T`'s `IComIID.Guid`. CsWin32 generates `IComIID`, but these two helpers come
+from a support library. The overlay names their concrete implementations. If a
+repository does not provide them, use an equivalent owned-pointer scope and a
+stable IID pointer; keep the same ownership and ABI contracts.
+
+`AcquireOwnedCcwPointer<T>()` in examples is pseudocode for a repository helper
+that returns one AddRef'd, caller-owned interface pointer for a managed object.
+Its implementation determines compatibility: classic
+`Marshal.GetComInterfaceForObject` uses built-in COM interop and is not a
+NativeAOT path, while a `ComWrappers` implementation can be AOT-compatible.
+
 ## Workflow
 
 1. **In Win32 metadata?** If yes, add the interface name to `NativeMethods.txt`
    and CsWin32 generates it. If not (WMI, Fusion, Setup Configuration, CLR
    hosting / metadata), define a manual struct in its own file - see
    [manual-structs.md](manual-structs.md).
-2. **Lifetime:** `using ComScope<T> scope = new();` for every transient COM
-   pointer, and free every COM `BSTR` out-param (`SysFreeString` / `FreeBSTR`,
-   or a repo-provided scoped `BSTR` wrapper). Never write the pre-`ComScope`
-   `T* p; try { ... } finally { p->Release(); }` shape; it leaks on every early
-   return. A pointer passed to a retaining API remains caller-owned until the
-   caller releases its reference. See [lifetime.md](lifetime.md).
+2. **Lifetime:** `using ComScope<T> scope = new();` for every transient **owned**
+   COM reference, and free every owned COM `BSTR` out-param (`SysFreeString` /
+   `FreeBSTR`, or a repo-provided scoped `BSTR` wrapper). A correct
+   `try` / `finally` also releases on early return, but an owned-pointer scope
+   centralizes initialization, release, and ownership transfer. Never release a
+   borrowed pointer unless the caller first acquires a reference. See
+   [lifetime.md](lifetime.md).
 3. **Activate** via a class-factory helper or `CoCreateInstance` with
-   `IID.Get<T>()` - not `&localGuid`. See [Activation](#activation).
+   the exact interface IID; prefer `IID.Get<T>()` when the support helper is
+   available. See [Activation](#activation).
 4. **Call** via `scope.Pointer->Method(...)`. Pass `ComScope<T>` directly where
-   the API expects `T**` / `void**`; the implicit operator takes the address.
+   the API expects `T**` / `void**` when the concrete scope provides those
+   conversions.
 5. **Match the caller's error contract.** If the top-level consumer treats COM
-   failure as "absent", helpers return `default` / `false` rather than throwing a
-   `COMException` that is immediately swallowed; otherwise call
-   `.ThrowOnFailure()`. See the parity table in
+  failure as a documented "absent" result, helpers may return `default` /
+  `false`; otherwise call `.ThrowOnFailure()`. Do not change a shared helper's
+  contract merely because one caller catches `COMException`. See the parity
+  table in
    [migration-and-testing.md](migration-and-testing.md).
-6. **Gate** by target framework only where a member needs a newer feature -
-   [comiid-and-cls.md](comiid-and-cls.md) has the `IComIID` story that governs
-   which TFMs `ComScope<T>` works on.
+6. **Gate .NET 10-only COM features with `#if NET`.** `ComWrappers`-based CCW
+  support is unavailable on .NET Framework. Generated `IComIID` works on both
+  supported runtime families with CsWin32 0.3.287 or later; see
+  [comiid-and-cls.md](comiid-and-cls.md).
 7. **Compose across packages** at the owner boundary. The owner implements
    generated partial hooks and publishes shared COM structs; extenders add
    behavior with extension blocks or uniquely named CCW providers. See
@@ -57,7 +77,7 @@ that vtable methods also follow live in the paired **cswin32-interop** skill.
 ## Activation
 
 ```csharp
-// Via CoCreateInstance - IID.Get<T>(), never &localGuid.
+// Via CoCreateInstance and the repository's IID support helper.
 Guid clsid = SomeCoClass.CLSID;
 using ComScope<ISomething> instance = new();
 PInvoke.CoCreateInstance(
@@ -66,24 +86,27 @@ PInvoke.CoCreateInstance(
 instance.Pointer->DoThing(...);
 ```
 
-- Use `IID.Get<T>()` for the IID - it reads the type's `IComIID.Guid`. Do not
-  take `&localGuid`.
+- Prefer `IID.Get<T>()` when available; it returns a `Guid*` to the type's
+  `IComIID.Guid` without a per-call copy. Otherwise pass a pointer to a stable
+  `Guid` containing the exact IID. A local `Guid` is valid for the duration of
+  the native call; the problem is an incorrect or ad hoc IID, not local storage.
 - Initialize `ComScope<T>` with `new()`; it implicitly converts to the `T**` /
-  `void**` output parameter.
+  `void**` output parameter when the concrete support type supplies those
+  conversions.
 - A repo may also ship a class-factory helper (activate via `CoGetClassObject`
   then `CreateInstance`), the AOT-friendly path when a CLSID is registered - see
   the overlay.
 
 ## Sibling pages
 
-- [lifetime.md](lifetime.md) - `ComScope<T>`, `BSTR`, the field-lifetime pointer
-  holder, ownership transfer out of a helper, and the forbidden raw `T*` field.
+- [lifetime.md](lifetime.md) - `ComScope<T>`, `BSTR`, owned and borrowed
+  references, field-lifetime strategies, and ownership transfer out of a helper.
 - [manual-structs.md](manual-structs.md) - defining an interface not in Win32
   metadata: `delegate* unmanaged[Stdcall]` vtables, exact slot indices, the
   dual-target `IComIID` member, and strongly-typed handle/token wrappers.
-- [comiid-and-cls.md](comiid-and-cls.md) - `IComIID` across target frameworks
-  (modern auto-emit versus the down-level per-struct polyfill) and CLS
-  compliance.
+- [comiid-and-cls.md](comiid-and-cls.md) - `IComIID` across .NET 10 and
+  .NET Framework (both-family auto-emit versus the older Framework per-struct
+  polyfill) and CLS compliance.
 - [migration-and-testing.md](migration-and-testing.md) - the error-handling
   parity table when migrating off `[ComImport]`, and mocking struct-based COM in
   tests via a CCW bridge.

--- a/.agents/skills/cswin32-com/ccw-composition.md
+++ b/.agents/skills/cswin32-com/ccw-composition.md
@@ -15,8 +15,8 @@ assembly and compilation** as its declaration; an extender package cannot
 implement the owner's hook.
 
 If an owner publishes CCW-capable generated types, implement the hook in the
-owner. On modern .NET, a `ComWrappers` provider can copy the runtime's canonical
-`IUnknown` entry points into the generated vtable:
+owner. On the .NET 10 leg, a `ComWrappers` provider can copy the runtime's
+canonical `IUnknown` entry points into the generated vtable:
 
 ```csharp
 using System.Collections;
@@ -61,10 +61,11 @@ public static unsafe partial class ComHelpers
 }
 ```
 
-Gate this implementation on TFMs that provide real `ComWrappers`. Without the
-hook, generated vtable creation throws `NotImplementedException` when it sees an
-uninitialized `QueryInterface` slot; moving the same partial declaration into an
-extender does not fix it.
+Gate this implementation with `#if NET`; .NET Framework does not provide the
+real `ComWrappers` support needed to populate the vtable. Without the hook,
+generated vtable creation throws `NotImplementedException` when it sees an
+uninitialized `QueryInterface` slot; moving the same partial declaration into
+an extender does not fix it.
 
 ## Extend owner types; do not redeclare them
 
@@ -132,8 +133,8 @@ Test more than compilation:
 2. obtain a CCW pointer for a managed implementation and query the expected
    interface;
 3. call through the owner-generated pointer struct and verify HRESULT behavior;
-4. build every TFM so `ComWrappers`-dependent code is absent or explicitly
-   unsupported on down-level targets;
+4. build all .NET 10 and .NET Framework TFMs so `ComWrappers`-dependent code is
+    absent or explicitly unsupported on .NET Framework;
 5. pack the owner and extender and compile a consumer that references only the
    extender package.
 

--- a/.agents/skills/cswin32-com/comiid-and-cls.md
+++ b/.agents/skills/cswin32-com/comiid-and-cls.md
@@ -1,28 +1,32 @@
 # IComIID across target frameworks, and CLS compliance
 
 Detail for [cswin32-com](SKILL.md). `IComIID` is the interface CsWin32 uses to
-recover a COM type's IID generically - `IID.Get<T>()` reads a type's
-`IComIID.Guid`. Its shape differs by target framework, and how much you author by
-hand depends on the CsWin32 version.
+recover a COM type's IID generically. A support helper such as `IID.Get<T>()`
+can expose a `Guid*` to the type's `IComIID.Guid`. Its shape differs by target
+framework, and how much you author by hand depends on the CsWin32 version.
 
-## Modern CsWin32 (0.3.287 and later)
+## CsWin32 0.3.287 and later
 
 The generator emits `IComIID` and attaches it to **every** generated COM struct
-on **all** target frameworks - a static-abstract `static ref readonly Guid Guid`
-on .NET 7+, an instance `ref readonly Guid Guid` on the old framework leg or
-`netstandard2.0`. Nothing to hand-author: adding a generated COM type to
-`NativeMethods.txt` carries `IComIID` through `ComScope<T>` automatically on every
-TFM. `IID.Get<T>()` reads it via `T.Guid` on modern .NET and `default(T).Guid` on
-the old leg.
+on both supported runtime families - a static-abstract
+`static ref readonly Guid Guid` on the .NET 10 leg, and an instance
+`ref readonly Guid Guid` on .NET Framework. Nothing to hand-author: adding a
+generated COM type to `NativeMethods.txt` carries `IComIID` through an
+`IComIID`-constrained scope automatically on both legs. A support helper reads
+it via `T.Guid` on .NET 10 and `default(T).Guid` on .NET Framework.
 
 Only **manual** structs implement `IComIID` by hand, matching the per-TFM shape
 (see [manual-structs.md](manual-structs.md)).
 
-## Down-level CsWin32 (before 0.3.287) or netstandard
+This both-family generation was added by
+[microsoft/CsWin32#1705](https://github.com/microsoft/CsWin32/pull/1705).
 
-Older generators emit the static-abstract `IComIID` and attach it to generated
-structs **only on .NET 7+**. On the old framework leg you supply the missing
-pieces by hand, both gated `#if !NET` so they vanish on modern .NET:
+## Older CsWin32 (before 0.3.287)
+
+Within this skill's .NET 10 / .NET Framework target pair, older generators emit
+the static-abstract `IComIID` and attach it to generated structs only on the
+.NET 10 leg. On .NET Framework you supply the missing pieces by hand, included
+only for that target with a Framework-only source folder or `#if NETFRAMEWORK`:
 
 - The `IComIID` interface itself (an instance-based `ref readonly Guid Guid`).
 - One `partial struct` per generated COM type used through `ComScope<T>`, adding
@@ -36,28 +40,40 @@ internal partial struct IRunningObjectTable : IComIID
     readonly ref readonly Guid IComIID.Guid
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => ref Unsafe.AsRef(in IID_Guid);   // generator-emitted, always present
+      get => ref Unsafe.AsRef(in IID_Guid);
     }
 }
 ```
 
+`IID_Guid` is the generator-emitted static field and is present on these older
+versions even when `IComIID` is not.
+
 Add a partial for each new generated COM type you scope. A **manual** struct is
 not given the instance polyfill (it would force an interface dispatch on a hot
-path); a manual struct that must work down-level spells out the instance member
-itself, as in [manual-structs.md](manual-structs.md). Whether a repo is on the
-modern or the down-level story - and where the polyfill files live - is
-repo-specific; **see the overlay.** Upgrading the generator past 0.3.287 lets you
-delete the whole polyfill.
+path); a manual struct that must work on .NET Framework spells out the instance
+member itself, as in [manual-structs.md](manual-structs.md). Whether a repo uses
+the 0.3.287+ both-family generation or the older Framework polyfill - and where
+those polyfill files live - is repository-specific; **see the overlay.**
+Upgrading the generator to 0.3.287 or later lets you delete the whole polyfill.
 
 ## CLS compliance
 
 A CLS-compliant assembly (`[assembly: CLSCompliant(true)]`) trips `CS3016` on
 generated COM wrappers that carry CCW thunks (the `[UnmanagedCallersOnly(...)]`
-array argument). Modern CsWin32 (0.3.287+) auto-emits `[CLSCompliant(false)]` on
-those wrappers and adds `CS3019` / `CS3021` to its own generated-file
-`#pragma warning disable` list, so the assembly builds clean with no consumer
-action. On an older generator you supply a hand-authored `[CLSCompliant(false)]`
-partial per generated COM type, or an assembly-level suppression - see the
-overlay. Do not add per-type partials or a blanket `NoWarn` on a modern
-generator. Reference:
+array argument). CsWin32 0.3.287+ auto-emits `[CLSCompliant(false)]` only on
+**internal** wrappers that carry those thunks and adds `CS3019` / `CS3021` to
+its generated-file `#pragma warning disable` list. Internal projections therefore
+need no consumer workaround. The .NET Framework target does not emit the thunks
+and receives no annotation.
+
+CsWin32 deliberately does not annotate **public** wrappers: the consuming
+library owns its public CLS contract. In a CLS-compliant assembly with a public
+projection, decide whether each wrapper belongs in the public surface. Mark an
+intentionally non-CLS wrapper with a hand-authored `[CLSCompliant(false)]`
+partial, reduce its visibility, or otherwise address the public contract rather
+than applying a blanket suppression. Before 0.3.287, internal CCW-bearing
+wrappers also need the hand-authored partials and may need narrowly scoped
+`CS3019` / `CS3021` suppression. See the overlay and
+[microsoft/CsWin32#1706](https://github.com/microsoft/CsWin32/pull/1706).
+The underlying array-argument diagnostic is tracked by
 [dotnet/roslyn#68526](https://github.com/dotnet/roslyn/issues/68526).

--- a/.agents/skills/cswin32-com/lifetime.md
+++ b/.agents/skills/cswin32-com/lifetime.md
@@ -1,52 +1,60 @@
 # Lifetime and access
 
 Detail for [cswin32-com](SKILL.md). Struct-based COM has no runtime to release
-references for you; scope every pointer.
+references for you. Release every reference the caller owns, and never release a
+borrowed pointer without first acquiring a reference.
 
 ## Where a COM pointer may live
 
-A raw `T*` (a CsWin32 COM struct pointer) is allowed only as a local in an
-`unsafe` method, a parameter, or a field of a `ref struct`. **A raw `T*` field on
-a `class` or non-`ref` `struct` is forbidden** - it is an apartment-agility
-hazard and leaks its reference if the owner is finalized without disposing. Use
-the field-lifetime holder below instead.
+A raw `T*` (a CsWin32 COM struct pointer) is simplest as a local in an `unsafe`
+method, a parameter, or a field of a `ref struct`. Avoid storing one directly in
+a class or non-`ref` struct by default: the owner must track whether the pointer
+is owned or borrowed, enforce the interface's apartment and thread contract,
+release an owned reference on the correct apartment, and prevent access after
+disposal. A finalizer on an arbitrary thread is not a substitute for releasing
+an apartment-affine pointer on its owning apartment. Use a field-lifetime
+strategy below unless the type explicitly enforces all of those invariants.
 
 ## ComScope<T> - transient pointers
 
-A `ref struct`, always `using`'d, that calls `Release` on dispose. **The default
-for everything that does not outlive the current method.** It implicitly converts
-to `T**` and `void**`, so an out-param writes straight into the scope:
+The examples use a support-library `ref struct` that owns one AddRef'd reference
+and calls `Release` on dispose. Always use it in a `using` declaration. It is the
+default for an **owned** pointer that does not outlive the current method. The
+conventional type implicitly converts to `T**` and `void**`, so an out-param
+writes straight into the scope:
 
 ```csharp
 using ComScope<ISomething> scope = new();
-Guid iid = IID.Get<ISomething>();
-factory.Pointer->QueryInterface(&iid, scope).ThrowOnFailure();
+factory.Pointer->QueryInterface(IID.Get<ISomething>(), scope).ThrowOnFailure();
 scope.Pointer->DoThing(...);
 ```
 
 - Access methods via `scope.Pointer->Method(...)`; null-check with
   `scope.IsNull`.
-- Applies to *every* COM out-param - `CoCreateInstance`, `QueryInterface`,
-  `IEnumXxx::Next`, a factory method, an app-local `STDAPI Get*` (declare the
-  `[DllImport]` with `T** pp`, not `out T*`, so the implicit operator binds).
+- Applies to every COM out-param whose contract returns an owned reference -
+    `CoCreateInstance`, `QueryInterface`, many `IEnumXxx::Next` and factory
+    methods, and app-local `STDAPI Get*` functions. Read the contract before
+    scoping an unusual borrowed output. Declare raw outputs with `T**` when the
+    scope's implicit pointer-to-pointer conversion should bind.
 
 ## Passing pointers to retaining APIs
 
 A helper that creates a CCW or queries an interface normally returns one owned,
 AddRef'd pointer. Passing that pointer to `Advise`, `SetClientSite`, or another
-API that retains it does **not** transfer the caller's reference. The retaining
-API adds its own reference; scope and release the caller's reference after the
-call:
+API that retains it does **not** transfer the caller's reference. When the call
+succeeds and its contract retains the pointer, the callee acquires its own
+reference; scope and release the caller's reference after the call:
 
 ```csharp
-using ComScope<IEventSink> sink = new(GetComPointer<IEventSink>(managedSink));
+using ComScope<IEventSink> sink = new(AcquireOwnedCcwPointer<IEventSink>(managedSink));
 source.Pointer->Advise(sink.Pointer, &cookie).ThrowOnFailure();
 ```
 
-The same scope is appropriate for a borrowed call such as a verb or callback:
-it keeps the pointer valid through the call and releases it immediately after.
-Do not leave the acquired pointer as an unscoped local merely because the callee
-also keeps a reference.
+The same scope is appropriate when an **owned** pointer is passed to a
+non-retaining call such as a verb or callback: the scope releases the caller's
+reference afterward. A pointer that is itself borrowed is different. Do not put
+it in a releasing scope; keep its owner alive for the call, or call `AddRef`
+before creating an owned scope.
 
 A successful cookie-producing subscription is a second lifetime edge. Store the
 cookie and call `Unadvise(cookie)` before releasing the source object. Use a
@@ -66,11 +74,22 @@ private static ComScope<ISomething> Acquire()
 {
     ComScope<ISomething> result = new();
     Guid clsid = SomeCoClass.CLSID;
-    HRESULT hr = PInvoke.CoCreateInstance(
+    HRESULT createResult = PInvoke.CoCreateInstance(
         &clsid, null, CLSCTX.CLSCTX_INPROC_SERVER, IID.Get<ISomething>(), result);
-    return hr.Succeeded ? result : default;   // ownership flows to the caller
+    if (createResult.Failed)
+    {
+        result.Dispose();
+        return default;
+    }
+
+    return result;
 }
 ```
+
+Disposing the scope on failure covers APIs that leave a non-null output despite
+failing. On success, returning the scope transfers that one owned reference to
+the caller. The concrete support type must make `default` null and disposal a
+no-op for this shape to be valid.
 
 ## BSTR - COM strings
 
@@ -100,12 +119,20 @@ copy.
 
 ## A COM pointer that outlives a method
 
-When a COM pointer must be stored in a class field (the only legal way to keep
-one on a non-`ref` type), use a finalizable managed holder that registers the
-pointer in the Global Interface Table (thread-agile) and releases it on dispose,
-with the finalizer as a safety net. Access it by round-tripping a short-lived
-`ComScope<T>` back out of the holder for the duration of a call; hoist one scope
-to the top of a method when several calls share it. When the source pointer is
-already owned by a `ComScope<T>` that will release, register **without** taking
-ownership (the GIT adds its own reference); take ownership only when no other code
-path will release. The concrete holder type is repo-specific - see the overlay.
+Choose a holder that matches the interface's apartment contract:
+
+- A same-apartment owner may keep an owned pointer only when it enforces access
+    and deterministic disposal on that apartment.
+- For cross-apartment access, marshal the interface. A Global Interface Table
+    holder stores one registered reference and retrieves an apartment-appropriate
+    proxy into a short-lived owned scope for each call. The GIT does not make the
+    underlying object agile.
+- For an interface documented as agile, a holder may use an agile-reference or
+    equivalent strategy, but it must still own and release the correct reference.
+
+When the source pointer is already owned by a `ComScope<T>` that will release,
+register without taking that caller reference; the GIT acquires its own. Take
+ownership only when no other code path will release the source reference. Every
+holder needs deterministic disposal, and any finalizer fallback must be valid
+for the chosen marshalling strategy. The concrete holder type is
+repository-specific - see the overlay.

--- a/.agents/skills/cswin32-com/manual-structs.md
+++ b/.agents/skills/cswin32-com/manual-structs.md
@@ -2,8 +2,10 @@
 
 Detail for [cswin32-com](SKILL.md). For an interface not in Win32 metadata (WMI,
 Fusion, Setup Configuration, CLR hosting / metadata), hand-write a struct that
-lays out the vtable yourself. Put each interface in its own file, excluded from
-any source-only or non-Windows build.
+lays out the vtable yourself. Put each interface in its own file. Include or
+exclude that file using the same platform and target-framework decisions as the
+paired interop skill; a cross-platform assembly may compile the declaration as
+long as reachable calls remain Windows-only.
 
 ## Shape
 
@@ -42,7 +44,7 @@ internal unsafe struct IAssemblyCache : IComIID
 
 - **`delegate* unmanaged[Stdcall]`** for the function-pointer cast. IDL
   `STDMETHODCALLTYPE` is `__stdcall` on Win32; the wrong convention silently
-  corrupts the stack. This works on the old framework leg too (it lowers to an IL
+  corrupts the stack. This works on .NET Framework too (it lowers to an IL
   `calli`).
 - **Vtable slots are exact and IUnknown-relative:** slot 0 = `QueryInterface`,
   1 = `AddRef`, 2 = `Release`, 3+ = interface methods in IDL order. When the
@@ -50,19 +52,22 @@ internal unsafe struct IAssemblyCache : IComIID
   `v2` method after three `IUnknown` and three `v1` methods is at slot 6). Unused
   slots may be omitted as long as the ones you call have the correct index.
 - **`IComIID` has two shapes** - a static-abstract `static ref readonly Guid
-  IComIID.Guid` on .NET 7+, and an instance `readonly ref readonly Guid
-  IComIID.Guid` down-level. A dual-target manual struct must spell out **both**
-  arms (`#if NET` / `#else`); a modern-only struct drops the `#else` and gates the
-  whole file `#if NET`. CsWin32 handles this automatically for *generated*
-  structs - see [comiid-and-cls.md](comiid-and-cls.md).
+  IComIID.Guid` on the .NET 10 leg, and an instance
+  `readonly ref readonly Guid IComIID.Guid` on .NET Framework. A dual-target
+  manual struct spells out **both** arms (`#if NET` / `#else`). A .NET 10-only
+  struct needs no conditional; a Framework-only struct uses only the
+  instance form. CsWin32 handles this automatically for *generated* structs -
+  see [comiid-and-cls.md](comiid-and-cls.md).
 - **Use the generated `PCWSTR` / `PWSTR`** for wide-string parameters (add them
   to `NativeMethods.txt`); raw `char*` with `fixed` only where no typed
   equivalent exists.
 - **Vtable methods are blittable** - the same rules as any `[DllImport]`; see the
   blittable-signatures page of the paired cswin32-interop skill (`HRESULT`
-  return, `T**` not `out T*`, `void*`, typed enum parameters).
-- **`CS0592`** forbids `[SupportedOSPlatform]` on a struct - put it on individual
-  methods.
+  return, raw `T**` pointer outputs, `void*`, typed enum parameters).
+- **Platform annotations may be type- or member-level.**
+  `[SupportedOSPlatform]` is valid on structs. Apply it to the whole interface
+  struct when every member has the same Windows contract, or to individual
+  methods when versions differ.
 
 ## Strongly-typed handle and token wrappers
 

--- a/.agents/skills/cswin32-com/migration-and-testing.md
+++ b/.agents/skills/cswin32-com/migration-and-testing.md
@@ -20,11 +20,12 @@ threw automatically. Preserve the old throw-versus-return at each call site:
 rejection (e.g. `Create(path)` on bad input), keep the null-return only for that
 path; activation and QI failures still throw.
 
-**Do not throw when the caller swallows it.** If the top-level consumer wraps the
-whole chain in `catch (COMException) { }`, inner helpers must return `default` /
-`false` / empty rather than constructing a `COMException` only to have it
-discarded - throwing there allocates, walks the stack, and hides the HRESULT for
-no benefit.
+**A swallowing caller does not define a shared helper's contract.** If the
+operation documents an expected "absent" result, an exception-free
+`Try*` / `false` / `default` path can avoid allocation and preserve the raw
+`HRESULT`. Otherwise retain `.ThrowOnFailure()` even when one top-level caller
+catches `COMException`. Change a shared helper only after auditing every caller
+and preserving its public failure contract.
 
 ## Mocking struct-based COM in tests
 
@@ -38,9 +39,15 @@ test:
 
 ```csharp
 // MockTypeLib : ComTypes.ITypeLib  (a normal managed class)
-IntPtr ccw = Marshal.GetComInterfaceForObject(mock, typeof(ComTypes.ITypeLib));
-try { walker.Analyze((ITypeLib*)ccw); }   // struct API; real QueryInterface works
-finally { Marshal.Release(ccw); }
+nint ccw = Marshal.GetComInterfaceForObject(mock, typeof(ComTypes.ITypeLib));
+try
+{
+  walker.Analyze((ITypeLib*)ccw);
+}
+finally
+{
+  Marshal.Release(ccw);
+}
 ```
 
 The CCW exposes a real vtable, so no hand-rolled native vtable is needed. But the

--- a/.agents/skills/cswin32-com/migration-and-testing.md
+++ b/.agents/skills/cswin32-com/migration-and-testing.md
@@ -42,11 +42,11 @@ test:
 nint ccw = Marshal.GetComInterfaceForObject(mock, typeof(ComTypes.ITypeLib));
 try
 {
-  walker.Analyze((ITypeLib*)ccw);
+    walker.Analyze((ITypeLib*)ccw);
 }
 finally
 {
-  Marshal.Release(ccw);
+    Marshal.Release(ccw);
 }
 ```
 

--- a/.agents/skills/cswin32-com/overlay.md
+++ b/.agents/skills/cswin32-com/overlay.md
@@ -12,25 +12,33 @@ commons. It is **not yet vendored** - no `github-*` provenance, and `core-pin` i
 `pending-promotion` until the promotion change vendors it. Keep the core generic;
 madowaku specifics live here.
 
-## madowaku is on the modern IComIID story
+## madowaku uses 0.3.287+ IComIID generation
 
 madowaku pins **CsWin32 0.3.298** (see
 [Directory.Packages.props](../../../Directory.Packages.props)), which is **past
-0.3.287**, so the generator emits `IComIID` on **all** TFMs and attaches it to
-every generated COM struct automatically - the modern path in
-[comiid-and-cls.md](comiid-and-cls.md). There is **no** hand-authored `IComIID`
-polyfill: adding a generated COM type to
+0.3.287**, so the generator emits `IComIID` on all three madowaku library TFMs
+and attaches it to every generated COM struct automatically - the 0.3.287+ path
+in [comiid-and-cls.md](comiid-and-cls.md). There is **no** hand-authored
+`IComIID` polyfill: adding a generated COM type to
 [NativeMethods.txt](../../../madowaku/NativeMethods.txt) carries `IComIID` through
 `ComScope<T>` on net472 with nothing extra. `IID.Get<T>()`
 ([IID.cs](../../../madowaku/Windows/Win32/Foundation/IID.cs)) reads it via
-`T.Guid` on modern .NET and `default(T).Guid` on net472.
+`T.Guid` on .NET 10 and `default(T).Guid` on net472.
+
+Madowaku's `#if NET` branches select both .NET 10 legs, while its
+`#if NETFRAMEWORK` branches select net472.
 
 ## Activation and lifetime helpers (this repo)
 
+- **Owned-pointer scope and IID access:**
+  [ComScope](../../../madowaku/Windows/Win32/System/Com/ComScope{T}.cs) owns one
+  AddRef'd interface pointer and converts to `T**` / `void**` for output calls;
+  [IID](../../../madowaku/Windows/Win32/Foundation/IID.cs) exposes the
+  `Guid*`-returning `IID.Get<T>()` helper used by the core examples.
 - **Class factory:**
   [ComClassFactory](../../../madowaku/Windows/Win32/System/Com/ComClassFactory.cs)
   (activate via `CoGetClassObject` then `CreateInstance`).
-- **Field-lifetime holder:** the core's GIT-backed holder is
+- **Cross-apartment field holder:** the core's GIT-backed strategy maps to
   [AgileComPointer](../../../madowaku/Windows/Win32/System/Com/AgileComPointer.cs),
   backed by
   [GlobalInterfaceTable](../../../madowaku/Windows/Win32/System/Com/GlobalInterfaceTable.cs).
@@ -46,7 +54,7 @@ polyfill: adding a generated COM type to
 ## Owner-side CCW vtable hook
 
 madowaku is the owner described by
-[ccw-composition.md](ccw-composition.md). Its modern .NET build implements the
+[ccw-composition.md](ccw-composition.md). Its .NET 10 build implements the
 `PopulateIUnknownImpl<TComInterface>` partial method declared by CsWin32's
 generated `ComHelpers` in
 [ComHelpers.cs](../../../madowaku/Windows/Win32/System/Com/ComHelpers.cs). The
@@ -78,9 +86,10 @@ disposing the source pointer.
   arms itself (static-abstract under `#if NET`, instance under `#else`) - the
   generator attaches `IComIID` to *generated* structs, not manual ones.
 - **CLS compliance:** madowaku does not assert `[assembly: CLSCompliant(true)]`,
-  so `CS3016` on generated COM wrappers never arises and no suppression is needed.
-  (On 0.3.287+ the generator also auto-emits `[CLSCompliant(false)]` for a
-  consumer that does assert CLS compliance.)
+  so `CS3016` on its public generated COM wrappers does not arise and no
+  suppression or per-type partial is needed. CsWin32 does not auto-annotate
+  public wrappers; if madowaku adopts CLS compliance later, audit that public
+  projection and mark intentionally non-CLS wrappers explicitly.
 
 ## `UnwrapCCW` is not available on net472
 

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: cswin32-interop
-description: 'Guides CsWin32 P/Invoke interop in a multi-targeted .NET library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, gating Windows-only code across target frameworks, or choosing between CsWin32 and [LibraryImport]. Paired with the cswin32-com skill for the struct-based COM layer.'
+description: 'Guides CsWin32 P/Invoke interop in a multi-targeted .NET 10 and .NET Framework library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, selecting compile-time / runtime / analyzer guards for Windows-only code, or choosing between CsWin32 and [LibraryImport]. Paired with the cswin32-com skill for the struct-based COM layer.'
 license: MIT
-compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; projects Windows APIs.
+compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; projects Windows APIs across .NET 10 and .NET Framework. Owner/extender composition requires C# 14.
 metadata:
   portability: portable
   applicability: dotnet
@@ -30,19 +30,23 @@ it - see the paired **cswin32-com** skill, whose vtable methods follow the same
 
 ## Rules
 
-1. **Replace `[DllImport]` with `PInvoke.*`.** Delete the old declaration and
-   any hand-written struct/enum/constant it depended on - the generator emits
-   projected equivalents. See [types-and-constants.md](types-and-constants.md).
+1. **Replace a hand-written `[DllImport]` with `PInvoke.*` when CsWin32 can
+  project the API.** After verifying the generated declaration and supporting
+  types, delete their hand-written equivalents. Keep a source-generated
+  `[LibraryImport]` on .NET 10 and `[DllImport]` on .NET Framework for an
+  export absent from the available Win32 metadata. See
+  [types-and-constants.md](types-and-constants.md).
 2. **Use the generated types directly** (`HANDLE`, `HMODULE`, `HRESULT.S_OK`,
    `FILE_FLAGS_AND_ATTRIBUTES`, ...). Never keep a parallel local copy of a
    Win32 enum or struct CsWin32 already projects.
 3. **Call the generated method directly** - no thin wrapper. Within one
-  ownership layer, generate once and share internal types with friend
-  assemblies. When a downstream package intentionally extends a public owner,
-  use the [owner/extender composition](composition.md) model instead.
-4. **Prefer CsWin32 for Windows APIs.** Reserve `[LibraryImport]` (or, on older
-   targets, `[DllImport]`) for genuinely non-Windows native calls such as
-   `libc`.
+   ownership layer, generate once and share internal types with friend
+   assemblies. When a downstream package intentionally extends a public owner,
+   use the [owner/extender composition](composition.md) model instead.
+4. **Prefer CsWin32 for Windows APIs present in its metadata.** Use
+  `[LibraryImport]` (or `[DllImport]` on .NET Framework) for private, custom,
+  or otherwise unprojectable Windows exports and for non-Windows native calls
+  such as `libc`. Keep those signatures blittable under the same rules.
 5. **Preserve the original error-handling contract when migrating.** Check the
    old declaration for `PreserveSig` / `SetLastError` / `BOOL` / `HRESULT`
    semantics and reproduce them: `PreserveSig=false` becomes
@@ -54,21 +58,22 @@ it - see the paired **cswin32-com** skill, whose vtable methods follow the same
    so every `[DllImport]` and every COM vtable method must be blittable. The
    full rule set is in [blittable-signatures.md](blittable-signatures.md).
 7. **Audit ownership and size units.** Generated wrappers do not decide which
-    allocator frees an output, whether a COM reference remains caller-owned, or
-    whether a length is bytes or elements. Record and test those contracts using
-    [ownership-and-units.md](ownership-and-units.md).
+   allocator frees an output, whether a COM reference remains caller-owned, or
+   whether a length is bytes or elements. Record and test those contracts using
+   [ownership-and-units.md](ownership-and-units.md).
 
-## The Windows-interop compile gate
+## Platform and target-framework guards
 
-CsWin32 output is Windows-only. A cross-platform or source-buildable library
-gates its Windows-interop code behind a repo-specific compile symbol (the
-"Windows-interop gate") plus, on any code path that also has a non-Windows
-branch, a runtime `IsWindows` check. A Windows-only library that still
-multi-targets frameworks has **no** platform gate - the cross-cut there is
-**target framework**, not platform. Either way,
-[gating.md](gating.md) covers guard selection, the correct nesting order,
-`CA1416`, and verifying the guarded build. Your overlay names the concrete gate
-(or states there is none).
+CsWin32 projects Windows APIs, but compile inclusion, runtime reachability, and
+the public platform contract are separate decisions. Generated declarations can
+live in a cross-platform assembly; reachable calls still need a recognized
+Windows runtime guard or a Windows-only API context. Exclude source at compile
+time only when a target intentionally omits that interop surface or one of its
+dependencies. In the .NET 10 / .NET Framework target model, use `NET` for the
+.NET 10 leg and `NETFRAMEWORK` for the Framework leg. See
+[gating.md](gating.md) for the decision table, `CA1416`, and guarded-build
+verification. An overlay records the concrete TFMs and any repository-specific
+compile symbol or source-item condition.
 
 ## Configuration
 
@@ -91,11 +96,11 @@ files under the intermediate output directory and adds them to `Compile`; the
 source generator stands down. Treat this as an opt-in for a specific build
 ordering, generated-file, or tooling requirement, not as a general upgrade.
 
-Before keeping build-task mode, clean and build every TFM, compare the emitted
-public API, and measure clean-build time. It can be materially slower. It also
-does not make an `allowMarshaling: false` project more AOT-safe by itself, so do
-not enable `DisableRuntimeMarshalling` merely because generation moved to the
-task.
+Before keeping build-task mode, clean and build all .NET 10 and .NET Framework
+TFMs, compare the emitted public API, and measure clean-build time. It can be
+materially slower. It also does not make an `allowMarshaling: false` project
+more AOT-safe by itself, so do not enable `DisableRuntimeMarshalling` merely
+because generation moved to the task.
 
 ## Sibling pages
 
@@ -114,5 +119,5 @@ task.
 - [ownership-and-units.md](ownership-and-units.md) - matching native allocators
   and deallocators, caller-owned COM references, failure cleanup, and
   byte-versus-element conversions.
-- [gating.md](gating.md) - multi-TFM / multi-platform guards, `CA1416`, a
-  stack-first scratch buffer, and verifying the guarded build.
+- [gating.md](gating.md) - source inclusion, runtime and TFM guards, `CA1416`, a
+  stack-first scratch-buffer strategy, and guarded-build verification.

--- a/.agents/skills/cswin32-interop/blittable-signatures.md
+++ b/.agents/skills/cswin32-interop/blittable-signatures.md
@@ -16,16 +16,18 @@ These rules apply to both surfaces.
   call site: `iface->Method(...).ThrowOnFailure();`. Branch on the raw `hr` only
   when you handle a specific code (e.g. `ERROR_INSUFFICIENT_BUFFER`) before
   throwing.
-- **Use `T**`, not `out T*`,** for pointer outputs. `out` forces a marshalling
-  path and a `fixed` round-trip at every call site; `T**` is the raw blittable
-  shape.
+- **Prefer `T**` for raw pointer outputs and vtable signatures.** `out T*` is
+  also blittable and represents the same native indirection, but it introduces
+  managed by-reference syntax and cannot bind to helpers that expose `T**` or
+  `void**`. Keep `out T*` only when the hand-written declaration intentionally
+  wants C# definite-assignment semantics; match the raw ABI with `T**` by
+  default.
 - **Use `void*` for opaque / reserved parameters** and pass `null` literally -
-  never round-trip through `IntPtr.Zero` inside `unsafe`. `IntPtr` is fine only
-  at boundaries with the wider .NET surface (`Marshal.*`,
-  `SafeHandle.DangerousGetHandle`, public API).
-- **Prefer `nint` / `nuint` over `IntPtr` / `UIntPtr`** for native-sized
-  integers - better cast semantics with `int` / `long`, no `IntPtr.Zero`
-  ceremony, no boxing surprises.
+  never round-trip through `IntPtr.Zero` inside `unsafe`.
+- **Prefer `nint` / `nuint` for new native-sized values.** Keep
+  `IntPtr` / `UIntPtr` only where an existing public contract or managed API
+  requires those names (`Marshal.*`, `SafeHandle.DangerousGetHandle`, or a
+  compatibility-sensitive public API), and convert once at that boundary.
 - **Use the generated `PCWSTR` / `PWSTR` for wide strings,** never a managed
   `string`. The caller pins with `fixed (char* p = managedString)` (implicit on
   most overloads). Add the type to `NativeMethods.txt` if not yet generated.

--- a/.agents/skills/cswin32-interop/gating.md
+++ b/.agents/skills/cswin32-interop/gating.md
@@ -30,11 +30,11 @@ if (OperatingSystem.IsWindows())
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 #endif
 {
-  _ = PInvoke.GetCurrentProcessId();
+    _ = PInvoke.GetCurrentProcessId();
 }
 else
 {
-  // Cross-platform fallback.
+    // Cross-platform fallback.
 }
 ```
 

--- a/.agents/skills/cswin32-interop/gating.md
+++ b/.agents/skills/cswin32-interop/gating.md
@@ -1,95 +1,89 @@
-# Gating and guarded builds
+# Platform and target-framework guards
 
-Detail for [cswin32-interop](SKILL.md). CsWin32 output is Windows-only. How you
-gate it depends on whether the library is cross-platform / source-buildable or
-Windows-only but multi-targeted.
+Detail for [cswin32-interop](SKILL.md). CsWin32 projects Windows APIs. Decide
+source inclusion, runtime reachability, and the platform contract independently;
+one guard does not automatically satisfy all three.
 
-## The two cross-cuts
+## Choose the guard from the constraint
 
-- **Platform.** A cross-platform or source-buildable library compiles its
-  Windows-interop code only behind a repo-specific compile symbol (the
-  "Windows-interop gate") and takes a runtime `IsWindows` check on any code path
-  that also has a non-Windows branch. Both are required.
-- **TFM.** A Windows-only library that multi-targets frameworks has no platform
-  gate; the cross-cut is target framework (for example an older `net472` /
-  `netstandard` leg versus a modern .NET leg). Guard only the members that
-  depend on a newer language or runtime feature.
+| Constraint | Compile-time action | Runtime action |
+| --- | --- | --- |
+| Windows-specific TFM or assembly | Usually none; the assembly already carries the platform context. | None unless the API requires a newer Windows version than the assembly contract. |
+| Cross-platform assembly; declarations compile on both runtime families | None. | Guard every reachable call with a recognized Windows check, or annotate the containing API as Windows-only. |
+| A target intentionally omits the interop source or one of its dependencies | Exclude whole files with conditional `Compile` items, or use a documented project symbol for smaller regions. | Still guard calls on any included target that can run cross-platform. |
+| A member exists only on the .NET 10 leg | Use `#if NET`. | Independent of the platform guard. |
+| A member or polyfill exists only on .NET Framework | Use a Framework-only source folder or `#if NETFRAMEWORK`. | Independent of the platform guard. |
 
-Your overlay names the concrete gate, or states there is none. Keep this core's
-guidance gate-name-agnostic.
+Generated P/Invoke declarations are not themselves a reason to remove source
+from non-Windows builds. Use compile-time exclusion only when the project has a
+real source or dependency constraint. When a whole file is conditional, prefer
+an MSBuild item condition over a whole-file `#if`. Namespace `using` directives
+and private helpers referenced only by a conditional region must use the same
+condition. The overlay names any custom symbol or item condition.
 
-## Nest the guards in the right order
+For a cross-platform binary, use a guard recognized by the platform analyzer:
 
 ```csharp
-#if WINDOWS_INTEROP_GATE
-    if (IsWindows)
-    {
-        PInvoke.GetFileAttributesEx(fullPath, out WIN32_FILE_ATTRIBUTE_DATA data);
-    }
+#if NET
+if (OperatingSystem.IsWindows())
+#else
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 #endif
-    // cross-platform fallback
+{
+  _ = PInvoke.GetCurrentProcessId();
+}
+else
+{
+  // Cross-platform fallback.
+}
 ```
 
-The compile gate is **outside**, the runtime check **inside**. The inverse -
-`if (IsWindows) { #if ... #endif }` - leaves dead code (or a missing return
-value) when the symbol is undefined. A file that is entirely Windows-only is
-better excluded from the non-Windows build via `<Compile Remove>` than wrapped
-in a whole-file `#if`.
-
-## Guard selection
-
-| Guard | Use for | Runtime OS check |
-| --- | --- | --- |
-| Windows-interop gate only | Multi-TFM Windows calls present on every framework | Yes |
-| gate plus "modern-only" (`&& NET`) | Members needing .NET 7+ features: static-abstract interface members, some `delegate*` conventions, real `ComWrappers` | Yes |
-| gate plus "not netstandard" | CsWin32 types unavailable on `netstandard` | Yes |
-| framework-only (`#if !NET`) | Code that exists only for the old framework leg, usually a polyfill - inherently Windows | No |
-
-Namespace `using` directives for gated types must live inside the same guard.
+Use `OperatingSystem.IsWindows()` on .NET 10 and
+`RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` on .NET Framework. If the
+interop call is also conditionally compiled, keep the compile condition outside
+the runtime branch so the fallback remains complete when that source is absent.
 
 ## CA1416 platform compatibility
 
 For a cross-platform assembly, satisfy the analyzer semantically rather than
 suppressing it:
 
-- `if (IsWindows)` satisfies `[SupportedOSPlatform]`; `if (IsUnixLike)`
-  satisfies `[UnsupportedOSPlatform("windows")]`. **Never** use `!IsWindows` -
-  use an explicit `else if (IsUnixLike)`.
-- Put a versioned `[SupportedOSPlatform("windows6.1")]` on methods that call
-  CsWin32 APIs. `CS0592` forbids the attribute on a `partial struct` - put it on
-  individual members instead.
-- Reserve `#pragma warning disable CA1416` for static local functions, which the
-  analyzer cannot flow into.
+- Use `OperatingSystem.IsWindows()` or
+  `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`. Annotate a custom
+  boolean field, property, or method with
+  `[SupportedOSPlatformGuard("windows")]` before relying on it as a guard.
+- Apply `[SupportedOSPlatform("windows")]` to an assembly, type, or member when
+  its contract is Windows-only. The attribute is valid on structs. Include a
+  version only when the API has that real minimum, and match the documented
+  version instead of applying one baseline to every CsWin32 call.
+- Use `#pragma warning disable CA1416` only as a narrow, justified last resort
+  when a recognized guard or platform annotation cannot express the contract.
 
 ## A stack-first scratch buffer
 
-Win32 string and buffer APIs want a caller-allocated span with a length retry. A
-stack-first buffer with an `ArrayPool<T>` fallback keeps the common case
-allocation-free:
+Win32 string and buffer APIs often want caller-allocated storage followed by a
+length retry. Check for a CsWin32 `Span<T>` convenience overload before writing
+a `fixed` block. For a bounded common case, start with a small stack span and
+rent from `ArrayPool<T>` when the required length exceeds it. Choose the stack
+size from element size, call depth, measured workloads, and the repository's
+stack budget; there is no universal byte cutoff.
 
-```csharp
-using BufferScope<char> buffer = new(stackalloc char[(int)PInvoke.MAX_PATH]);
-int length = (int)PInvoke.GetShortPathName(path, buffer.AsSpan());
-if (length > buffer.Length)
-{
-    buffer.EnsureCapacity(length);
-    length = (int)PInvoke.GetShortPathName(path, buffer.AsSpan());
-}
-```
-
-Always `using` it (it is a `ref struct`), never `stackalloc` more than about
-1024 bytes, and check for a CsWin32 convenience overload (e.g.
-`GetShortPathName(string, Span<char>)`) before writing a `fixed` block. The
-`scratch-buffer-strategy` skill covers choosing the strategy; the concrete
-buffer type and its location are repo-specific - see the overlay.
+A repository may provide a disposable `ref struct` that combines the stack and
+pool paths. Always dispose that scope so a rented array is returned. The
+`scratch-buffer-strategy` skill covers the choice when installed, and the
+overlay names any concrete helper. On retry, preserve the native API's exact
+length semantics: bytes versus elements, and whether the required count includes
+a terminator or header.
 
 ## Verify the guarded build
 
-Anything referenced **only** inside the Windows-interop gate must itself be
-inside it, or the build that undefines the symbol breaks - most often on
-warnings-as-errors. Watch for `IDE0005` (unused `using`), `IDE0051` / `IDE0052`
-(unused private members), `CA1823` (an unused private field, e.g. a constant
-read only inside the guard), and `CS1587` (an XML doc comment left before a
-now-gated member). The same applies to a polyfill behind `#if !NET` consumed
-only from gated code. Build **both** configurations - symbol defined and
-undefined - before pushing.
+Anything referenced **only** inside a compile condition must itself be inside
+that condition, or the excluded build can fail under warnings-as-errors. Watch
+for `IDE0005` (unused `using`), `IDE0051` / `IDE0052` (unused private members),
+`CA1823` (an unused private field), and `CS1587` (an XML doc comment left before
+a conditional member).
+
+Build all .NET 10 and .NET Framework TFMs and every custom-symbol state that
+changes source inclusion. For a cross-platform binary, also execute an
+unsupported-OS path and verify it takes the fallback without loading or calling
+the Windows API.

--- a/.agents/skills/cswin32-interop/library-layering.md
+++ b/.agents/skills/cswin32-interop/library-layering.md
@@ -27,11 +27,11 @@ with the composition owner, while a public `Windows.Win32.PInvoke` does.
 Move a helper toward the lowest reusable layer that can own it without importing
 higher-level policy:
 
-- A pooled scratch buffer, allocation-free flag operation, or downlevel BCL
-  polyfill belongs in the managed foundation.
+- A pooled scratch buffer, allocation-free flag operation, or .NET Framework
+   BCL polyfill belongs in the managed foundation.
 - A `HANDLE` close helper, `HRESULT` mapping, `PWSTR` ownership operation,
-  `ComScope<T>`, `SAFEARRAY`/`VARIANT` support, or owner-side CCW hook belongs in
-  the Win32 owner when multiple extenders can use it.
+   owned COM-pointer scope, `SAFEARRAY`/`VARIANT` support, or owner-side CCW hook
+   belongs in the Win32 owner when multiple extenders can use it.
 - A windowing framework, accessibility model, dialog abstraction, or
   domain-specific COM adapter belongs in the extender.
 - An implementation-only vtable provider needed by one extender stays there

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -13,16 +13,21 @@ promoted to the shared commons. It is **not yet vendored**, so it carries no
 will vendor it and add a real pin. Keep the core generic - everything
 madowaku-specific lives here.
 
-## The Windows-interop gate: there isn't one
+## Targeting model
 
-madowaku is a **Windows-only** library, so there is no `FEATURE_WINDOWSINTEROP`
-symbol, no source build, and no `IsWindows` runtime split. The cross-cut is
-purely **TFM**: code must compile on `net472`, `net10.0`, and
-`net10.0-windows10.0.22000.0` (see [AGENTS.md](../../../AGENTS.md)). Use `#if NET`
-only for members that need a .NET 7+ feature; net472-only code lives under
+madowaku is a **Windows-only** library. The cross-cut is purely **TFM**: code
+must compile on `net472`, `net10.0`, and
+`net10.0-windows10.0.22000.0` (see [AGENTS.md](../../../AGENTS.md)). `#if NET`
+selects both .NET 10 legs; `#if NETFRAMEWORK` selects net472. net472-only code
+lives under
 [madowaku/Framework/](../../../madowaku/Framework/), which is net472-scoped by
-`DefaultItemExcludes`, so no `#if NETFRAMEWORK` goes inside it. `CA1416` does not
-arise the way it does in a cross-platform repo.
+`DefaultItemExcludes`, so no `#if NETFRAMEWORK` goes inside it.
+
+The windows-qualified TFM supplies a Windows platform context. The unqualified
+net10 TFM deliberately suppresses `CA1416` in
+[madowaku.csproj](../../../madowaku/madowaku.csproj) because this package's
+contract is Windows-only; that suppression is a repository policy, not portable
+CsWin32 guidance.
 
 ## One public PInvoke surface
 
@@ -59,7 +64,7 @@ The portable core's [library layering](library-layering.md) maps to this fleet
 as follows:
 
 - **Touki is the managed foundation.** It owns cross-domain helpers such as
-  `BufferScope<T>`, allocation-free enum operations, and downlevel runtime
+  `BufferScope<T>`, allocation-free enum operations, and .NET Framework runtime
   polyfills. Touki may use an internal CsWin32 projection for implementation,
   but it does not publish the fleet's canonical Win32 type identity.
 - **madowaku is the Win32 composition owner.** It publishes `PInvoke`, generated
@@ -84,21 +89,22 @@ not prove the dependency can be consumed externally.
 ## Generation mode: keep the source generator
 
 CsWin32 0.3.298 supports `<CsWin32RunAsBuildTask>true</CsWin32RunAsBuildTask>`,
-but an alternating all-TFM Release spike on 2026-07-11 averaged 2.51 seconds for
-clean source-generator builds and 4.37 seconds for build-task mode (+1.86
-seconds, roughly 74%); incremental builds were effectively equal (1.59 versus
-1.54 seconds). Both modes emitted the same 96 top-level types and matching key
-interop constructs. madowaku therefore keeps the default Roslyn source
-generator. Do not enable build-task mode without a new concrete ordering or
-tooling need, an all-TFM API comparison, and fresh timing data after SDK or
-CsWin32 changes. `allowMarshaling: false` already supplies the raw AOT-friendly
-signatures; moving generation to an MSBuild task does not require
-`DisableRuntimeMarshalling`.
+but an alternating three-library-TFM Release spike on 2026-07-11 averaged 2.51
+seconds for clean source-generator builds and 4.37 seconds for build-task mode
+(+1.86 seconds, roughly 74%); incremental builds were effectively equal (1.59
+versus 1.54 seconds). Both modes emitted the same 96 top-level types and
+matching key interop constructs. madowaku therefore keeps the default Roslyn
+source generator. Do not enable build-task mode without a new concrete ordering
+or tooling need, an API comparison across all three library TFMs, and fresh
+timing data after SDK or CsWin32 changes. `allowMarshaling: false` already
+supplies the raw AOT-friendly signatures; moving generation to an MSBuild task
+does not require `DisableRuntimeMarshalling`.
 
 ## Polyfills: Touki first
 
 BCL polyfills come from the `KlutzyNinja.Touki` package, not this repo. If a
-modern `System.*` API is missing on net472, add it upstream in Touki, not here.
+`System.*` API available on .NET 10 is missing on net472, add it upstream in
+Touki, not here.
 The narrow exception is **Windows-only** shims (Win32 / COM / CsWin32), which live
 under [madowaku/Framework/](../../../madowaku/Framework/), the folder mirror of
 the BCL namespace being polyfilled. Source preference: a Microsoft package, then
@@ -109,8 +115,9 @@ last resort. The core's stack-first buffer is Touki's `BufferScope<T>` (from the
 ## ComWrappers / CCW polyfill (net472)
 
 CsWin32 unconditionally emits `Windows.Win32.ComHelpers.UnwrapCCW<T1, T2>`, which
-references `ComWrappers.ComInterfaceDispatch` - a .NET 5+ type. madowaku ships a
-Windows-only shim at
+references `ComWrappers.ComInterfaceDispatch`. The type is available on
+madowaku's .NET 10 legs but not on net472, so madowaku ships a Windows-only shim
+at
 [madowaku/Framework/System/Runtime/InteropServices/ComWrappers.cs](../../../madowaku/Framework/System/Runtime/InteropServices/ComWrappers.cs)
 whose `GetInstance<T>` always returns `null`, so `UnwrapCCW` on net472 yields
 `COR_E_OBJECTDISPOSED`. Do not expose surfaces that rely on `UnwrapCCW` on
@@ -122,13 +129,18 @@ the [cswin32-com](../cswin32-com/overlay.md) overlay.
 - **Enum flags:** use the Touki enum extensions (`AreFlagsSet`,
   `IsOnlyOneFlagSet`, `AreAnyFlagsSet`, `SetFlags`, `ClearFlags`) - never
   `Enum.HasFlag` (it boxes on net472).
+- **Native integers:** use `nint` / `nuint`, never `IntPtr` / `UIntPtr`, per
+  [AGENTS.md](../../../AGENTS.md). Convert only when a managed API requires the
+  named BCL type.
 - **`HMODULE`** has helpers at
   [madowaku/Windows/Win32/Foundation/HMODULE.cs](../../../madowaku/Windows/Win32/Foundation/HMODULE.cs).
 - **Verification:** `dotnet build -c Release` and `dotnet test -c Release` across
-  all TFMs before pushing - net472 RyuJIT and Release-mode inlining surface bugs
-  Debug does not. For a downstream extender change, also pack both layers and
-  compile a clean-cache consumer that references only the extender package and
-  calls one madowaku-owned and one extender-owned `PInvoke` member. The
+  all three library TFMs and both test TFMs before pushing. The net481 test
+  runtime exercises the net472 library under Framework RyuJIT, where
+  Release-mode inlining surfaces bugs Debug does not. For a downstream extender
+  change, also pack both layers and compile a clean-cache consumer that
+  references only the extender package and calls one madowaku-owned and one
+  extender-owned `PInvoke` member. The
   [thirtytwo owner/extender migration](https://github.com/JeremyKuhne/thirtytwo/pull/20)
   validated this flow with madowaku `0.4.0-alpha.1`, including nuspec inspection
   and a consumer that had no local madowaku source.
@@ -136,5 +148,5 @@ the [cswin32-com](../cswin32-com/overlay.md) overlay.
 ## Cross-references
 
 - [`cswin32-com`](../cswin32-com/SKILL.md) - the struct-based COM layer.
-- [`dotnet-polyfills`](../dotnet-polyfills/SKILL.md) - the downlevel polyfill
+- [`dotnet-polyfills`](../dotnet-polyfills/SKILL.md) - the .NET Framework polyfill
   stack behind the "Touki first" policy.

--- a/.agents/skills/cswin32-interop/ownership-and-units.md
+++ b/.agents/skills/cswin32-interop/ownership-and-units.md
@@ -17,7 +17,7 @@ Common pairs include:
 
 | Acquired value | Release operation |
 | --- | --- |
-| AddRef'd COM interface | `IUnknown::Release` (normally through `ComScope<T>`) |
+| AddRef'd COM interface | `IUnknown::Release` (prefer a repository-provided owned-pointer scope) |
 | COM task allocator memory, including many Shell PIDLs | `CoTaskMemFree` |
 | `LocalAlloc` memory | `LocalFree` |
 | `BSTR` | `SysFreeString` / `Marshal.FreeBSTR` |
@@ -67,17 +67,34 @@ ownership behavior.
 A helper that returns an AddRef'd COM pointer gives the caller one reference.
 Passing it to a method such as `Advise`, `SetClientSite`, or another retaining
 API does not transfer that caller reference. The callee adds its own reference
-when its contract retains the pointer; the caller still releases its reference:
+when its contract retains the pointer; the caller still releases its reference.
+In the example, `AcquireOwnedCcwPointer<T>()` is pseudocode for a repository
+helper that returns one caller-owned CCW interface pointer. Its implementation
+may use classic COM marshalling or `ComWrappers`; only the latter can support a
+NativeAOT path. Use the repository's owned-pointer scope when available;
+otherwise make the release explicit:
 
 ```csharp
-using ComScope<IEventSink> sink = new(GetComPointer<IEventSink>(managedSink));
-source->Advise(sink.Pointer, &cookie).ThrowOnFailure();
+IEventSink* sink = AcquireOwnedCcwPointer<IEventSink>(managedSink);
+try
+{
+    source->Advise(sink, &cookie).ThrowOnFailure();
+}
+finally
+{
+    if (sink is not null)
+    {
+        sink->Release();
+    }
+}
 ```
 
 Pair every successful cookie-producing `Advise` with `Unadvise(cookie)` before
-releasing the source object. Scope borrowed-call pointers too: even when the
-callee retains nothing, the scope keeps the pointer valid for the call and
-releases the caller reference afterward.
+releasing the source object. Do not confuse a non-retaining parameter with a
+borrowed pointer: an owned pointer passed to a non-retaining call still needs its
+caller reference released, while a pointer that is itself borrowed must not be
+released. Keep the borrowed pointer's owner alive for the whole call, or call
+`AddRef` first when an owned scope is required.
 
 ## Length parameters: bytes are not elements
 

--- a/.agents/skills/cswin32-interop/types-and-constants.md
+++ b/.agents/skills/cswin32-interop/types-and-constants.md
@@ -31,11 +31,11 @@ because an extension property is not a compile-time constant. Use the unified
 
 ## Some flags are standalone constants, not enum members
 
-A Win32 `#define` that sits outside a `typedef enum` generates as an
-`internal const` on the `PInvoke` class, not as an enum member. Add the
-**constant name** to `NativeMethods.txt` like any API, then OR it onto an enum
-of matching width and cast back where needed. Do not reintroduce a local `const`
-the generator already emits.
+A Win32 `#define` that sits outside a `typedef enum` generates as a `const` on
+the configured generated host, not as an enum member. Its visibility follows
+the CsWin32 `public` setting. Add the **constant name** to `NativeMethods.txt`
+like any API, then OR it onto an enum of matching width and cast back where
+needed. Do not reintroduce a local `const` the generator already emits.
 
 ## Match local types to the generated type
 
@@ -43,9 +43,11 @@ Declare the CsWin32 type and let it flow, instead of casting to `int` / `uint`
 at every use:
 
 ```csharp
-WIN32_ERROR result = PInvoke.RmStartSession(...);   // not int
-// Helpers take the typed value; cast to int only at a non-CsWin32 boundary,
-// e.g. new Win32Exception((int)result, ...).
+// Keep the generated type rather than storing the result as int.
+WIN32_ERROR result = PInvoke.RmStartSession(...);
+
+// Cast only at a non-CsWin32 boundary.
+Win32Exception exception = new((int)result, ...);
 ```
 
 The same applies to `HRESULT`, `BOOL`, `HANDLE`, and every flag enum. **Delete
@@ -74,14 +76,21 @@ type is the source of truth.
 `DateTime.FromFileTime((long)hi << 32 | lo)`. Note CsWin32 uses
 `ComTypes.FILETIME` (int fields) for COM members and
 `Windows.Win32.Foundation.FILETIME` (uint fields) for kernel ones; a shared
-extension usually targets `ComTypes.FILETIME`. Distinguish local-time sources
-(e.g. a process start time) from UTC sources (e.g. a file's last-write time)
-when converting.
+extension usually targets `ComTypes.FILETIME`. Read the producing API's time
+contract and choose the desired managed result deliberately. `GetFileTime` and
+the creation / exit outputs from `GetProcessTimes` are UTC-based timestamps: use
+`FromFileTimeUtc` to preserve UTC, or `FromFileTime` only when intentionally
+converting the result to local time. The kernel / user outputs from
+`GetProcessTimes` are elapsed 100-nanosecond durations, not dates; combine their
+64-bit values and convert them to `TimeSpan` ticks. Do not infer time-zone or
+duration semantics from the projected struct shape.
 
 ## Native integers
 
-Always use `nint` / `nuint`, never `IntPtr` / `UIntPtr`. Note that `nint` does
-not implement `IEquatable<nint>` on .NET Framework, so a generic method
-constrained `where T : unmanaged, IEquatable<T>` cannot be instantiated with
-`nint` for a cross-target call site - pick a concrete value type or split the
-path by TFM.
+Prefer `nint` / `nuint` for new native-sized values. Preserve
+`IntPtr` / `UIntPtr` where an existing public contract or managed API requires
+those names, and convert at that boundary rather than carrying both forms
+through the implementation. Note that `nint` does not implement
+`IEquatable<nint>` on .NET Framework, so a generic method constrained
+`where T : unmanaged, IEquatable<T>` cannot be instantiated with `nint` for a
+cross-target call site - pick a concrete value type or split the path by TFM.


### PR DESCRIPTION
## Summary

- prepare the `cswin32-interop` and `cswin32-com` portable cores for promotion to `JeremyKuhne/agent-skills`
- remove the SDK-specific `FEATURE_WINDOWSINTEROP` model and scope target guidance to .NET 10 and .NET Framework
- correct platform guards, import fallbacks, generated constants, `IComIID` / CLS behavior, COM ownership, CCW acquisition, and apartment-lifetime guidance
- keep madowaku-specific TFMs, Touki bindings, helpers, measurements, and validation instructions in overlays
- declare `cswin32-com`'s dependency on `cswin32-interop` and update the local skill catalog

## Validation

- `dotnet test -c Debug` (515 passed)
- `dotnet test -c Release` (515 passed)
- `pwsh tools/Validate-AgentFiles.ps1`
- strict `Validate-Skills.ps1 -RequirePortfolioMetadata` for both skills
- `skills-ref@0.1.5` for both skills
- markdownlint for all affected Markdown
- link and anchor validation for the catalog and both skill directories
- `git diff --check`