### PR TITLE
Update vendored agent skills to v0.11.0

### DIFF
--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -36,5 +36,5 @@ Optional frontmatter fields: `argument-hint`, `user-invocable`,
 
 Vendor-neutral location for [Agent Skills](https://agentskills.io/).
 Discovered by GitHub Copilot (VS Code, CLI, cloud agent) and Claude Code.
-The `description` field is the trigger surface &mdash; phrase it around the
+The `description` field is the trigger surface — phrase it around the
 verbs and nouns a user would say when they need the skill.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -11,28 +11,11 @@ overlap.
 
 ## Inventory
 
-Each skill is one of three kinds: **born-local** (specific to madowaku; no
-upstream, no provenance), a **portable core pending promotion** (reconciled here
-to be upstreamed to the commons, paired with a local `overlay.md`), or
-**vendored** from the shared commons
+Each skill is one of two kinds: **born-local** (specific to madowaku; no
+upstream or provenance), or **vendored** from the shared commons
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) at a
 pinned ref (also with an `overlay.md`). See
 [the vendoring model](#vendoring-model) below.
-
-### Portable cores (pending promotion to the commons)
-
-Generic CsWin32 cores (thin `SKILL.md` plus sibling pages) reconciled from
-madowaku's and dotnet/msbuild's CsWin32 skills, each with a madowaku `overlay.md`.
-They carry portfolio `metadata` but no `github-*` provenance yet; a separate
-change will upstream them to the commons and re-vendor them here with a pin.
-
-| Skill | Trigger phrasing |
-| ----- | ---------------- |
-| [cswin32-interop](./cswin32-interop/SKILL.md) | "replace `[DllImport]` with CsWin32", generated `PInvoke.*` / Win32 types, "which package owns this helper?", split a public owner from downstream extenders, native allocator ownership, byte/element sizes, `NativeMethods.*`, blittable signatures, compile-time / runtime / analyzer guards |
-| [cswin32-com](./cswin32-com/SKILL.md) | struct-based COM with `ComScope`, caller-owned CCW references, `Advise` / `Unadvise`, activation, raw vtables, manual COM structs, `IComIID` across .NET 10 and .NET Framework, cross-assembly CCWs, mocking struct COM |
-
-`cswin32-com` declares `cswin32-interop` as a hard dependency; promote and
-install the pair together even though invocation remains surface-specific.
 
 ### Born-local
 
@@ -40,11 +23,13 @@ install the pair together even though invocation remains surface-specific.
 | ----- | ---------------- |
 | [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" |
 
-### Vendored (commons `v0.10.0`, unless noted)
+### Vendored (commons `v0.11.0`)
 
 | Skill | Trigger phrasing |
 | ----- | ---------------- |
-| [performance-testing](./performance-testing/SKILL.md) | "add a benchmark", "run perf tests", "compare allocations", "BenchmarkDotNet", "why is net481 slower/faster", "how long / how much memory" |
+| [cswin32-interop](./cswin32-interop/SKILL.md) | "replace `[DllImport]` with CsWin32", generated `PInvoke.*` / Win32 types, "which package owns this helper?", split a public owner from downstream extenders, native allocator ownership, byte/element sizes, `NativeMethods.*`, blittable signatures, compile-time / runtime / analyzer guards |
+| [cswin32-com](./cswin32-com/SKILL.md) | struct-based COM with `ComScope`, caller-owned CCW references, `Advise` / `Unadvise`, activation, raw vtables, manual COM structs, `IComIID` across .NET 10 and .NET Framework, cross-assembly CCWs, mocking struct COM; requires `cswin32-interop` at the same pin |
+| [performance-testing](./performance-testing/SKILL.md) | "add a benchmark", "run perf tests", "compare allocations", `BenchmarkDotNet`, multi-phase or exact-oracle investigations, dirty-source reproducibility, "why is net481 slower/faster", "how long / how much memory" |
 | [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | optimize a `net481` / .NET Framework hot path, specialize a generic for primitives, diagnose a Framework micro-benchmark regression |
 | [scratch-buffer-strategy](./scratch-buffer-strategy/SKILL.md) | zeroed `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs `ArrayPool`, "should I rent or stackalloc?", net481/net10 size crossovers |
 | [dotnet-polyfills](./dotnet-polyfills/SKILL.md) | "use a modern .NET API on .NET Framework", PolySharp / `System.Memory` / `Microsoft.Bcl.*`, "which package supplies this type downlevel", "is this already polyfilled" |
@@ -57,7 +42,7 @@ install the pair together even though invocation remains surface-specific.
 | [manage-skills](./manage-skills/SKILL.md) | "find a skill for X", "build a skill" / "create a skill", "update the skill", reconcile a local skill change against the commons vs a repo overlay |
 | [agent-files-review](./agent-files-review/SKILL.md) | review or validate changes to `AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, "fix the agent-files CI failure" |
 | [engineering-baseline](./engineering-baseline/SKILL.md) | "ensure this repo follows modern engineering best practices", "audit this repository", "bring this repo up to standard" |
-| [github-actions-cost-optimization](./github-actions-cost-optimization/SKILL.md) &mdash; pinned `@85325db` | "reduce CI cost / spend / minutes", optimize GitHub Actions triggers, matrices, runners, caches, artifacts |
+| [github-actions-cost-optimization](./github-actions-cost-optimization/SKILL.md) | "reduce CI cost / spend / minutes", optimize GitHub Actions triggers, matrices, runners, caches, artifacts |
 
 ## Vendoring model
 
@@ -71,20 +56,14 @@ core plus a thin repo-specific **overlay**:
 - **Overlay** &mdash; `overlay.md` beside the core holds madowaku paths, project
   names, and cross-references to other skills. Its frontmatter records the
   `core-pin` it was reviewed against.
-- **Portable core pending promotion** &mdash; `cswin32-interop` and `cswin32-com`
-  are generic cores reconciled here (with madowaku overlays) to be upstreamed to
-  the commons. They carry portfolio `metadata` but no `github-*` provenance and
-  use `core-pin: pending-promotion` until a separate change vendors them.
 - **Born-local** &mdash; `publish-release` is specific to madowaku's structure
   (the `KlutzyNinja.Madowaku` release-tag flow), carries no provenance, and is
   never upstreamed.
 
-All but one vendored core are pinned to the commons `v0.10.0` tag.
-`github-actions-cost-optimization` postdates that tag, so it is pinned to commit
-`85325db`; re-pin it to a release tag once the commons ships one that includes
-it. The [manage-skills](./manage-skills/SKILL.md) skill drives find / build /
-update, and [agent-files-review](./agent-files-review/SKILL.md) validates the
-resulting files.
+All 16 vendored cores are pinned to the commons `v0.11.0` tag. The
+[manage-skills](./manage-skills/SKILL.md) skill drives find / build / update,
+and [agent-files-review](./agent-files-review/SKILL.md) validates the resulting
+files.
 
 ## Disambiguation
 
@@ -96,8 +75,9 @@ Both touch CsWin32. They are mutually exclusive by **surface**:
   `HRESULT`/`BOOL`, platform and TFM guards, the `ComWrappers` polyfill, the
   public `PInvoke` owner/extender surface** &rarr; `cswin32-interop`.
 - **COM interfaces &mdash; `ComScope<T>`, `IComIID` (emitted on .NET 10 and
-  .NET Framework), `IID.Get<T>()`, manual struct-based interfaces (CLR hosting,
-  metadata, etc.), `delegate* unmanaged` vtables, `CoCreateInstance` /
+  .NET Framework), `IID.Get<T>()`, manual struct-based interfaces (Setup
+  Configuration, private / third-party APIs, etc.), `delegate* unmanaged`
+  vtables, `CoCreateInstance` /
   `CoGetClassObject`** &rarr; `cswin32-com`.
 
 If a change adds both a new P/Invoke and a new COM type, run

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -50,13 +50,13 @@ Skills are authored once as a portable **core** in the commons and shared from
 there. madowaku holds a pinned, provenance-stamped **copy** of each vendored
 core plus a thin repo-specific **overlay**:
 
-- **Vendored core** &mdash; the `SKILL.md` (and its sibling pages) carry
+- **Vendored core** — the `SKILL.md` (and its sibling pages) carry
   `metadata.github-*` provenance (source repo, ref, tree SHA). It is a mirror of
   upstream; **do not hand-edit it**, or `gh skill update` will flag the drift.
-- **Overlay** &mdash; `overlay.md` beside the core holds madowaku paths, project
+- **Overlay** — `overlay.md` beside the core holds madowaku paths, project
   names, and cross-references to other skills. Its frontmatter records the
   `core-pin` it was reviewed against.
-- **Born-local** &mdash; `publish-release` is specific to madowaku's structure
+- **Born-local** — `publish-release` is specific to madowaku's structure
   (the `KlutzyNinja.Madowaku` release-tag flow), carries no provenance, and is
   never upstreamed.
 
@@ -73,12 +73,12 @@ Both touch CsWin32. They are mutually exclusive by **surface**:
 
 - **P/Invoke functions, Win32 structs/enums/constants, `HANDLE`/`HMODULE`/
   `HRESULT`/`BOOL`, platform and TFM guards, the `ComWrappers` polyfill, the
-  public `PInvoke` owner/extender surface** &rarr; `cswin32-interop`.
-- **COM interfaces &mdash; `ComScope<T>`, `IComIID` (emitted on .NET 10 and
+  public `PInvoke` owner/extender surface** → `cswin32-interop`.
+- **COM interfaces — `ComScope<T>`, `IComIID` (emitted on .NET 10 and
   .NET Framework), `IID.Get<T>()`, manual struct-based interfaces (Setup
   Configuration, private / third-party APIs, etc.), `delegate* unmanaged`
   vtables, `CoCreateInstance` /
-  `CoGetClassObject`** &rarr; `cswin32-com`.
+  `CoGetClassObject`** → `cswin32-com`.
 
 If a change adds both a new P/Invoke and a new COM type, run
 `cswin32-interop` first to add the P/Invoke surface, then `cswin32-com`
@@ -86,43 +86,43 @@ for the COM activation and per-struct partial.
 
 ### PR and release workflows: `create-pr` vs `address-pr-feedback` vs `publish-release`
 
-- **Open a new PR for in-progress work** &rarr; `create-pr`.
+- **Open a new PR for in-progress work** → `create-pr`.
 - **Iterate on an existing PR** (review comments, Copilot feedback, CI fixes)
-  &rarr; `address-pr-feedback`.
-- **Cut a `KlutzyNinja.Madowaku` release tag** (a tag, not a PR) &rarr;
+  → `address-pr-feedback`.
+- **Cut a `KlutzyNinja.Madowaku` release tag** (a tag, not a PR) →
   `publish-release` (born-local). All three honor the same publish boundary in
   [AGENTS.md](../../AGENTS.md).
 
 ### Performance cluster
 
-- **Measure** (author / run a BenchmarkDotNet benchmark, read results) &rarr;
+- **Measure** (author / run a BenchmarkDotNet benchmark, read results) →
   `performance-testing`.
 - **Tune net472/net481 codegen** (specialization, unrolling, BCL delegation)
-  &rarr; `framework-jit-optimization`.
+  → `framework-jit-optimization`.
 - **Choose a scratch buffer** (`stackalloc` vs `ArrayPool` vs `BufferScope<T>`)
-  &rarr; `scratch-buffer-strategy`.
-- **Read IL for hidden struct copies or boxing** &rarr; `il-copy-inspection`.
+  → `scratch-buffer-strategy`.
+- **Read IL for hidden struct copies or boxing** → `il-copy-inspection`.
 
 ### Skill and agent-file meta: `manage-skills` vs `agent-files-review`
 
-- **Catalog lifecycle** (discover, add, vendor, sync a skill) &rarr;
+- **Catalog lifecycle** (discover, add, vendor, sync a skill) →
   `manage-skills`.
 - **Validate one agent file's syntax and conventions** (frontmatter, mirror,
-  whitespace) &rarr; `agent-files-review`.
+  whitespace) → `agent-files-review`.
 
 ### `engineering-baseline` vs `github-actions-cost-optimization`
 
 - **Whole-repo nine-domain audit** (foundation, build, test, publish,
-  versioning, CI, supply chain, governance, agent enablement) &rarr;
+  versioning, CI, supply chain, governance, agent enablement) →
   `engineering-baseline`.
-- **CI runner cost specifically** (minutes, matrices, caches, artifacts) &rarr;
+- **CI runner cost specifically** (minutes, matrices, caches, artifacts) →
   `github-actions-cost-optimization`.
 
 ## Maintenance
 
 Freshness is tracked from git history, not from a manual column. CI warns
 (does not fail) when a skill directory has no commits in the last 90 days
