### PR TITLE
Add HGLOBAL native-memory helpers and Span.CopyToNative

### DIFF
--- a/madowaku.tests/Madowaku/SpanExtensionsTests.cs
+++ b/madowaku.tests/Madowaku/SpanExtensionsTests.cs
@@ -1,0 +1,238 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.System.Memory;
+
+namespace Madowaku;
+
+[TestClass]
+public unsafe class SpanExtensionsTests
+{
+    [TestMethod]
+    public void CopyToNative_ReadOnlySpan_NoNullTerminate_CopiesData()
+    {
+        int[] data = [1, 2, 3, 4, 5];
+        HGLOBAL global = ((ReadOnlySpan<int>)data).CopyToNative();
+
+        try
+        {
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, data.Length);
+                result.ToArray().Should().Equal(data);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_ReadOnlySpan_NullTerminate_AddsDefaultValue()
+    {
+        int[] data = [1, 2, 3];
+        HGLOBAL global = ((ReadOnlySpan<int>)data).CopyToNative(nullTerminate: true);
+
+        try
+        {
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, data.Length + 1);
+                result[..data.Length].ToArray().Should().Equal(data);
+                result[^1].Should().Be(0);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_Span_NoNullTerminate_CopiesData()
+    {
+        int[] data = [10, 20, 30];
+        Span<int> span = data;
+        HGLOBAL global = span.CopyToNative();
+
+        try
+        {
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, data.Length);
+                result.ToArray().Should().Equal(data);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_EmptySpan_NullTerminate_AllocatesTerminatorOnly()
+    {
+        ReadOnlySpan<int> span = default;
+        HGLOBAL global = span.CopyToNative(nullTerminate: true);
+
+        try
+        {
+            global.IsNull.Should().BeFalse();
+
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, 1);
+                result[0].Should().Be(0);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_ReadOnlySpan_ToExistingHGLOBAL_CopiesData()
+    {
+        int[] data = [1, 2, 3, 4];
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, (nuint)(data.Length * sizeof(int)));
+
+        try
+        {
+            ((ReadOnlySpan<int>)data).CopyToNative(global);
+
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, data.Length);
+                result.ToArray().Should().Equal(data);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_ReadOnlySpan_ToExistingHGLOBAL_NullTerminate_AddsDefaultValue()
+    {
+        int[] data = [1, 2, 3];
+        HGLOBAL global = PInvoke.GlobalAlloc(
+            GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE,
+            (nuint)((data.Length + 1) * sizeof(int)));
+
+        try
+        {
+            ((ReadOnlySpan<int>)data).CopyToNative(global, nullTerminate: true);
+
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, data.Length + 1);
+                result[..data.Length].ToArray().Should().Equal(data);
+                result[^1].Should().Be(0);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_Span_ToExistingHGLOBAL_CopiesData()
+    {
+        int[] data = [5, 6, 7];
+        Span<int> span = data;
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, (nuint)(data.Length * sizeof(int)));
+
+        try
+        {
+            span.CopyToNative(global);
+
+            void* memory = PInvoke.GlobalLock(global);
+            try
+            {
+                Span<int> result = new(memory, data.Length);
+                result.ToArray().Should().Equal(data);
+            }
+            finally
+            {
+                PInvoke.GlobalUnlock(global);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_ToExistingHGLOBAL_DestinationTooSmall_ThrowsArgumentException()
+    {
+        int[] data = [1, 2, 3];
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            FluentActions.Invoking(() => ((ReadOnlySpan<int>)data).CopyToNative(global))
+                .Should().Throw<ArgumentException>();
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void CopyToNative_ToExistingHGLOBAL_DestinationTooSmallForNullTerminator_ThrowsArgumentException()
+    {
+        int[] data = [1, 2, 3];
+        HGLOBAL global = PInvoke.GlobalAlloc(
+            GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE,
+            (nuint)(data.Length * sizeof(int)));
+
+        try
+        {
+            FluentActions.Invoking(() => ((ReadOnlySpan<int>)data).CopyToNative(global, nullTerminate: true))
+                .Should().Throw<ArgumentException>();
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+}

--- a/madowaku.tests/Windows/Win32/Foundation/HGLOBALTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HGLOBALTests.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.ComponentModel;
+using Windows.Win32.System.Memory;
+
+namespace Windows.Win32.Foundation;
+
+[TestClass]
+public unsafe class HGLOBALTests
+{
+    [TestMethod]
+    public void Size_ValidHandle_ReturnsAllocatedSize()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int) * 4);
+
+        try
+        {
+            global.Size.Should().Be((nuint)(sizeof(int) * 4));
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void Size_NullHandle_ReturnsZero()
+    {
+        HGLOBAL global = default;
+
+        global.Size.Should().Be((nuint)0);
+    }
+
+    [TestMethod]
+    public void IsValid_ValidHandle_ReturnsTrue()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            global.IsValid.Should().BeTrue();
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void IsValid_NullHandle_ReturnsFalse()
+    {
+        HGLOBAL global = default;
+
+        global.IsValid.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Lock_ValidHandle_ReturnsNonNullMemory()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            using HGLOBAL.LockScope scope = global.Lock();
+            nint scopePointer = (nint)(void*)scope;
+            nint memoryPointer = (nint)scope.Memory;
+            scopePointer.Should().NotBe(0);
+            memoryPointer.Should().Be(scopePointer);
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void Lock_WrittenData_IsReadableThroughScope()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            using (HGLOBAL.LockScope scope = global.Lock())
+            {
+                *(int*)(void*)scope = 42;
+            }
+
+            using (HGLOBAL.LockScope scope = global.Lock())
+            {
+                (*(int*)(void*)scope).Should().Be(42);
+            }
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void Lock_MultipleNestedLocks_IncrementsLockCount()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            using HGLOBAL.LockScope outer = global.Lock();
+            using HGLOBAL.LockScope inner = global.Lock();
+
+            nint outerPointer = (nint)(void*)outer;
+            nint innerPointer = (nint)(void*)inner;
+            outerPointer.Should().NotBe(0);
+            innerPointer.Should().NotBe(0);
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void Lock_InvalidHandle_ThrowsWin32Exception()
+    {
+        HGLOBAL global = default;
+
+        FluentActions.Invoking(() => global.Lock())
+            .Should().Throw<Win32Exception>();
+    }
+
+    [TestMethod]
+    public void Dispose_CalledMultipleTimes_DoesNotThrow()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            HGLOBAL.LockScope scope = global.Lock();
+            scope.Dispose();
+            scope.Dispose();
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+
+    [TestMethod]
+    public void Dispose_UnlocksMemory_AllowsGlobalFree()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        HGLOBAL.LockScope scope = global.Lock();
+        scope.Dispose();
+
+        PInvoke.GlobalFree(global).IsNull.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ImplicitConversion_ToVoidPointer_MatchesMemoryProperty()
+    {
+        HGLOBAL global = PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, sizeof(int));
+
+        try
+        {
+            using HGLOBAL.LockScope scope = global.Lock();
+            void* converted = scope;
+            nint convertedPointer = (nint)converted;
+            nint memoryPointer = (nint)scope.Memory;
+            convertedPointer.Should().Be(memoryPointer);
+        }
+        finally
+        {
+            PInvoke.GlobalFree(global);
+        }
+    }
+}

--- a/madowaku/NativeMethods.txt
+++ b/madowaku/NativeMethods.txt
@@ -17,6 +17,16 @@ GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS
 GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT
 GetModuleHandleEx
 GetProcAddress
+GlobalAlloc
+GlobalFlags
+GlobalFree
+GlobalHandle
+GlobalLock
+GlobalMemoryStatus
+GlobalReAlloc
+GlobalSize
+GlobalUnlock
+GMEM_INVALID_HANDLE
 HRESULT
 IClassFactory
 IClassFactory2

--- a/madowaku/NativeMethods.txt
+++ b/madowaku/NativeMethods.txt
@@ -20,9 +20,7 @@ GetProcAddress
 GlobalAlloc
 GlobalFlags
 GlobalFree
-GlobalHandle
 GlobalLock
-GlobalMemoryStatus
 GlobalReAlloc
 GlobalSize
 GlobalUnlock

--- a/madowaku/SpanExtensions.cs
+++ b/madowaku/SpanExtensions.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32;
+using Windows.Win32.System.Memory;
+
+namespace Madowaku;
+
+/// <summary>
+///  Native helpers for span types.
+/// </summary>
+public static unsafe class SpanExtensions
+{
+    extension<T>(ReadOnlySpan<T> span) where T : unmanaged
+    {
+        /// <summary>
+        ///  Copies the contents of the span to newly allocated global (native) memory.
+        /// </summary>
+        /// <param name="nullTerminate">
+        ///  <see langword="true"/> to allocate room for and write an additional default
+        ///  <typeparamref name="T"/> value as a null terminator after the copied data.
+        /// </param>
+        /// <param name="flags">
+        ///  The flags to pass to <see cref="PInvoke.GlobalAlloc(GLOBAL_ALLOC_FLAGS, nuint)"/>.
+        /// </param>
+        /// <returns>
+        ///  A handle to the allocated global memory containing a copy of the span's data.
+        /// </returns>
+        /// <exception cref="System.ComponentModel.Win32Exception">
+        ///  Thrown if the native allocation, lock, or unlock operation fails.
+        /// </exception>
+        public HGLOBAL CopyToNative(
+            bool nullTerminate = false,
+            GLOBAL_ALLOC_FLAGS flags = GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE)
+        {
+            int sizeofT = sizeof(T);
+            int length = span.Length;
+            if (nullTerminate)
+            {
+                length = checked(length + 1);
+            }
+
+            nuint size = checked((nuint)length * (nuint)sizeofT);
+
+            HGLOBAL global = PInvoke.GlobalAlloc(flags, size);
+            if (global.IsNull)
+            {
+                Error.ThrowLastError();
+            }
+
+            using var lockScope = global.Lock();
+            Span<T> destinationSpan = new Span<T>(lockScope, length);
+            span.CopyTo(destinationSpan);
+
+            if (nullTerminate)
+            {
+                destinationSpan[^1] = default;
+            }
+
+            return global;
+        }
+
+        /// <summary>
+        ///  Copies the contents of the span into existing global (native) memory.
+        /// </summary>
+        /// <param name="destination">
+        ///  The handle to the existing global memory to copy into.
+        /// </param>
+        /// <param name="nullTerminate">
+        ///  <see langword="true"/> to write an additional default <typeparamref name="T"/>
+        ///  value as a null terminator after the copied data.
+        /// </param>
+        /// <exception cref="System.ArgumentException">
+        ///  Thrown if <paramref name="destination"/> is not large enough to hold the copied data.
+        /// </exception>
+        /// <exception cref="System.ComponentModel.Win32Exception">
+        ///  Thrown if the native size query, lock, or unlock operation fails.
+        /// </exception>
+        public void CopyToNative(HGLOBAL destination, bool nullTerminate = false)
+        {
+            int sizeofT = sizeof(T);
+            int length = span.Length;
+            if (nullTerminate)
+            {
+                length = checked(length + 1);
+            }
+
+            nuint size = checked((nuint)length * (nuint)sizeofT);
+
+            nuint destinationSize = PInvoke.GlobalSize(destination);
+            if (destinationSize < size)
+            {
+                throw new ArgumentException("Destination is not large enough to hold the copied data.", nameof(destination));
+            }
+
+            using var lockScope = destination.Lock();
+            Span<T> destinationSpan = new Span<T>(lockScope, length);
+            span.CopyTo(destinationSpan);
+
+            if (nullTerminate)
+            {
+                destinationSpan[^1] = default;
+            }
+        }
+    }
+
+    extension<T>(Span<T> span) where T : unmanaged
+    {
+        /// <inheritdoc cref="SpanExtensions.CopyToNative{T}(ReadOnlySpan{T}, bool, GLOBAL_ALLOC_FLAGS)"/>
+        public HGLOBAL CopyToNative(
+            bool nullTerminate = false,
+            GLOBAL_ALLOC_FLAGS flags = GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE)
+        {
+            return ((ReadOnlySpan<T>)span).CopyToNative(nullTerminate, flags);
+        }
+
+        /// <inheritdoc cref="SpanExtensions.CopyToNative{T}(ReadOnlySpan{T}, HGLOBAL, bool)"/>
+        public void CopyToNative(HGLOBAL destination, bool nullTerminate = false)
+        {
+            ((ReadOnlySpan<T>)span).CopyToNative(destination, nullTerminate);
+        }
+    }
+}

--- a/madowaku/SpanExtensions.cs
+++ b/madowaku/SpanExtensions.cs
@@ -49,13 +49,21 @@ public static unsafe class SpanExtensions
                 Error.ThrowLastError();
             }
 
-            using var lockScope = global.Lock();
-            Span<T> destinationSpan = new Span<T>(lockScope, length);
-            span.CopyTo(destinationSpan);
-
-            if (nullTerminate)
+            try
             {
-                destinationSpan[^1] = default;
+                using var lockScope = global.Lock();
+                Span<T> destinationSpan = new Span<T>(lockScope, length);
+                span.CopyTo(destinationSpan);
+
+                if (nullTerminate)
+                {
+                    destinationSpan[^1] = default;
+                }
+            }
+            catch
+            {
+                PInvoke.GlobalFree(global);
+                throw;
             }
 
             return global;
@@ -89,6 +97,11 @@ public static unsafe class SpanExtensions
             nuint size = checked((nuint)length * (nuint)sizeofT);
 
             nuint destinationSize = PInvoke.GlobalSize(destination);
+            if (destinationSize == 0)
+            {
+                Error.ThrowLastError();
+            }
+
             if (destinationSize < size)
             {
                 throw new ArgumentException("Destination is not large enough to hold the copied data.", nameof(destination));

--- a/madowaku/Windows/Win32/Foundation/HGLOBAL.cs
+++ b/madowaku/Windows/Win32/Foundation/HGLOBAL.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Windows.Win32.Foundation;
+
+/// <summary>
+///  Global memory handle.
+/// </summary>
+public unsafe partial struct HGLOBAL
+{
+    /// <summary>
+    ///  Locks the global memory handle and returns a pointer to the memory.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Use the result in a <c>using</c> statement to ensure the memory is unlocked when done.
+    ///  </para>
+    /// </remarks>
+    public LockScope Lock() => new LockScope(this);
+
+    /// <summary>
+    ///  Returns the current size of the global memory handle. Returns 0 if the handle is invalid.
+    /// </summary>
+    public nuint Size => PInvoke.GlobalSize(this);
+
+    /// <summary>
+    ///  Returns a value indicating whether the handle is null or invalid.
+    /// </summary>
+    public bool IsValid => !IsNull && PInvoke.GlobalFlags(this) != PInvoke.GMEM_INVALID_HANDLE;
+
+    /// <summary>
+    ///  Locks the global memory handle and returns a pointer to the memory.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Use in a <c>using</c> statement to ensure the memory is unlocked when done.
+    ///  </para>
+    /// </remarks>
+    public unsafe ref struct LockScope
+    {
+        private readonly HGLOBAL _global;
+        private void* _memory;
+
+        /// <summary>
+        ///  Constructs a new <see cref="LockScope"/> for the specified global memory handle.
+        /// </summary>
+        public LockScope(HGLOBAL global)
+        {
+            _global = global;
+            _memory = PInvoke.GlobalLock(global);
+            if (_memory is null)
+            {
+                Error.ThrowLastError();
+            }
+        }
+
+        /// <summary>
+        ///  The pointer to the locked memory.
+        /// </summary>
+        public readonly void* Memory => _memory;
+
+        /// <summary>
+        ///  Implicit converter to the pointer to the locked memory.
+        /// </summary>
+        public static implicit operator void*(LockScope scope) => scope.Memory;
+
+        /// <inheritdoc cref="IDisposable.Dispose"/>
+        public void Dispose()
+        {
+            if (_memory is null)
+            {
+                return;
+            }
+
+            if (!PInvoke.GlobalUnlock(_global))
+            {
+                Error.ThrowIfLastErrorNot(WIN32_ERROR.ERROR_SUCCESS);
+            }
+
+            _memory = null;
+        }
+    }
+}

--- a/madowaku/Windows/Win32/Foundation/HGLOBAL.cs
+++ b/madowaku/Windows/Win32/Foundation/HGLOBAL.cs
@@ -14,7 +14,7 @@ public unsafe partial struct HGLOBAL
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Use the result in a <c>using</c> statement to ensure the memory is unlocked when done.
+    ///   Use the result in a <see langword="using"/> statement to ensure the memory is unlocked when done.
     ///  </para>
     /// </remarks>
     public LockScope Lock() => new LockScope(this);
@@ -34,7 +34,7 @@ public unsafe partial struct HGLOBAL
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Use in a <c>using</c> statement to ensure the memory is unlocked when done.
+    ///   Use in a <see langword="using"/> statement to ensure the memory is unlocked when done.
     ///  </para>
     /// </remarks>
     public unsafe ref struct LockScope


### PR DESCRIPTION
## Summary
- Add HGLOBAL.Lock()/LockScope, Size, and IsValid`n- Add ReadOnlySpan<T>/Span<T>.CopyToNative extensions (allocating and existing-destination overloads)
- Add corresponding GlobalAlloc/GlobalFree/GlobalLock/GlobalUnlock/GlobalSize/GlobalFlags P/Invoke entries
- Add tests for HGLOBAL and SpanExtensions(HGLOBALTests, SpanExtensionsTests)

## Testing
- dotnet build succeeded
- Ran HGLOBALTests and SpanExtensionsTests (40 tests, all passed)