-&mdash; see
+— see
 [.github/workflows/agent-files.yml](../../.github/workflows/agent-files.yml).
 
 A stale warning means "re-read this skill end-to-end against the current
@@ -133,7 +133,7 @@ codebase." Confirm:
 3. Every claim about the codebase is still true.
 
 The only way to clear the warning is to commit a change to the skill
-directory &mdash; ideally the result of a real review pass, but at minimum
+directory — ideally the result of a real review pass, but at minimum
 a whitespace touch with a commit message stating "verified still current."
 
 When adding a new skill, append a row to the inventory above in the same

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/address-pr-feedback
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: ceb544da854ef7ba911679b8af8bca2631150ef9
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: remote-write
 name: address-pr-feedback
 ---
-
 # Address PR feedback
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: address-pr-feedback
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - address-pr-feedback
@@ -11,7 +11,7 @@ skill. The `SKILL.md` is a **pinned copy of the portable core** from
 `metadata.github-*` provenance in its frontmatter). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: agent-customization
     binding: optional-overlay
     github-path: skills/agent-files-review
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 64a00d548909d8f84fb8ac6f6e3db77deceab270
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: agent-files-review
 ---
-
 # Agent customization files - review checklist
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: agent-files-review
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - agent-files-review
@@ -12,7 +12,7 @@ portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku scaffold paths
 

--- a/.agents/skills/code-comprehension/SKILL.md
+++ b/.agents/skills/code-comprehension/SKILL.md
@@ -5,8 +5,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/code-comprehension
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: d2e1be7b63a31345f054a1d0785a67d5ba2aa604
     maturity: canary
@@ -16,7 +16,6 @@ metadata:
     risk: advisory
 name: code-comprehension
 ---
-
 # Code comprehension review
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/code-comprehension/overlay.md
+++ b/.agents/skills/code-comprehension/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: code-comprehension
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - code-comprehension
@@ -12,7 +12,7 @@ copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/create-pr
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: dcdd58e7cad32b4907ce6a8bf0fe6bf01cb14f59
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: remote-write
 name: create-pr
 ---
-
 # Create a pull request
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: create-pr
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - create-pr
@@ -12,7 +12,7 @@ core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku publish boundary
 

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -1,18 +1,22 @@
 ---
-name: cswin32-com
-description: 'Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across .NET 10 and .NET Framework, connection-point Advise/Unadvise ownership, caller-owned CCW references, manually defining COM interfaces not in Win32 metadata (WMI, Fusion, CLR hosting/metadata), COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.'
-license: MIT
 compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; Windows COM APIs across .NET 10 and .NET Framework. Cross-assembly extension-block examples require C# 14.
+description: Guides struct-based COM interop using CsWin32 - AOT-compatible raw pointer calls without [ComImport] or built-in CLR marshalling; managed [ComImport] mirrors are limited to CCW bridges. Consult when working with ComScope, IID.Get, delegate* unmanaged vtables, CoCreateInstance or a class factory, IComIID across .NET 10 and .NET Framework, connection-point Advise/Unadvise ownership, caller-owned CCW references, manually defining COM interfaces absent from Win32 metadata, COM pointer lifetime in fields, cross-assembly CCWs, or mocking struct-based COM in tests. Not for ordinary RCW-based COM consumption with no raw struct pointers or CCW bridge. Paired with the cswin32-interop skill for the general P/Invoke layer and blittable-signature rules.
+license: MIT
 metadata:
-  portability: portable
-  applicability: dotnet
-  binding: optional-overlay
-  risk: local-write
-  maturity: canary
-  requires: cswin32-interop
-  related: security-review, il-copy-inspection
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/cswin32-com
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 16f0e262ed5b4a11f90a91b70cb4b9ab473a3d1a
+    maturity: canary
+    portability: portable
+    related: security-review, il-copy-inspection
+    requires: cswin32-interop
+    risk: local-write
+name: cswin32-com
 ---
-
 # CsWin32 struct-based COM interop
 
 If `overlay.md` exists beside this file, read it before acting; it contains
@@ -43,8 +47,8 @@ NativeAOT path, while a `ComWrappers` implementation can be AOT-compatible.
 ## Workflow
 
 1. **In Win32 metadata?** If yes, add the interface name to `NativeMethods.txt`
-   and CsWin32 generates it. If not (WMI, Fusion, Setup Configuration, CLR
-   hosting / metadata), define a manual struct in its own file - see
+  and CsWin32 generates it. If not (for example, Setup Configuration or a
+  private / third-party interface), define a manual struct in its own file - see
    [manual-structs.md](manual-structs.md).
 2. **Lifetime:** `using ComScope<T> scope = new();` for every transient **owned**
    COM reference, and free every owned COM `BSTR` out-param (`SysFreeString` /

--- a/.agents/skills/cswin32-com/manual-structs.md
+++ b/.agents/skills/cswin32-com/manual-structs.md
@@ -1,30 +1,32 @@
 # Manual COM structs
 
-Detail for [cswin32-com](SKILL.md). For an interface not in Win32 metadata (WMI,
-Fusion, Setup Configuration, CLR hosting / metadata), hand-write a struct that
-lays out the vtable yourself. Put each interface in its own file. Include or
-exclude that file using the same platform and target-framework decisions as the
-paired interop skill; a cross-platform assembly may compile the declaration as
-long as reachable calls remain Windows-only.
+Detail for [cswin32-com](SKILL.md). For an interface not in Win32 metadata, such
+as Setup Configuration or a private / third-party interface, hand-write a struct
+that lays out the vtable yourself. Put each interface in its own file. Include
+or exclude that file using the same platform and target-framework decisions as
+the paired interop skill; a cross-platform assembly may compile the declaration
+as long as reachable calls remain Windows-only.
 
 ## Shape
 
+Replace the placeholder with the interface's exact IID.
+
 ```csharp
-internal unsafe struct IAssemblyCache : IComIID
+internal unsafe struct IPrivateService : IComIID
 {
-    public static readonly Guid IID_IAssemblyCache = new(0xE707DCDE, ...);
+  public static readonly Guid IID_IPrivateService = new("...");
 
 #if NET
     static ref readonly Guid IComIID.Guid
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => ref Unsafe.AsRef(in IID_IAssemblyCache);
+        get => ref Unsafe.AsRef(in IID_IPrivateService);
     }
 #else
     readonly ref readonly Guid IComIID.Guid
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => ref Unsafe.AsRef(in IID_IAssemblyCache);
+        get => ref Unsafe.AsRef(in IID_IPrivateService);
     }
 #endif
 
@@ -32,8 +34,8 @@ internal unsafe struct IAssemblyCache : IComIID
 
     public HRESULT QueryInterface(Guid* riid, void** ppvObject)
     {
-        fixed (IAssemblyCache* pThis = &this)
-            return ((delegate* unmanaged[Stdcall]<IAssemblyCache*, Guid*, void**, HRESULT>)
+          fixed (IPrivateService* pThis = &this)
+              return ((delegate* unmanaged[Stdcall]<IPrivateService*, Guid*, void**, HRESULT>)
                 _lpVtbl[0])(pThis, riid, ppvObject);
     }
     // AddRef @1, Release @2, then interface methods at their slot indices.
@@ -67,7 +69,9 @@ internal unsafe struct IAssemblyCache : IComIID
 - **Platform annotations may be type- or member-level.**
   `[SupportedOSPlatform]` is valid on structs. Apply it to the whole interface
   struct when every member has the same Windows contract, or to individual
-  methods when versions differ.
+  methods when versions differ. In dual-target source, place the attribute under
+  `#if NET` unless the .NET Framework target provides a compatible source
+  polyfill; .NET Framework reference assemblies do not define it.
 
 ## Strongly-typed handle and token wrappers
 

--- a/.agents/skills/cswin32-com/overlay.md
+++ b/.agents/skills/cswin32-com/overlay.md
@@ -1,16 +1,17 @@
 ---
 core: cswin32-com
-core-pin: pending-promotion
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - cswin32-com
 
 Repository-specific companion to the [cswin32-com](SKILL.md) core. The `SKILL.md`
-and its sibling pages are a **portable core** reconciled from madowaku's and
-dotnet/msbuild's CsWin32 skills, authored here so it can be promoted to the shared
-commons. It is **not yet vendored** - no `github-*` provenance, and `core-pin` is
-`pending-promotion` until the promotion change vendors it. Keep the core generic;
-madowaku specifics live here.
+and its sibling pages are a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift. Madowaku specifics live here.
+
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku uses 0.3.287+ IComIID generation
 
@@ -80,8 +81,8 @@ disposing the source pointer.
 
 ## Manual structs and CLS compliance
 
-- **Manual COM structs** for interfaces not in Win32 metadata (e.g. CLR
-  hosting / metadata such as `ICLRMetaHost`, `ICLRRuntimeInfo`) go in their own
+- **Manual COM structs** for interfaces not in Win32 metadata (for example,
+  Setup Configuration or private / third-party interfaces) go in their own
   files. A manual struct that must work on net472 spells out **both** `IComIID`
   arms itself (static-abstract under `#if NET`, instance under `#else`) - the
   generator attaches `IComIID` to *generated* structs, not manual ones.

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -1,18 +1,22 @@
 ---
-name: cswin32-interop
-description: 'Guides CsWin32 P/Invoke interop in a multi-targeted .NET 10 and .NET Framework library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, selecting compile-time / runtime / analyzer guards for Windows-only code, or choosing between CsWin32 and [LibraryImport]. Paired with the cswin32-com skill for the struct-based COM layer.'
-license: MIT
 compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; projects Windows APIs across .NET 10 and .NET Framework. Owner/extender composition requires C# 14.
+description: Guides CsWin32 P/Invoke interop in a multi-targeted .NET 10 and .NET Framework library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, selecting compile-time / runtime / analyzer guards for Windows-only code, or choosing between CsWin32 and [LibraryImport]. Not for managed-only changes with no native boundary. Paired with the cswin32-com skill for the struct-based COM layer.
+license: MIT
 metadata:
-  portability: portable
-  applicability: dotnet
-  binding: optional-overlay
-  risk: local-write
-  maturity: canary
-  requires: none
-  related: cswin32-com, dotnet-polyfills, scratch-buffer-strategy, security-review
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/cswin32-interop
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 14960bec081ff29eaa9bf5593b7a6ca9d5201ae8
+    maturity: canary
+    portability: portable
+    related: cswin32-com, dotnet-polyfills, scratch-buffer-strategy, security-review
+    requires: none
+    risk: local-write
+name: cswin32-interop
 ---
-
 # CsWin32 P/Invoke interop
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/cswin32-interop/gating.md
+++ b/.agents/skills/cswin32-interop/gating.md
@@ -59,6 +59,10 @@ suppressing it:
 - Use `#pragma warning disable CA1416` only as a narrow, justified last resort
   when a recognized guard or platform annotation cannot express the contract.
 
+The platform attributes are available on modern .NET but not in .NET Framework
+reference assemblies. In dual-target source, place them under `#if NET` unless
+the Framework target provides a compatible source polyfill.
+
 ## A stack-first scratch buffer
 
 Win32 string and buffer APIs often want caller-allocated storage followed by a

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -1,17 +1,17 @@
 ---
 core: cswin32-interop
-core-pin: pending-promotion
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - cswin32-interop
 
 Repository-specific companion to the [cswin32-interop](SKILL.md) core. The
-`SKILL.md` and its sibling pages are a **portable core** reconciled from
-madowaku's and dotnet/msbuild's CsWin32 skills, authored here so it can be
-promoted to the shared commons. It is **not yet vendored**, so it carries no
-`github-*` provenance and `core-pin` is `pending-promotion`; the promotion change
-will vendor it and add a real pin. Keep the core generic - everything
-madowaku-specific lives here.
+`SKILL.md` and its sibling pages are a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
+`gh skill update` would flag the drift. Everything madowaku-specific lives here.
+
+> **Pinned to the commons v0.11.0 tag.**
 
 ## Targeting model
 

--- a/.agents/skills/dotnet-polyfills/SKILL.md
+++ b/.agents/skills/dotnet-polyfills/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/dotnet-polyfills
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: ae0aa41d3c5c002298172ba4e5f7b24eb615d9db
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: dotnet-polyfills
 ---
-
 # .NET downlevel polyfills
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/dotnet-polyfills/overlay.md
+++ b/.agents/skills/dotnet-polyfills/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: dotnet-polyfills
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - dotnet-polyfills
@@ -12,7 +12,7 @@ portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/engineering-baseline/SKILL.md
+++ b/.agents/skills/engineering-baseline/SKILL.md
@@ -6,18 +6,17 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/engineering-baseline
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: a5b695d91108206c115e7915dfafc1b3c54d3ada
+    github-tree-sha: b0e52e484192142c2b3083ee181b4f7a5b61b0d6
     maturity: canary
     portability: portable
-    related: manage-skills, security-review, create-pr
+    related: manage-skills, security-review, create-pr, github-actions-cost-optimization
     requires: none
     risk: remote-write
 name: engineering-baseline
 ---
-
 # Engineering baseline
 
 If `overlay.md` exists beside this file, read it before acting; it contains
@@ -33,11 +32,12 @@ The standard in one paragraph: a high-quality .NET repository is **buildable**
 (centralized, deterministic, analyzer-enforced), **tested** (with coverage and,
 where it applies, perf and fuzz surfaces), **publishable** (signed, SourceLinked,
 validated packages with rich metadata), **released** deterministically from tags,
-**gated** by CI with least-privilege tokens and pinned actions, **secured** by
-branch protection, dependency updates, and scanning, **governed** by the OSS
-community files, and **agent-enabled** with vendored skills and the agent-file
-gates. The [baseline](baseline.md) is that standard as a checklist; the
-[citation catalog](references/best-practices.md) is the *why* behind every line.
+**gated** by cost-aware CI with least-privilege tokens and pinned actions,
+**secured** by branch protection, dependency updates, and scanning,
+**governed** by the OSS community files, and **agent-enabled** with vendored
+skills and the agent-file gates. The [baseline](baseline.md) is that standard as
+a checklist; the [citation catalog](references/best-practices.md) is the *why*
+behind every line.
 
 ## When to use
 
@@ -107,10 +107,12 @@ When in doubt, stop and ask one yes/no question.
 ## Related skills
 
 Run a security review over any code the scaffold generates or the assessment
-adds, and use the repository's PR skills to publish the result. The
-agent-enablement domain hands off to the skill-lifecycle skill and the fleet
-onboarding runbook for vendoring the skill tier and wiring the agent-file gates.
-A consuming repository wires these concrete cross-references in its overlay.
+adds, and use the repository's PR skills to publish the result. Hand detailed
+workflow usage, billing, and matrix analysis to the GitHub Actions cost
+optimization skill. The agent-enablement domain hands off to the skill-lifecycle
+skill and the fleet onboarding runbook for vendoring the skill tier and wiring
+the agent-file gates. A consuming repository wires these concrete
+cross-references in its overlay.
 
 ## Sub-pages
 

--- a/.agents/skills/engineering-baseline/assess.md
+++ b/.agents/skills/engineering-baseline/assess.md
@@ -21,6 +21,8 @@ Read the repository's actual state before judging it. Gather, read-only:
   shippable one, whether test / perf / fuzz / analyzer projects are present.
 - `.github/`: workflows, `dependabot.yml`, `CODEOWNERS`, issue/PR templates,
   rulesets, `copilot-instructions.md`.
+- CI topology: triggers, matrices, runners, required status names, repeated
+  setup, caches/artifacts, and whether one merged change causes duplicate runs.
 - Agent wiring: `AGENTS.md`, the skills location, the agent-file validator and
   its CI gate.
 - Remote settings you can read without admin: read them from the repository's
@@ -128,10 +130,13 @@ Batch related local fixes into coherent commits with clear messages. Do not
 commit or push unless the user asks - preparing the changes is authorized;
 publishing them is not.
 
-## 5. Hand off the security and agent domains
+## 5. Hand off specialized domains
 
 - For domain 7 findings on code that handles untrusted input, run the security
   review skill rather than judging vulnerability shapes here.
+- For domain 6 findings about runner choice, matrices, duplicate triggers,
+  storage, or estimated spend, run the GitHub Actions cost optimization skill.
+  This baseline establishes the required shape; that skill measures and tunes it.
 - For domain 9 (vendoring the skill tier, wiring the validator and link checker,
   the drift loop), hand off to the skill-lifecycle skill and the fleet
   onboarding runbook - this skill confirms the gate exists; those own the how.

--- a/.agents/skills/engineering-baseline/baseline.md
+++ b/.agents/skills/engineering-baseline/baseline.md
@@ -107,8 +107,12 @@ literals.
   (MSTest `[assembly: Parallelize(Workers = 0, Scope = MethodLevel)]`; xunit.v3
   unlimited parallel threads). Why: fast feedback, and it surfaces hidden test
   ordering or shared-state bugs early.
-- **(core)** Tests run in CI on every push and pull request, in Release. Why:
-  Release codegen and timing differ from Debug; gate what ships.
+- **(core)** Tests run in Release on every merge candidate. Run them again on a
+  default-branch push only when a direct or bypass update can avoid equivalent
+  pre-merge validation; a pull request with strict up-to-date checks or a merge
+  queue should not pay for an identical post-merge run. Why: Release codegen and
+  timing differ from Debug; gate what ships without duplicating the same
+  candidate.
 - **(core)** Code coverage collected and reported, with a gate on patch
   coverage (new/changed lines). Why: a patch gate holds new code to a bar
   without fighting noise in the whole-project number.
@@ -162,8 +166,11 @@ literals.
 
 ## 6. CI/CD
 
-- **(core)** A build-and-test workflow triggered on push and pull request to the
-  default branch. Why: the gate that keeps the default branch green.
+- **(core)** A build-and-test workflow triggered for every merge candidate and
+  available for manual diagnosis. Add a default-branch push trigger only when
+  branch rules permit an update that bypasses equivalent pre-merge validation;
+  include `merge_group` when a merge queue is available. Why: gate every path to
+  the default branch without automatically testing the same change twice.
 - **(core)** A least-privilege token: top-level `permissions: contents: read`,
   with any write scope granted per-job. Why: limits blast radius if a workflow
   step is compromised.
@@ -172,8 +179,18 @@ literals.
   malicious code; a SHA cannot.
 - **(core)** Concurrency control that cancels superseded in-flight runs for a
   pull request. Why: saves runner time and surfaces only the latest result.
+- **(core)** The automatic matrix contains the minimum load-bearing Release
+  gates; Debug and expensive platform/architecture breadth run through a named
+  manual, scheduled, or release workflow with a named owner and occasion or
+  cadence when delayed detection is acceptable. Why: preserve the support
+  contract without charging every pull request for every dimension.
+- **(core)** Each job uses the least expensive runner that is proven compatible;
+  native behavior still executes on its required operating system and
+  architecture. Why: lightweight scripts do not need premium runners, while
+  cross-compilation does not replace native execution.
 - **(conditional: restorable dependencies)** Dependency caching keyed on the
-  lock/props files. Why: cuts CI time without staleness when versions change.
+  lock/props files and pointed at the directory the tool actually uses. Why:
+  cuts CI time without staleness or a cache that never captures restored data.
 - **(core)** A stable aggregate status-check name that branch protection can
   require, even when the matrix underneath changes. Why: keeps the required
   check name from breaking when the build matrix is edited.
@@ -199,14 +216,19 @@ literals.
   deprecation, and listing checks, and a license allowlist) rather than tracking
   latest. Why: a freshly published version is the least-vetted and the usual
   vector for a compromised release.
-- **(core)** Static analysis / code scanning (for example CodeQL) on a schedule
-  and on pull requests. Why: catches injectable and memory-safety bug classes
-  before merge.
+- **(core)** Static analysis / code scanning (for example CodeQL) on pull
+  requests (and `merge_group` when used) and on a schedule, with code-scanning
+  results required by merge protection at documented thresholds. Moving it to
+  schedule-only is an accepted divergence only after documenting the
+  delayed-detection security tradeoff, cadence, and alert owner. Why: catches
+  injectable and memory-safety bug classes before merge by default.
 - **(core)** Secret scanning and push protection enabled. Why: stops credentials
   from entering history.
 - **(core)** Branch protection or a repository ruleset on the default branch:
-  require the status check, require pull requests, block force-push and deletion.
-  Why: prevents direct, unreviewed, or history-rewriting changes to main.
+  require the status and code-scanning checks, require pull requests with no
+  bypass, require branches up to date or a merge queue, and block force-push and
+  deletion. Why: prevents direct, unreviewed, stale-base, or history-rewriting
+  changes to main.
 - **(conditional: untrusted input) (deferred)** Address the
   [OWASP Top Ten](https://owasp.org/www-project-top-ten/) classes for any code
   that handles untrusted input or runs as a service - the security-review skill

--- a/.agents/skills/engineering-baseline/overlay.md
+++ b/.agents/skills/engineering-baseline/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: engineering-baseline
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - engineering-baseline
@@ -13,7 +13,7 @@ scaffolding tree are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/engineering-baseline/references/best-practices.md
+++ b/.agents/skills/engineering-baseline/references/best-practices.md
@@ -89,6 +89,10 @@ The cross-cutting standards the domain checks draw from.
 | Pin actions by full commit SHA | [Scorecard: Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies), [StepSecurity](https://github.com/step-security/harden-runner) | A tag is mutable and can be repointed at malicious code; a SHA cannot |
 | OIDC trusted publishing | [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing), [GitHub OIDC](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect) | Removes the standing long-lived secret that is the usual leak |
 | Concurrency and caching | [Concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency), [Caching](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) | Cancels superseded runs and cuts CI time |
+| Cost-aware topology and runner selection | [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing), [Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions), [hosted-runner specifications](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) | Each job has independent setup and billing granularity; current rates and visibility-specific hardware make runner and matrix choices materially different even when public-repository allowances hide invoice cost |
+| Measure workflow and job usage | [Actions usage metrics](https://docs.github.com/en/enterprise-cloud@latest/organizations/collaborating-with-groups-in-organizations/viewing-usage-metrics-for-github-actions) | Job runtime, runner type, queue time, and failure rate distinguish actual hot spots from guesses |
+| Manual extended validation | [Manually running workflows](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow) | Expensive breadth can remain available without charging every change, provided it has an explicit trigger and owner |
+| Test the merge candidate | [Required status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets#require-status-checks-to-pass-before-merging), [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) | Strict up-to-date checks or a merge queue prevent a green stale branch from merging as an untested combination |
 
 ## 7. Supply-chain and security
 
@@ -98,7 +102,7 @@ The cross-cutting standards the domain checks draw from.
 | A dependency-update tool | [Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates), [Renovate](https://docs.renovatebot.com/) | Out-of-date dependencies accrue known-vulnerable flaws |
 | Single trusted feed (source mapping) | [Package source mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping) | Blocks dependency-confusion across configured feeds |
 | Adopt only vetted, quarantined versions | [Renovate: minimumReleaseAge](https://docs.renovatebot.com/configuration-options/#minimumreleaseage), [OpenSSF Concise Guide](https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Concise-Guide-for-Developing-More-Secure-Software.md) | A freshly published version is least-vetted and the usual compromised-release vector |
-| Static analysis / code scanning | [CodeQL code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql), [Scorecard: SAST](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast) | Catches injectable and memory-safety bug classes before merge |
+| Static analysis / code scanning | [CodeQL code scanning](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql), [code-scanning merge protection](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/set-code-scanning-merge-protection), [Scorecard: SAST](https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast) | Catches injectable and memory-safety bug classes and blocks the merge while required analysis is absent, pending, or over threshold |
 | Secret scanning + push protection | [About secret scanning](https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning), [About push protection](https://docs.github.com/en/code-security/secret-scanning/introduction/about-push-protection) | Stops credentials from entering history |
 | `SECURITY.md` with private reporting | [GitHub: adding a security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository), [Scorecard: Security-Policy](https://github.com/ossf/scorecard/blob/main/docs/checks.md#security-policy) | Gives reporters a safe path; a Scorecard signal |
 | Dependency vulnerability auditing | [NuGet audit](https://learn.microsoft.com/en-us/nuget/concepts/auditing-packages) | Surfaces advisories against the restored graph at build time |
@@ -152,6 +156,17 @@ defects to flag.
 - **Coverage thresholds.** A strict whole-project gate is noisy on small or
   fast-moving repos; a patch gate on changed lines is the pragmatic default. The
   baseline requires *a* gate, not a specific number.
+- **Default-branch push validation.** A pull request with strict up-to-date
+  checks or a merge-queue ruleset with no bypass path validates the merge
+  candidate; repeating identical build/test work after merge is optional
+  confirmation. Keep the push trigger when administrators, automation, or direct
+  pushes can bypass equivalent pre-merge checks. Record the ruleset assumption
+  next to the workflow decision.
+- **Automatic matrix breadth.** Operating systems, architectures, target
+  frameworks, Debug builds, and Native AOT legs belong on every merge only when
+  they protect a merge-blocking invariant. It is reasonable to move lower-risk
+  breadth to a scheduled/manual or release workflow, but document the resulting
+  detection delay, cadence, and owner.
 - **Branch protection as code vs UI.** Classic branch protection is configured in
   the UI; [repository rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets)
   can be exported and version-controlled as JSON. Prefer as-code for

--- a/.agents/skills/engineering-baseline/scaffold.md
+++ b/.agents/skills/engineering-baseline/scaffold.md
@@ -54,9 +54,24 @@ pwsh /path/to/New-DotnetRepo.ps1 `
 The script produces: `global.json`, `Directory.Build.props/.targets`,
 `Directory.Packages.props` (CPM on), a `dotnet new`-generated project and test
 project, `.gitignore`/`.gitattributes`/`.editorconfig`, `README.md`, `LICENSE`,
-`.github/workflows/` (ci, publish, codeql), `dependabot.yml`, `SECURITY.md`,
-`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, issue/PR templates, and `AGENTS.md`
-with its generated Copilot mirror.
+`.github/workflows/` (automatic CI, manual Full CI, publish, CodeQL, and the
+agent mirror), `dependabot.yml`, `SECURITY.md`, `CODE_OF_CONDUCT.md`,
+`CONTRIBUTING.md`, issue/PR templates, and `AGENTS.md` with its generated Copilot
+mirror.
+
+The workflow defaults are cost-aware without weakening the merge gate. A pull
+request or merge group gets one Release build/test job: standard Linux for
+modern-only projects and Windows when a legacy target framework must compile
+there. Maintainers run the manually dispatched Full CI workflow before every
+release and after SDK or build-tool changes; it covers Debug and Release in one
+job. CodeQL runs on pull requests, merge groups, and a weekly schedule. For a
+private repository with GitHub Code Security, enable it before the first pull
+request and require CodeQL results in the ruleset. Without that entitlement,
+replace CodeQL with a supported scanner and require its status check instead.
+None of these workflows repeats automatically after a strictly protected merge.
+If the remote ruleset later permits direct or bypass pushes, restore
+default-branch push triggers in CI, CodeQL (or its replacement), and the agent
+mirror before relying on that path.
 
 It also standardizes output paths to a top-level `artifacts/` tree:
 
@@ -120,11 +135,13 @@ The script creates an `AGENTS.md` stub, generates its Copilot mirror
 an `agent-files.yml` workflow that fails if the mirror drifts from `AGENTS.md`,
 and vendors a pinned starting skill tier into `.agents/skills/` via `gh skill`
 (`manage-skills`, `agent-files-review`, `create-pr`, `address-pr-feedback`,
-`security-review` by default; override with `-Skills` / `-SkillsRef`). When
+and `security-review` by default; override with `-Skills` / `-SkillsRef`). When
 `gh skill` is unavailable it records the pinned install commands instead of
-failing. The broader agent-file gate (skill-frontmatter validation, link
-checking) and vendoring any domain skills remain a handoff to the skill-lifecycle
-skill and the fleet onboarding runbook - do not reinvent that pipeline here.
+failing. Vendor the GitHub Actions cost optimization skill when the repository
+needs a measured workflow audit beyond these defaults. The broader agent-file
+gate (skill-frontmatter validation, link checking) and vendoring any domain
+skills remain a handoff to the skill-lifecycle skill and the fleet onboarding
+runbook - do not reinvent that pipeline here.
 
 ## 7. Validate locally
 
@@ -146,9 +163,15 @@ publishing verb.** Do not run them silently:
 - Replace `<SHA>` placeholders in workflows (see step 3).
 - `gh repo create <owner>/<name> --public --source . --remote origin`
 - `git init && git add -A && git commit -m "Initial scaffold" && git push -u origin main`
-- Branch protection / ruleset on `main`: require the `build` status check,
-  require pull requests, block force-push and deletion. Emit the exact
-  `gh api` call or ruleset JSON for review.
+- For a private repository, enable GitHub Code Security before the first pull
+    request. If it is unavailable, replace CodeQL with a supported scanner.
+- Branch protection / ruleset on `main`: require `build`, strict up-to-date
+    branches or a merge queue, and either CodeQL code-scanning results at
+    documented thresholds or the replacement scanner's status check; require pull
+    requests with no bypass path; block force-push and deletion. If a bypass path
+    is required, restore default-branch push validation in CI, CodeQL or its
+    replacement, and the agent mirror first. Emit the exact `gh api` call or
+    ruleset JSON for review.
 - Enable secret scanning and push protection (GitHub repo Settings > Security).
 - Register the trusted-publishing policy on nuget.org before the first publish.
 

--- a/.agents/skills/engineering-baseline/scripts/New-DotnetRepo.ps1
+++ b/.agents/skills/engineering-baseline/scripts/New-DotnetRepo.ps1
@@ -88,7 +88,12 @@ param(
     [string] $FrameworkLegacy,
     [string] $License = 'MIT',
     [ValidateSet('mstest', 'xunit')] [string] $TestRunner = 'mstest',
-    [string[]] $Skills = @('manage-skills', 'agent-files-review', 'create-pr', 'address-pr-feedback', 'security-review'),
+    [string[]] $Skills = @(
+        'manage-skills',
+        'agent-files-review',
+        'create-pr',
+        'address-pr-feedback',
+        'security-review'),
     [string] $SkillsRef,
     [string] $SkillsRepo = 'JeremyKuhne/agent-skills'
 )
@@ -171,6 +176,7 @@ if ($SdkIsPrerelease) { Warn "host SDK $SdkVersion is a prerelease; global.json 
 
 $LegacyTfmLine     = if ($IsMultiTarget) { "`n    <LegacyTfm>$FrameworkLegacy</LegacyTfm>" } else { '' }
 $FrameworksDisplay = if ($IsMultiTarget) { "$Framework, $FrameworkLegacy" } else { $Framework }
+$CiRunner          = if ($IsMultiTarget) { 'windows-latest' } else { 'ubuntu-latest' }
 
 $installLines = if ($IsTool) {
     @('```shell', "dotnet tool install --global $PackageId", '```')
@@ -211,6 +217,7 @@ $tokens = @{
     DESCRIPTION        = $Description
     PACKAGE_ID         = $PackageId
     ARCHETYPE          = $Archetype
+    CI_RUNNER           = $CiRunner
     INSTALL_COMMAND    = $InstallCommand
     PACKAGE_VERSIONS   = $PackageVersionsXml
 }
@@ -613,14 +620,19 @@ Then, with explicit approval for each step, run:
      git branch -M main
      git push -u origin main
 
-  4. Branch protection (propose exact ruleset JSON or enable via GitHub web UI):
-     - Require status check:  build
-     - Require pull requests
-     - Block force-push and deletion
+  4. For a private repository, enable GitHub Code Security before the first pull
+     request. If it is unavailable, replace CodeQL with a supported scanner.
 
-  5. Enable secret scanning and push protection (GitHub repo Settings > Security).
+  5. Branch protection: require the build status check, branches up to date or a
+     merge queue, and either CodeQL code-scanning results at documented
+     thresholds or the replacement scanner's status check. Require pull requests
+     with no bypass path; block force-push and deletion. If a direct or bypass
+     push is required, restore default-branch push validation in ci.yml,
+     codeql.yml or its replacement, and agent-files.yml first.
 
-  6. Register trusted-publishing policy on nuget.org before the first publish:
+  6. Enable secret scanning and push protection (GitHub repo Settings > Security).
+
+  7. Register trusted-publishing policy on nuget.org before the first publish:
      Owner: $Owner  Repo: $Name  Workflow: publish.yml
      https://www.nuget.org/account/transform/trusted-publishers
 

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/agent-files.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/agent-files.yml.tmpl
@@ -1,22 +1,27 @@
 name: Agent files
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - AGENTS.md
+      - .github/copilot-instructions.md
+      - .github/workflows/agent-files.yml
+      - tools/Sync-AgentInstructions.ps1
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   mirror-check:
     name: copilot-instructions mirror
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@<SHA> # v6.0.3
 

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/codeql.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/codeql.yml.tmpl
@@ -1,21 +1,28 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
   schedule:
     - cron: '17 4 * * 1'   # weekly Monday scan
 
 permissions:
+  actions: read
   contents: read
   security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:
     name: analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@<SHA> # v6.0.3
       - uses: github/codeql-action/init@<SHA> # v4.36.2

--- a/.agents/skills/engineering-baseline/scripts/template/.github/workflows/full-ci.yml.tmpl
+++ b/.agents/skills/engineering-baseline/scripts/template/.github/workflows/full-ci.yml.tmpl
@@ -1,24 +1,21 @@
-name: CI
+name: Full CI
 
+# Maintainers run this before each release and after SDK or build-tool changes.
 on:
-  pull_request:
-    branches: [main]
-  merge_group:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
-    name: build
+    name: Debug and Release
     runs-on: {{CI_RUNNER}}
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@<SHA> # v6.0.3
         with:
@@ -34,7 +31,9 @@ jobs:
         # SDK version comes from global.json
 
       - run: dotnet restore --locked-mode
-      - run: dotnet build --configuration Release --no-restore
+      - run: dotnet build --configuration Debug --no-restore
       # The global.json MTP runner treats --no-build as a test-app argument and
       # exits 5 with zero tests. CI=true keeps this implicit restore locked.
+      - run: dotnet test --configuration Debug
+      - run: dotnet build --configuration Release --no-restore
       - run: dotnet test --configuration Release

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/framework-jit-optimization
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 1523bdc712c82636a88605ecf3f31b95308a0e39
+    github-tree-sha: 97120f8dc990d4af91d9dbfb1c191a48ecce48f1
     maturity: canary
     portability: portable
     related: performance-testing, scratch-buffer-strategy, pre-pr-self-review
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: framework-jit-optimization
 ---
-
 # .NET Framework 4.8.1 JIT optimization
 
 If `overlay.md` exists beside this file, read it before acting; it contains
@@ -80,7 +79,7 @@ beats a naive per-element loop for whole-buffer primitives.
 
 **Practical consequence:** do not assume "the BCL is vectorized so my generic code
 is fine." On `net481` a hand-written specialized loop frequently beats the BCL by
-2-3&times; for full-scan workloads.
+2-3× for full-scan workloads.
 
 ## Decision flow for a new framework-only fast path
 
@@ -121,17 +120,17 @@ a PR.
 
 | Decision | Net481 effect (length 4096, full scan) |
 | --- | --- |
-| `typeof(T)` specialization vs generic `IEquatable` loop | 1.42&times; faster |
-| `[AggressiveInlining]` on a tight scalar loop (length 16) | 1.82&times; &rarr; 1.07&times; vs baseline |
-| Unroll-4 indexed (`ptr[0..3]` + `ptr += 4`) | 1.5&times; faster than scalar |
-| Unroll-8 same form | **1.6&times; slower** than scalar at 256+ |
-| Per-iteration `*ptr; ptr++` instead of indexed reads | ~1.4&times; slower than indexed |
+| `typeof(T)` specialization vs generic `IEquatable` loop | 1.42× faster |
+| `[AggressiveInlining]` on a tight scalar loop (length 16) | 1.82× → 1.07× vs baseline |
+| Unroll-4 indexed (`ptr[0..3]` + `ptr += 4`) | 1.5× faster than scalar |
+| Unroll-8 same form | **1.6× slower** than scalar at 256+ |
+| Per-iteration `*ptr; ptr++` instead of indexed reads | ~1.4× slower than indexed |
 | Integer-indexed unroll (`ptr[i+0..3]; i += 4`) | **Worse than the scalar baseline** |
-| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5-3&times; slower** than branchful conditional store |
-| SWAR haszero for char `Replace` (dense matches) | **3&times; slower** than scalar |
-| BCL `IndexOf` for `Replace` (full-scan) | 2.18-3.08&times; slower than specialized scalar |
-| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2-3&times; **faster** than full-scan specialization |
-| Exponential `SequenceEqual` probe for `CommonPrefixLength` (4096, full match) | 3.3&times; faster than per-element scalar |
+| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5-3× slower** than branchful conditional store |
+| SWAR haszero for char `Replace` (dense matches) | **3× slower** than scalar |
+| BCL `IndexOf` for `Replace` (full-scan) | 2.18-3.08× slower than specialized scalar |
+| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2-3× **faster** than full-scan specialization |
+| Exponential `SequenceEqual` probe for `CommonPrefixLength` (4096, full match) | 3.3× faster than per-element scalar |
 | Tuple swap `(a, b) = (b, a)` for plain locals | **~23% slower** than `T t = a; a = b; b = t;` |
 | Tuple swap on paired `Span<T>` indexed swap (sort hot path) | **~9% slower** than explicit temps |
 | Tuple swap on a single `Span<T>` indexed swap or two `ref` locals | Equivalent (within noise) |

--- a/.agents/skills/framework-jit-optimization/antipatterns.md
+++ b/.agents/skills/framework-jit-optimization/antipatterns.md
@@ -14,7 +14,7 @@ your specific call pattern.
 The `net481` JIT does not lower the ternary into a `cmov` for `ushort` / `byte`
 stores. You get a guaranteed store every iteration regardless of whether the
 value changed. For a sparse-match `Replace` workload (the realistic case), the
-extra writes cost 1.5-3&times; vs the branchful form below.
+extra writes cost 1.5-3× vs the branchful form below.
 
 ```c#
 // GOOD on net481.
@@ -77,7 +77,7 @@ The bit-trick (`(x - Lo16) & ~x & Hi16`) adds a dependent-chain of 3 arithmetic
 ops per chunk, plus a load and an XOR, plus the broadcast computation. **Whenever
 any lane matches, the code falls through to the four scalar checks** - you
 pay the SWAR overhead **on top of** the mutation cost. On dense matches this
-regresses by 3&times;.
+regresses by 3×.
 
 The classic strchr-style SWAR optimization makes sense in C without true SIMD;
 on `net481` it does not pay back its overhead even for sparse data, because the
@@ -102,7 +102,7 @@ The attribute looks like a non-functional hint, but on `net481` it's load-bearin
 A small specialized loop that doesn't get inlined into its caller becomes a
 JIT-time call, defeating the entire `typeof(T)` specialization (because the
 caller now invokes a generic stub through a virtual dispatch mechanism the
-specialization was meant to elide). Measured: 1.82&times; &rarr; 1.07&times; on
+specialization was meant to elide). Measured: 1.82× → 1.07× on
 a tight scalar loop at length 16 just from adding the attribute back.
 
 If you really must remove it (e.g. method body becomes too large), measure

--- a/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
+++ b/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
@@ -23,8 +23,8 @@ slightly less aggressive unrolling lose to a hand-written `ushort*` /
 
 | Method | Realistic input | Win factor (length 4096) |
 | --- | --- | --- |
-| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18-3.08&times; faster than `IndexOf`-walking |
-| `IndexOfAnyExcept(T)` | typically scans most of the buffer (e.g. trim, parse) | 0.34&times; vs scalar = 3&times; faster |
+| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18-3.08× faster than `IndexOf`-walking |
+| `IndexOfAnyExcept(T)` | typically scans most of the buffer (e.g. trim, parse) | 0.34× vs scalar = 3× faster |
 
 These are the methods that already have `typeof(T)` specialization in the
 Framework-only tree.
@@ -56,9 +56,9 @@ Measured ratios vs a full-scan `ushort*` unroll-4 specialization on `net481`:
 
 | Match density (1 in N) | BCL `IndexOf`-walk vs specialized |
 | ---: | --- |
-| 1   | **9&times; slower** (specialization wins) |
-| 7   | 1.85&times; slower (specialization still wins) |
-| 64  | **0.45&times; slower** (BCL wins) |
+| 1   | **9× slower** (specialization wins) |
+| 7   | 1.85× slower (specialization still wins) |
+| 64  | **0.45× slower** (BCL wins) |
 
 Realistic `Count` calls are sparse (counting newlines in source, separators in a
 path, error markers in a log line). The BCL form is correct.
@@ -84,10 +84,10 @@ return length;
 ```
 
 `O(log n)` BCL calls instead of `O(n)` element compares. At length 4096 with a
-full match this beats any scalar loop by **3.3&times;** even on `net481`.
+full match this beats any scalar loop by **3.3×** even on `net481`.
 
 The early-divergence case (mismatch at index 8) is roughly tied with a scalar
-specialization - absolute saving is ~8 ns - not worth a 3.3&times;
+specialization - absolute saving is ~8 ns - not worth a 3.3×
 regression on the long-prefix case (path normalization, string interning,
 sorted-key compression are the realistic callers).
 

--- a/.agents/skills/framework-jit-optimization/overlay.md
+++ b/.agents/skills/framework-jit-optimization/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: framework-jit-optimization
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - framework-jit-optimization
@@ -12,7 +12,7 @@ pages are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/framework-jit-optimization/specialization.md
+++ b/.agents/skills/framework-jit-optimization/specialization.md
@@ -75,7 +75,7 @@ Always put this on the generic entry method when you specialize:
 - The `net481` JIT's default heuristics are conservative. Without the attribute,
   the wrapper method itself is a JIT-time call, defeating the whole point.
 - Measured impact on a tight scalar `ref T` loop at length 16:
-  `1.82&times; &rarr; 1.07&times;` vs the dedicated-overload baseline. The
+  `1.82× → 1.07×` vs the dedicated-overload baseline. The
   attribute is doing real work, not just hinting.
 
 The inlining attribute is also why we don't need separate `extension(Span<char>)`
@@ -109,7 +109,7 @@ ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
 Without the mask, `[AggressiveInlining]` plus a literal signed argument
 (`(sbyte)-1`, `(short)-1`) on net481 RyuJIT produces wrong results in
 **Release** (Debug passes). The caller's int-promoted constant
-(`-1` &rarr; `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
+(`-1` → `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
 loop's `cmp` immediate as a 32-bit value. The `movzx`-loaded byte is in
 `[0, 0xFF]`, so `cmp ecx, 0FFFFFFFF` is unconditionally false - the loop
 runs, finds nothing, returns silently.

--- a/.agents/skills/framework-jit-optimization/unrolling.md
+++ b/.agents/skills/framework-jit-optimization/unrolling.md
@@ -56,7 +56,7 @@ if (*ptr == oldShort) *ptr = newShort; ptr++;
 ```
 
 Every load now depends on the previous `ptr++`. The JIT does not recover the
-parallelism by recognizing the pattern. Measured: 0.84&times; vs 1.12&times;
+parallelism by recognizing the pattern. Measured: 0.84× vs 1.12×
 ratio at length 256 on `net481` - the `ptr++` form is actually slower
 than the un-unrolled scalar baseline.
 
@@ -75,7 +75,7 @@ for (int i = 0; i < unrollEnd; i += 4)
 
 The `net481` JIT does not hoist the `ptr + i` calculation. Each `ptr[i + k]`
 becomes `lea` + `mov`. **Worse than the scalar baseline at length 4096
-(1.22&times;).** Always advance the pointer instead.
+(1.22×).** Always advance the pointer instead.
 
 ### Unroll-by-8
 
@@ -89,7 +89,7 @@ while (ptr < unrollEnd)
 }
 ```
 
-Wins at length 16 (small loop, fewer iterations). **Regresses 1.3-1.6&times;
+Wins at length 16 (small loop, fewer iterations). **Regresses 1.3-1.6×
 at length 256+** on `net481`. Most likely the larger method body trips a
 register-allocation or loop-alignment threshold. The .NET 10 JIT recovers but
 `net481` does not.

--- a/.agents/skills/github-actions-cost-optimization/SKILL.md
+++ b/.agents/skills/github-actions-cost-optimization/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/github-actions-cost-optimization
-    github-pinned: 85325dbeb5d5c3e9be39b9f7725a25d971b77d8a
-    github-ref: 85325dbeb5d5c3e9be39b9f7725a25d971b77d8a
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 1fac6778d86ec0879641e2b593e881f49b43c648
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: github-actions-cost-optimization
 ---
-
 # GitHub Actions cost optimization
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/github-actions-cost-optimization/overlay.md
+++ b/.agents/skills/github-actions-cost-optimization/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: github-actions-cost-optimization
-core-pin: 85325dbeb5d5c3e9be39b9f7725a25d971b77d8a
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - github-actions-cost-optimization
@@ -12,10 +12,7 @@ sibling pages are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to an unreleased commit.** This skill postdates the commons `v0.10.0`
-> tag, so `core-pin` is the commit SHA
-> `85325dbeb5d5c3e9be39b9f7725a25d971b77d8a` rather than a release tag. Re-pin to
-> a tag once the commons ships one that includes this skill.
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 
@@ -41,5 +38,4 @@ sibling pages are a **pinned copy of the portable core** from
 ## Updating
 
 Pull upstream changes with `gh skill update github-actions-cost-optimization`
-(review the diff, re-pin `core-pin`) - ideally re-pinning to a release tag once
-one includes this skill.
+(review the diff, re-pin `core-pin`).

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/il-copy-inspection
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 07bce64dc12f798aeeec01aab716d26bbde5c0ed
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: advisory
 name: il-copy-inspection
 ---
-
 # Inspecting IL for struct copies
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/il-copy-inspection/overlay.md
+++ b/.agents/skills/il-copy-inspection/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: il-copy-inspection
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - il-copy-inspection
@@ -12,7 +12,7 @@ copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 
@@ -20,8 +20,9 @@ copy of the portable core** from
   large mutable structs passed by value at the COM boundary - `VARIANT`,
   `SAFEARRAY`, `ComScope<T>`, `BSTR`, `PWSTR` - where a hidden defensive copy or
   a box silently costs allocations and correctness.
-- **Read IL on both targets.** A copy the modern-.NET JIT elides can persist on
-  the `net481` RyuJIT; inspect the framework build too.
+- **Read IL on both targets** to compare copies emitted by the C# compiler. To
+  determine whether the net481 RyuJIT retains or elides an emitted copy, inspect
+  machine code with `DisassemblyDiagnoser`; IL alone cannot answer that.
 - **Pair a finding with a benchmark** in
   [madowaku.perf](../../../madowaku.perf/madowaku.perf.csproj) before reshaping a
   hot type.
@@ -30,6 +31,8 @@ copy of the portable core** from
 
 - [`cswin32-com`](../cswin32-com/SKILL.md) - the struct-based COM interop that
   produces most of madowaku's copy-sensitive types.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) - the
+  machine-code layer that determines whether a JIT retained an emitted copy.
 - [`performance-testing`](../performance-testing/SKILL.md) - the harness that
   quantifies the copy or box the IL reveals.
 

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/manage-skills
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: bb78d07296156a84ee9f54023145532a5275607a
+    github-tree-sha: 5b881e8d4c0a1d5e9bdf3d48cb91d515088e44d2
     maturity: canary
     portability: portable
     related: agent-files-review
@@ -17,7 +17,6 @@ metadata:
     risk: remote-write
 name: manage-skills
 ---
-
 # Manage skills
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/manage-skills/overlay.md
+++ b/.agents/skills/manage-skills/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: manage-skills
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - manage-skills
@@ -13,26 +13,23 @@ bundled `scripts/Validate-Skills.ps1`, and `assets/overlay.md.tmpl` are a
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 
-- **The commons is `JeremyKuhne/agent-skills`; madowaku pins to `v0.10.0`**
-  (the one exception is `github-actions-cost-optimization`, which postdates that
-  tag and is pinned to a commit SHA - see its overlay).
+- **The commons is `JeremyKuhne/agent-skills`; madowaku pins all vendored cores
+  to `v0.11.0`.**
 - **The catalog is** [.agents/skills/README.md](../README.md); add or update its
   inventory row and disambiguation in the same change as any vendor, tweak, or
   new skill.
 - **Born-local (never upstreamed):**
   [`publish-release`](../publish-release/SKILL.md) is specific to madowaku's
   structure and carries no `github-*` provenance; leave it out of the commons.
-- **Portable cores pending promotion:**
+- **CsWin32 domain cores:**
   [`cswin32-interop`](../cswin32-interop/SKILL.md) and
-  [`cswin32-com`](../cswin32-com/SKILL.md) are generic cores reconciled from
-  madowaku's and dotnet/msbuild's CsWin32 skills, each with a madowaku
-  `overlay.md`. They carry portfolio `metadata` but no provenance yet
-  (`core-pin: pending-promotion`); a separate change upstreams them to the
-  commons and re-vendors them here with a pin.
+  [`cswin32-com`](../cswin32-com/SKILL.md) are now vendored commons cores with
+  madowaku overlays. The COM core declares the interop core as a hard
+  dependency; install and update them at the same pin.
 - **Frontmatter validation**: run the bundled
   [scripts/Validate-Skills.ps1](scripts/Validate-Skills.ps1) on a skill
   directory. The repo's own agent-file checks live in

--- a/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
+++ b/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
@@ -18,6 +18,8 @@
       - compatibility: if present, a string <= 500 chars.
       - yaml: inline scalar values carry no unquoted ':' (a mapping indicator that
         a strict parser, like the strictyaml skills-ref uses, would reject).
+      - readability: Markdown files contain no HTML entities; direct Unicode and
+        plain words remain valid.
       - length: SKILL.md is at most 500 lines (the spec's progressive-disclosure
         recommendation, "Keep your main SKILL.md under 500 lines").
 
@@ -450,6 +452,18 @@ function Test-SkillDir ([string] $dir) {
     $metadata = if ($fm.Contains('metadata')) { $fm['metadata'] } else { $null }
     Test-PortfolioMetadata $metadata $raw $dir $RequirePortfolioMetadata.IsPresent |
         ForEach-Object { $errors.Add($_) }
+
+    $htmlEntityRegex = [regex]::new('&(?:#[0-9]+|#[xX][0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9]+);', [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    foreach ($markdownFile in Get-ChildItem -LiteralPath $dir -Recurse -File -Filter '*.md') {
+        [int] $lineNumber = 0
+        foreach ($line in Get-Content -LiteralPath $markdownFile.FullName) {
+            $lineNumber++
+            foreach ($match in $htmlEntityRegex.Matches($line)) {
+                [string] $relativePath = [System.IO.Path]::GetRelativePath($dir, $markdownFile.FullName)
+                $errors.Add("$relativePath`:$lineNumber contains HTML entity '$($match.Value)'; write the character directly or use plain words.")
+            }
+        }
+    }
 
     $lineCount = Measure-SkillLineCount $raw
     if ($lineCount -gt $MaxSkillLines) {

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: dotnet-project-gated
     binding: optional-overlay
     github-path: skills/performance-testing
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 5a20e5995ee9e6d6d6a24131e1522f0084761e79
+    github-tree-sha: 9cdddfa386a045ddc14a9799126929da23341e89
     maturity: canary
     portability: portable
     related: framework-jit-optimization, scratch-buffer-strategy, pre-pr-self-review
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: performance-testing
 ---
-
 # Performance testing with BenchmarkDotNet
 
 If `overlay.md` exists beside this file, read it before acting; it contains
@@ -142,6 +141,9 @@ inspection.
   method, the interactive picker, and useful switches.
 - [interpreting-results.md](interpreting-results.md) - before/after discipline on
   both TFMs and reading the memory columns.
+- [investigation-workflow.md](investigation-workflow.md) - fresh-state phase
+   measurement versus profiling, experiment ledgers, exact-source oracles, and
+   reconstructable run provenance for multi-step investigations.
 - [reading-codegen.md](reading-codegen.md) - seeing the C# lowering, IL, and JIT
   asm behind a number: sharplab, `[DisassemblyDiagnoser]`, `[HardwareCounters]`,
   the `DOTNET_JitDisasm*` knobs, and the tiering/PGO inspection traps.

--- a/.agents/skills/performance-testing/investigation-workflow.md
+++ b/.agents/skills/performance-testing/investigation-workflow.md
@@ -1,0 +1,191 @@
+# Reproducible performance investigations
+
+Detail for the [performance-testing](SKILL.md) skill. Use this workflow when a
+performance question spans multiple phases, compares an external implementation,
+iterates through several candidate optimizations, or must remain reproducible from
+a dirty worktree.
+
+For a simple A/B benchmark over one pure operation, use [authoring.md](authoring.md),
+[running.md](running.md), and [interpreting-results.md](interpreting-results.md)
+directly. Do not add phase harnesses or source bundles when the ordinary benchmark
+already answers the question.
+
+The expected outputs are a trustworthy benchmark or profile, a compact experiment
+ledger, and enough source and run provenance to reconstruct any result that is kept.
+Creating those local artifacts does not authorize committing, uploading, or
+publishing them.
+
+## Measure phases with fresh state
+
+A mutable or consumable intermediate representation cannot be reused across
+measurements. Reuse can make a later phase observe already-mutated state, shared
+arrays, warmed caches, or an object graph that no longer represents a fresh
+operation.
+
+For phase latency:
+
+1. Prepare a bounded batch of fresh inputs in `[IterationSetup]`.
+2. Consume every item exactly once in the `[Benchmark]` method.
+3. Set `OperationsPerInvoke` to the number of items consumed so BenchmarkDotNet
+   reports per-operation time and allocation.
+4. Release the batch in `[IterationCleanup]` so one iteration's live set does not
+   leak into the next.
+5. Run separate configurations for one item, an intermediate batch, and a larger
+   batch. Keep `OperationsPerInvoke` accurate for each configuration.
+
+The one-item run exposes timer and harness overhead. The larger run exposes
+retained-live-set and GC distortion. Keep the smallest batch that amortizes the
+harness without changing the workload's allocation or latency shape.
+
+A consumable-state benchmark may need one invocation per iteration. BenchmarkDotNet
+can then warn that the minimum iteration time was not reached. Document why the
+invocation count must remain one; do not silence the warning by consuming the same
+state repeatedly.
+
+### Use a different harness for CPU profiling
+
+The one-shot measurement harness is often too sparse for a useful periodic CPU
+profile. Prefer an adaptive end-to-end benchmark that BenchmarkDotNet can repeat,
+then use the repository's trace analyzer to scope the profile to the phase method.
+Work before that phase call remains outside the selected subtree while the repeated
+end-to-end operation supplies enough observations.
+
+Profile the one-shot harness only when the selected phase query has enough
+contributing records under the analyzer's sample-quality contract. A whole-trace
+sample count does not establish quality for a narrow phase.
+
+Before trusting a decomposition, compare it with an independently measured
+end-to-end operation:
+
+- phase allocations should add to the end-to-end allocation at the report's
+  precision;
+- phase means should approximately add to the end-to-end mean;
+- each phase should receive fresh, semantically equivalent state.
+
+A large gap usually means setup leaked into a measurement, state was reused, or
+the batch changed GC and live-set behavior.
+
+## Keep an experiment ledger
+
+Start the ledger before the first edit and add one row per candidate. Record
+rejected variants as carefully as retained ones.
+
+| Hypothesis | Small edit | Discriminating check | Time | Allocation | Target frame | Decision |
+| --- | --- | --- | ---: | ---: | --- | --- |
+| Example claim | One-variable change | Same filtered benchmark | Result | Result | Before -> after | Keep or reject, with reason |
+
+Change one material variable at a time. Use the same scenario, filter, target
+framework, job, and profiler scope before and after. Preserve both target
+frameworks when the production code serves both. A rejection is useful evidence:
+it prevents a later investigation from retrying an attractive idea that already
+lost on throughput, allocation, another runtime, or the intended target frame.
+
+The final report should explain why the retained implementation beat at least the
+most plausible alternative, not merely state that the retained row was faster than
+the original baseline.
+
+## Compare an exact-source oracle
+
+When the baseline lives in another repository or revision, compare against exact
+source rather than an unpinned package or a mutable checkout:
+
+1. Create a clean detached checkout at an exact commit SHA.
+2. Build it in Release with the subject repository's pinned SDK. Record the SDK
+   version and any compatibility override.
+3. Verify the built assembly's informational version and configuration when that
+   metadata is available, and retain its SHA-256 hash.
+4. Isolate namespace and type collisions with an `extern alias` rather than
+   renaming either implementation.
+5. Make the oracle reference opt-in. Set an environment variable whose name is
+   also an optional MSBuild property before launching BenchmarkDotNet; the
+   generated child build inherits the environment, while an outer `/p:` argument
+   alone may not reach that child build.
+6. Include the oracle reference and benchmark methods only when that property is
+   present. An ordinary build must contain neither.
+7. Validate semantic parity before measuring: equivalent inputs, outputs,
+   exceptions, options, and fresh mutable state for every operation.
+8. Remove the temporary checkout after the retained artifacts record its commit
+   and assembly hash.
+
+Do not assume a parsed model or decoded object graph can be reused safely. Prove
+that repeated materialization is independent, or reconstruct the intermediate
+state per operation. Shared mutable arrays or caches can make an oracle appear
+faster while changing the work being measured.
+
+As a build check, inspect the generated BenchmarkDotNet child project for an
+opt-in run and confirm that it contains the exact oracle reference. Then build
+without the environment property and confirm that no oracle reference or
+oracle-only benchmark method remains.
+
+## Preserve a reconstructable run
+
+Give every retained run a unique directory or output stem, for example:
+
+```text
+<subject>-<phase>-<variant>-<tfm>-<job>-<timestamp>
+```
+
+Retain the compact report and raw result, exact command line, non-secret
+environment settings, runtime and JIT identity, OS and architecture, base commit,
+clean/dirty state, experiment-ledger row, and any trace manifest. Keep separate
+run directories so a later BenchmarkDotNet invocation cannot overwrite the
+baseline used in a claim.
+
+### Dirty-source bundle contract
+
+A commit SHA plus hashes is insufficient when tracked, untracked, binary, or
+ignored inputs affected the run. For a dirty worktree, retain one of these:
+
+- a complete source snapshot; or
+- a base commit plus all of the following reconstruction artifacts.
+
+The reconstruction artifacts are:
+
+1. A binary-capable full-index patch of every tracked difference from the recorded
+   base commit, including staged and unstaged changes. Store that commit in
+   `$baseCommit`, then use `git diff --binary --full-index $baseCommit --` so the
+   patch and restore point cannot disagree.
+2. An archive containing the bytes of every relevant untracked or ignored source,
+   generated input, and benchmark data file, stored at its repository-relative
+   path. Build the archive from an explicit allowlist after reviewing each file
+   for credentials, signing material, personal data, proprietary inputs, and
+   unrelated local configuration. Include required file metadata when it affects
+   the build or run.
+3. A manifest containing the base commit, repository-relative path, tracked /
+   untracked / ignored classification, byte length, and SHA-256 hash for every
+   archived input, plus hashes of the patch and archive themselves. Record who or
+   what performed the allowlist review and list any non-secret external
+   provisioning requirements.
+4. The exact restore procedure: detach the base commit, apply the binary patch,
+   extract the archive at the repository root, and verify the manifest hashes.
+
+Hashes prove integrity; they do not replace missing content. Never archive a file
+merely because it is ignored or untracked. Do not archive credentials, signing
+material, package caches, unrelated build output, or data whose redistribution is
+not authorized. When a secret influences setup, record a non-secret provisioning
+requirement rather than the secret. If the run cannot be reconstructed without
+retaining sensitive bytes, do not publish or share the bundle; keep the result
+local or redesign the input so a safe equivalent can be retained.
+
+For a result that will support a durable claim, test the restore procedure in a
+temporary clean checkout before discarding the original worktree. The restored
+checkout must reproduce the recorded source hashes and include every build or
+benchmark input that was not obtainable from the base commit.
+
+## Acceptance checks
+
+The workflow is complete when all applicable checks pass:
+
+- A consumable parse/materialize split uses fresh-state batches for measurement
+  and an adaptive end-to-end path for profiling unless the one-shot phase has
+  enough query-level evidence.
+- The ledger preserves rejected variants and explains the final decision.
+- An opt-in BenchmarkDotNet child build references the assembly built from the
+   recorded oracle commit and hash, semantic-parity checks pass on fresh state, and
+   an ordinary build has no oracle surface.
+- A clean checkout plus the retained dirty-source bundle reconstructs and verifies
+   every source and input byte needed for the run; its explicit allowlist contains
+   no secret, unauthorized, or unrelated content.
+- The retained command, non-secret environment, runtime/JIT, OS/architecture,
+   target framework, job, and profiler scope identify the execution environment
+   closely enough to rerun the same experiment.

--- a/.agents/skills/performance-testing/overlay.md
+++ b/.agents/skills/performance-testing/overlay.md
@@ -1,19 +1,19 @@
 ---
 core: performance-testing
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - performance-testing
 
 Repository-specific companion to the vendored [performance-testing](SKILL.md)
 skill. The `SKILL.md` and its sibling pages (`authoring.md`, `running.md`,
-`interpreting-requests.md`, `interpreting-results.md`, `reading-codegen.md`) are
-a **pinned copy of the portable core** from
+`interpreting-requests.md`, `interpreting-results.md`, `reading-codegen.md`,
+`investigation-workflow.md`) are a **pinned copy of the portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift. Everything madowaku-specific lives here.
 
-> **Pinned to the commons v0.10.0 tag.** Pull later upstream changes with
+> **Pinned to the commons v0.11.0 tag.** Pull later upstream changes with
 > `gh skill update performance-testing`, review the diff, then re-pin `core-pin`.
 
 ## Concrete bindings for the core's placeholders
@@ -48,6 +48,19 @@ dotnet run -c Release -f net481 --project madowaku.perf -- --filter *VariantConv
 
 `-c Release` is mandatory. Compare both TFMs before claiming a win, since the
 net481 and modern-.NET JITs differ significantly.
+
+## Reproducible investigations
+
+Use [investigation-workflow.md](investigation-workflow.md) when a performance
+question spans phases, compares an exact external source revision, evaluates
+multiple candidates, or must preserve a dirty-worktree experiment. Keep its
+ledger and reconstruction artifacts local unless the user explicitly approves
+publishing them and the source bundle contains no secret or unauthorized data.
+
+Madowaku does not currently vendor a repository-specific trace-analyzer skill.
+Use BenchmarkDotNet diagnosers and [reading-codegen.md](reading-codegen.md) for
+local drill-down. Do not claim source-line profile evidence without first wiring
+and validating an appropriate trace tool.
 
 ## madowaku specifics
 

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/pre-pr-self-review
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 880e117910c69bb909f59a3dfea81cbbf33ac047
+    github-tree-sha: c172ca7a01a7368bb4fee88b4d0b756442d38976
     maturity: canary
     portability: portable
     related: create-pr, address-pr-feedback, security-review, performance-testing
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: pre-pr-self-review
 ---
-
 # Pre-PR self-review
 
 If `overlay.md` exists beside this file, read it before acting; it contains
@@ -110,7 +109,7 @@ patterns in a `polyfill-correctness` overlay companion):
 - Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT)
   and are measured or explicitly marked unmeasured.
 
-If the change is not in the Framework-only tree, skip to &sect;3.
+If the change is not in the Framework-only tree, skip to section 3.
 
 ## 3. PR description matches reality
 

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: pre-pr-self-review
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - pre-pr-self-review
@@ -11,7 +11,7 @@ skill. The `SKILL.md` is a **pinned copy of the portable core** from
 `metadata.github-*` provenance in its frontmatter). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku recurring mistakes to self-check
 

--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -25,44 +25,44 @@ existing tag through `workflow_dispatch` after a transient or authentication
 failure. [publish.yml](../../../.github/workflows/publish.yml) validates the tag
 against a SemVer-with-`v`-prefix regex as its first step, so a malformed tag such
 as `v.0.1.0-alpha.3` fails fast before any pack/push. The `v*.*.*` trigger glob
-is *not* the guard &mdash; it matches the stray dot too; the validation step is
+is *not* the guard — it matches the stray dot too; the validation step is
 what stops a typo. See the "Tag-format guard" section in
 [versioning.md](versioning.md).
 
 **Approval scope.** "Publish a release" authorizes preparing the tag and
 release notes. It does **not** authorize the tag push. The
 **Approval checkpoint** below is the gate. See
-[AGENTS.md](../../../AGENTS.md) &sect; "Working with the user on changes" for
+[AGENTS.md](../../../AGENTS.md) section "Working with the user on changes" for
 the canonical rule.
 
 ## Steps overview
 
 1. **Inspect repo state** (below).
-2. Establish the prior version &mdash; see [versioning.md](versioning.md).
-3. Decide the prerelease channel (alpha / beta / rc / stable) &mdash; [versioning.md](versioning.md).
-4. Decide `Major.Minor.Patch` and check the `AssemblyVersion` gotcha &mdash; [versioning.md](versioning.md).
-5. Compose and validate the tag &mdash; [versioning.md](versioning.md).
-6. **Approval checkpoint** (below) &mdash; stop and wait for an explicit publish verb.
-7. Create and push the tag, then watch the workflow &mdash; see [release-steps.md](release-steps.md).
-8. Create the GitHub release from the notes template &mdash; [release-steps.md](release-steps.md).
-9. Aftercare &mdash; [release-steps.md](release-steps.md).
+2. Establish the prior version — see [versioning.md](versioning.md).
+3. Decide the prerelease channel (alpha / beta / rc / stable) — [versioning.md](versioning.md).
+4. Decide `Major.Minor.Patch` and check the `AssemblyVersion` gotcha — [versioning.md](versioning.md).
+5. Compose and validate the tag — [versioning.md](versioning.md).
+6. **Approval checkpoint** (below) — stop and wait for an explicit publish verb.
+7. Create and push the tag, then watch the workflow — see [release-steps.md](release-steps.md).
+8. Create the GitHub release from the notes template — [release-steps.md](release-steps.md).
+9. Aftercare — [release-steps.md](release-steps.md).
 
 ## 1. Inspect repo state
 
 Read-only checks:
 
-- `git remote -v` &mdash; confirm `origin` points at `JeremyKuhne/madowaku`
+- `git remote -v` — confirm `origin` points at `JeremyKuhne/madowaku`
   (the push target).
-- `git rev-parse --abbrev-ref HEAD` &mdash; must be `main` or a release branch.
+- `git rev-parse --abbrev-ref HEAD` — must be `main` or a release branch.
   Refuse to tag from an arbitrary feature branch unless the user explicitly
   says so.
-- `git status --porcelain` &mdash; must be clean. If dirty, stop and ask.
-- `git log origin/main..HEAD` and `git log HEAD..origin/main` &mdash; must both
+- `git status --porcelain` — must be clean. If dirty, stop and ask.
+- `git log origin/main..HEAD` and `git log HEAD..origin/main` — must both
   be empty. The tag must point at the published `origin/main` tip (or whatever
   the user confirmed in the previous bullet).
 
 There is only one package, so no "which package" prompt is needed. Then work
-through steps 2&ndash;5 in [versioning.md](versioning.md) to land on a
+through steps 2–5 in [versioning.md](versioning.md) to land on a
 validated tag.
 
 ## Approval checkpoint
@@ -70,7 +70,7 @@ validated tag.
 **Stop here.** Show the user:
 
 - The chosen tag (e.g. `v0.1.0-alpha.4`).
-- The prior tag and what bumped (e.g. "alpha.3 &rarr; alpha.4, no Major/Minor
+- The prior tag and what bumped (e.g. "alpha.3 → alpha.4, no Major/Minor
   change").
 - The commit the tag will point at (`git rev-parse HEAD`, short SHA + subject).
 - A short summary of the changes since the prior tag
@@ -79,7 +79,7 @@ validated tag.
 
 Wait for an explicit publishing verb (`tag`, `push the tag`, `ship it`,
 `publish`). Do **not** infer approval from the original "publish a release"
-request &mdash; that authorized the *preparation*, not the push. See
+request — that authorized the *preparation*, not the push. See
 [AGENTS.md](../../../AGENTS.md).
 
 After approval, follow [release-steps.md](release-steps.md) to push the tag,
@@ -87,18 +87,18 @@ watch the workflow, and create the GitHub release.
 
 ## Sub-pages
 
-- [versioning.md](versioning.md) &mdash; establishing the prior version, the
+- [versioning.md](versioning.md) — establishing the prior version, the
   prerelease channel decision, the `Major.Minor.Patch` bump table, the
   `AssemblyVersion` gotcha, the exact tag format, and the tag-format guard.
-- [release-steps.md](release-steps.md) &mdash; creating and pushing the
+- [release-steps.md](release-steps.md) — creating and pushing the
   annotated tag, `workflow_dispatch` recovery, the GitHub release notes
   template, and aftercare.
 
 ## Cross-references
 
-- [AGENTS.md](../../../AGENTS.md) &sect; "Working with the user on changes"
-  &mdash; the publish-boundary rule governing the approval checkpoint.
-- [madowaku/madowaku.csproj](../../../madowaku/madowaku.csproj) &mdash; MinVer
+- [AGENTS.md](../../../AGENTS.md) section "Working with the user on changes"
+  — the publish-boundary rule governing the approval checkpoint.
+- [madowaku/madowaku.csproj](../../../madowaku/madowaku.csproj) — MinVer
   wiring and package metadata.
 - [.github/workflows/publish.yml](../../../.github/workflows/publish.yml)
-  &mdash; the publish pipeline itself.
+  — the publish pipeline itself.

--- a/.agents/skills/publish-release/release-steps.md
+++ b/.agents/skills/publish-release/release-steps.md
@@ -12,7 +12,7 @@ git tag -a v0.1.0-alpha.4 -m "v0.1.0-alpha.4"
 git push origin v0.1.0-alpha.4
 ```
 
-Do **not** use lightweight tags &mdash; annotated tags carry the tagger and
+Do **not** use lightweight tags — annotated tags carry the tagger and
 date that show up in GitHub releases.
 
 Pushing the tag triggers the publish workflow. Watch the run:
@@ -28,19 +28,19 @@ nuget.org is bound to owner `JeremyKuhne`, repository `madowaku`, and workflow
 file `publish.yml` (the filename only, not `.github/workflows/publish.yml`), with
 the optional environment left blank. The action's required `user` input is the
 NuGet profile name `JeremyKuhne`, not an email address. Only
-`KlutzyNinja.Madowaku` packs &mdash; the test and perf projects set
+`KlutzyNinja.Madowaku` packs — the test and perf projects set
 `<IsPackable>false</IsPackable>`, so they produce no package.
 
 > **The tag format is guarded.** [publish.yml](../../../.github/workflows/publish.yml)
 > validates the tag against the SemVer-with-`v`-prefix regex (and rejects
 > non-tag refs) before packing, so a malformed tag like `v.0.1.0-alpha.3`
 > fails fast instead of silently publishing a MinVer height fallback. Still
-> confirm the published version on nuget.org matches what you intended &mdash;
+> confirm the published version on nuget.org matches what you intended —
 > the guard catches *malformed*, not *wrong-but-well-formed*. See the
 > "Tag-format guard" section in [versioning.md](versioning.md).
 
 If the workflow fails, treat it like any CI failure: do **not** delete and
-re-push the tag without explicit user approval &mdash; that's destructive and
+re-push the tag without explicit user approval — that's destructive and
 the nuget.org publish is irreversible. Fix forward with the next tag in the
 stream.
 
@@ -72,7 +72,7 @@ gh release create v0.1.0-alpha.4 `
 ```
 
 If `gh` is not available or not authenticated, use the GitHub web UI
-(Releases &rarr; Draft a new release &rarr; choose the existing tag), or the
+(Releases → Draft a new release → choose the existing tag), or the
 GitHub MCP tools.
 
 ### Release notes template
@@ -121,13 +121,13 @@ Notes on the template:
 
 ## 3. Aftercare
 
-- This package is not dog-fooded by another project in the repo &mdash; the
+- This package is not dog-fooded by another project in the repo — the
   test and perf projects reference it by project reference, and
   [Directory.Packages.props](../../../Directory.Packages.props) pins
   *dependencies* (Touki, CsWin32, etc.), not `KlutzyNinja.Madowaku` itself. So
   there is no consumer version to bump after a release.
 - If you bumped `Major` (binary break), make sure the release notes call out
-  the `AssemblyVersion` move (`0.0.0.0` &rarr; `1.0.0.0`) so downstream
+  the `AssemblyVersion` move (`0.0.0.0` → `1.0.0.0`) so downstream
   binders know to rebuild.
 - The README's NuGet badge tracks nuget.org automatically; no manual edit is
   needed after publishing.

--- a/.agents/skills/publish-release/versioning.md
+++ b/.agents/skills/publish-release/versioning.md
@@ -21,11 +21,11 @@ but choosing a duplicate is almost always a mistake):
 Record the prior version (e.g. `0.1.0-alpha.3`).
 
 > **Watch the tag list for the historical `v.` typo.** The most recent tag in
-> this repo at the time of writing is `v.0.1.0-alpha.3` &mdash; note the stray
+> this repo at the time of writing is `v.0.1.0-alpha.3` — note the stray
 > `.` after `v`. MinVer (prefix `v`) cannot parse it, so it is **silently
 > ignored** for versioning. When establishing the prior version, take the
 > newest tag that is *well-formed* (here `v0.1.0-alpha.2`), not merely the
-> newest tag. The publish workflow now rejects such tags &mdash; see the
+> newest tag. The publish workflow now rejects such tags — see the
 > "Tag-format guard" section in section 4.
 
 ## 2. Decide the prerelease channel (alpha / beta / rc / stable)
@@ -40,24 +40,24 @@ Present these options (however your agent surface asks the user a multiple-
 choice question), and mark the option matching the prior channel as the
 recommended default:
 
-- `Stay in alpha` &mdash; bug fixes / additive work during early development.
-- `Promote to beta` &mdash; feature-complete for the upcoming Minor; only
+- `Stay in alpha` — bug fixes / additive work during early development.
+- `Promote to beta` — feature-complete for the upcoming Minor; only
   stabilization work expected.
-- `Promote to rc` &mdash; release candidate; only blocker bug fixes.
-- `Promote to stable` &mdash; drop the prerelease label entirely.
-- `Use a different label` &mdash; free-form.
+- `Promote to rc` — release candidate; only blocker bug fixes.
+- `Promote to stable` — drop the prerelease label entirely.
+- `Use a different label` — free-form.
 
 Channel rules of thumb:
 
-- Don't *skip* channels casually. `alpha` &rarr; `beta` &rarr; `rc` &rarr;
-  `stable` is the normal path. Going `alpha` &rarr; `stable` is allowed but
+- Don't *skip* channels casually. `alpha` → `beta` → `rc` →
+  `stable` is the normal path. Going `alpha` → `stable` is allowed but
   should be deliberate.
 - Once you ship a stable `Major.Minor.Patch`, the next prerelease must
-  bump *something* (`0.1.0` &rarr; `0.1.1-alpha.1` or `0.2.0-alpha.1`); you
+  bump *something* (`0.1.0` → `0.1.1-alpha.1` or `0.2.0-alpha.1`); you
   cannot ship `0.1.0-alpha.2` after `0.1.0` stable.
 - Do **not** mix channels backwards (no going from `beta` back to `alpha`
   for the same Major.Minor.Patch). If a beta turned out to need more
-  churn, bump the underlying version: `0.2.0-beta.3` &rarr; `0.3.0-alpha.1`.
+  churn, bump the underlying version: `0.2.0-beta.3` → `0.3.0-alpha.1`.
 
 ## 3. Decide `Major.Minor.Patch`
 
@@ -77,10 +77,10 @@ underlying `Major.Minor.Patch` portion.
 For pre-1.0, the user may treat **Major** and **Minor** as both "Minor"
 during alpha/beta. That is fine; just confirm the call out loud:
 
-> "This change adds a public type but you're still in 0.1.x alpha &mdash; bump
+> "This change adds a public type but you're still in 0.1.x alpha — bump
 > to 0.2.0-alpha.1 (treating it as Minor) or stay at 0.1.0-alpha.4?"
 
-### When `AssemblyVersion` changes &mdash; and why it matters
+### When `AssemblyVersion` changes — and why it matters
 
 MinVer's defaults (used as-is in this repo, no overrides) produce:
 
@@ -97,16 +97,16 @@ Only a **Major** bump changes `AssemblyVersion`. That has real consequences:
   stricter, and `madowaku.dll` is strong-named
   (`klutzyninja.snk`, see [madowaku/madowaku.csproj](../../../madowaku/madowaku.csproj)).
 - A change in `Version`/`FileVersion` *without* `AssemblyVersion` changing
-  is binary-compatible &mdash; consumers can drop the new DLL into an existing
+  is binary-compatible — consumers can drop the new DLL into an existing
   bin folder and it just works.
 
 **Therefore:** any binary breaking change *must* bump `Major`, even during
-0.x. Refusing to bump `Major` on a binary break &mdash; to "stay at 0.1.x"
-&mdash; silently keeps `AssemblyVersion = 0.0.0.0` across an incompatible
+0.x. Refusing to bump `Major` on a binary break — to "stay at 0.1.x"
+— silently keeps `AssemblyVersion = 0.0.0.0` across an incompatible
 boundary, which is a real foot-gun for downstream binders.
 
 When `Major` does bump, also note in the release that `AssemblyVersion`
-moved (`0.0.0.0` &rarr; `1.0.0.0`).
+moved (`0.0.0.0` → `1.0.0.0`).
 
 ## 4. Compose the tag
 
@@ -128,15 +128,15 @@ Examples (good):
 - `v0.2.0`
 - `v1.0.0-rc.1`
 
-Examples (malformed &mdash; do not create):
+Examples (malformed — do not create):
 
-- `v.0.1.0-alpha.4` &mdash; stray `.` after `v`. This is the exact defect in
+- `v.0.1.0-alpha.4` — stray `.` after `v`. This is the exact defect in
   the existing `v.0.1.0-alpha.3` tag; do not recreate it.
-- `0.1.0-alpha.4` &mdash; missing `v` prefix (MinVer's prefix is `v`).
-- `v0.1.0.alpha.4` &mdash; `.` instead of `-` before prerelease.
-- `v0.1` &mdash; missing patch component (the workflow glob `v*.*.*` requires
+- `0.1.0-alpha.4` — missing `v` prefix (MinVer's prefix is `v`).
+- `v0.1.0.alpha.4` — `.` instead of `-` before prerelease.
+- `v0.1` — missing patch component (the workflow glob `v*.*.*` requires
   three dot-separated segments).
-- `v01.02.03` &mdash; leading zeros in numeric identifiers.
+- `v01.02.03` — leading zeros in numeric identifiers.
 
 A well-formed tag matches this SemVer-with-`v`-prefix shape:
 
@@ -150,13 +150,13 @@ madowaku's [publish.yml](../../../.github/workflows/publish.yml) runs a
 **Validate tag format** step as the first thing in the publish job, before
 checkout. It rejects the run (fails fast, before any pack/push) when:
 
-- The ref is not a tag (`github.ref` must start with `refs/tags/`) &mdash; this
+- The ref is not a tag (`github.ref` must start with `refs/tags/`) — this
   catches a `workflow_dispatch` accidentally launched from `main` or a branch,
   which would otherwise make MinVer compute a `*.<height>` fallback and publish
   a wrong version.
 - The tag name does not match the SemVer-with-`v`-prefix regex above.
 
-The trigger glob (`tags: ['v*.*.*']`) is *not* the guard &mdash; `*` matches a
+The trigger glob (`tags: ['v*.*.*']`) is *not* the guard — `*` matches a
 stray dot, so a typo'd tag such as `v.0.1.0-alpha.3` still starts the workflow.
 The validation step is what actually stops it: that tag fails the regex and the
 job throws before packing.
@@ -164,7 +164,7 @@ job throws before packing.
 Even with the guard in place:
 
 - Still triple-check the tag string against the good examples above before
-  pushing &mdash; the guard prevents a *malformed* publish, not a *wrong but
+  pushing — the guard prevents a *malformed* publish, not a *wrong but
   well-formed* one (e.g. tagging `v0.2.0` when you meant `v0.1.1`).
 - After the workflow runs, confirm the published version on nuget.org matches
   the version you intended.

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/scratch-buffer-strategy
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 3ae67f801e33d4b55730633f22e27c0fa941ea99
     maturity: canary
@@ -17,7 +17,6 @@ metadata:
     risk: advisory
 name: scratch-buffer-strategy
 ---
-
 # Scratch buffer strategy (net481 + net10)
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/scratch-buffer-strategy/overlay.md
+++ b/.agents/skills/scratch-buffer-strategy/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: scratch-buffer-strategy
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - scratch-buffer-strategy
@@ -12,7 +12,7 @@ core** from [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skil
 (see the `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/security-review
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.11.0
+    github-ref: refs/tags/v0.11.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: b5f145ccbc662182f38554418b5c8b7057c16baa
+    github-tree-sha: 883a99623b74cd6f5bfc2e0706b71a1513d1c62f
     maturity: canary
     portability: portable
     related: pre-pr-self-review, performance-testing, fuzz-testing
@@ -17,7 +17,6 @@ metadata:
     risk: local-write
 name: security-review
 ---
-
 # Security review
 
 If `overlay.md` exists beside this file, read it before acting; it contains

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -6,15 +6,15 @@ or *unchecked precondition* could push the code into the failure mode, not
 whether it currently does.
 
 The largest category - `unsafe` / `Unsafe.*` / `MemoryMarshal.*` and other
-caller-validated APIs (&sect;7) - lives in [unsafe-apis.md](unsafe-apis.md).
+caller-validated APIs (section 7) - lives in [unsafe-apis.md](unsafe-apis.md).
 
 When attention is limited, allocate it by tier:
 
-- **Critical (never skip):** &sect;1, &sect;4, [unsafe-apis.md](unsafe-apis.md).
-- **Standard (every member):** &sect;2, &sect;5, &sect;9.
-- **Conditional (when the code shape matches):** &sect;3 (allocates
-  proportional to input), &sect;6 (encoder uses in-band sentinels),
-  &sect;8 (path-handling API).
+- **Critical (never skip):** sections 1 and 4, [unsafe-apis.md](unsafe-apis.md).
+- **Standard (every member):** sections 2, 5, and 9.
+- **Conditional (when the code shape matches):** section 3 (allocates
+  proportional to input), section 6 (encoder uses in-band sentinels),
+  section 8 (path-handling API).
 
 ## 1. Length / size of inputs
 
@@ -47,7 +47,7 @@ outside. Specialized fast paths often bypass the affected code
 ## 3. Allocation pressure / memory DoS
 
 - Does work allocate proportional to (or worse than) input size?
-- Is the worst case bounded by an explicit cap (&sect;1) or only by
+- Is the worst case bounded by an explicit cap (section 1) or only by
   available memory?
 - Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
   per call (acceptable if bounded), or grow without limit (red flag)?
@@ -64,7 +64,7 @@ allocation count.
   alternation) that retries every wildcard on mismatch. Safe shape:
   **fixed savepoint slots** (each new wildcard overwrites the
   previous slot of the same kind), bounding the worst case to
-  O(n&middot;m).
+  O(n * m).
 - Hashtable attacks: are user-controlled keys hashed with a
   randomized hash (modern .NET `string.GetHashCode()` and
   `Dictionary<,>` are per-process randomized), or a deterministic one

--- a/.agents/skills/security-review/overlay.md
+++ b/.agents/skills/security-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: security-review
-core-pin: v0.10.0
+core-pin: v0.11.0
 ---
 
 # madowaku overlay - security-review
@@ -12,7 +12,7 @@ The `SKILL.md` and its sibling pages (`checklist.md`, `principles.md`,
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.10.0 tag.**
+> **Pinned to the commons v0.11.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/security-review/unsafe-apis.md
+++ b/.agents/skills/security-review/unsafe-apis.md
@@ -1,6 +1,6 @@
 # Caller-validated APIs (`unsafe`, `Unsafe.*`, `MemoryMarshal.*`)
 
-Detail for &sect;7 of the [security-review](SKILL.md) audit
+Detail for section 7 of the [security-review](SKILL.md) audit
 [checklist.md](checklist.md). Mandatory whenever a PR touches one of these.
 The compiler offloads safety to you; the review *is* the safety check.
 
@@ -23,7 +23,7 @@ Walk every use site against this table; rows are independent.
 | `Unsafe.As<TFrom, TTo>(ref TFrom)` / `Unsafe.As<T>(object)` | `sizeof(TTo) <= sizeof(TFrom)`; GC reference layout matches. | Reads garbage past source; corrupts GC heap if reference layout differs. **Older-JIT pitfall:** on .NET Framework RyuJIT, an `[AggressiveInlining]` method that reinterprets a signed-primitive parameter via `Unsafe.As<T, byte>(ref param)` can propagate the caller's int-promoted negative value into the comparison immediate; mask explicitly. | One test per primitive width including signed/negative values; mask with `& 0xFF` / `& 0xFFFF` if needed. |
 | `Unsafe.SkipInit<T>(out T)` | Caller fully initializes every reachable field before any read. | Stale-pointer foot-gun for ref fields; uninitialized read otherwise. | Test every code path that reads from the skip-init local. |
 | `MemoryMarshal.Cast<TFrom, TTo>` / `AsBytes` | Result length is `source.Length * sizeof(TFrom) / sizeof(TTo)`; partial elements vanish silently. | Caller treats a truncated result as the full payload. | Partial-element case (source length doesn't divide evenly). |
-| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime &le; referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
+| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime <= referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
 | `fixed (T* p = ...)` | `p` valid only inside the `fixed` block. | Dangling pointer after GC relocates. | Manual review: `p` not stashed in a field, passed to `async`/iterator continuations, or returned. |
 | `stackalloc T[n]` | `n` small and bounded. | Stack-overflow DoS if `n` comes from input. | Max-allowed size succeeds; one element more is rejected before `stackalloc` runs. Use a pooled / growable scratch-buffer helper when the input could exceed the stack budget. |
 | `[DllImport]` / `LibraryImport` | Marshaller attrs (`[MarshalAs]`, `SizeConst`, `string` vs `IntPtr`) silently change buffer sizes / ownership. | Buffer overrun, double-free, type confusion across the managed/native boundary. | Cross-check signature against native docs; re-verify on every TFM. |


### PR DESCRIPTION
## Summary

- re-vendor all 16 applicable commons cores from `JeremyKuhne/agent-skills` v0.11.0 with canonical provenance and matching overlay pins
- convert `cswin32-interop`, `cswin32-com`, and `github-actions-cost-optimization` to normal release-pinned cores
- include v0.11's reproducible performance investigation workflow and engineering baseline full-CI template
- update madowaku's catalog and local bindings while keeping project-gated `fuzz-testing` and `roslyn-analyzers` unvendored
- make the born-local `publish-release` skill compatible with v0.11's stricter readable-source validation

## Validation

- `dotnet test -c Debug` (515 passed)
- `dotnet test -c Release` (515 passed)
- `pwsh tools/Validate-AgentFiles.ps1`
- all 17 local skills pass repository validation
- all 16 vendored cores pass strict portfolio validation and `skills-ref@0.1.5`
- vendored bodies, sibling files, provenance, and tree SHAs match the immutable `v0.11.0` tag
- Markdownlint passes across all 81 agent Markdown files
- skill and catalog links resolve
- pre-PR reviewer found no blocking issues
- `git diff --check` passes