### PR TITLE
Add Win32Exception.Create helpers and Madowaku.Io exception hierarchy

### DIFF
--- a/madowaku.tests/Io/DriveLockedExceptionTests.cs
+++ b/madowaku.tests/Io/DriveLockedExceptionTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+
+namespace Madowaku.Io;
+
+[TestClass]
+public class DriveLockedExceptionTests
+{
+    [TestMethod]
+    public void Constructor_SetsHResultToFveLockedVolume()
+    {
+        DriveLockedException exception = new();
+        exception.HResult.Should().Be(HRESULT.FVE_E_LOCKED_VOLUME.Value);
+    }
+
+    [TestMethod]
+    public void Constructor_NullMessage_UsesDescription()
+    {
+        DriveLockedException exception = new();
+        exception.Message.Should().Be(HRESULT.FVE_E_LOCKED_VOLUME.ToStringWithDescription());
+    }
+
+    [TestMethod]
+    public void Constructor_WithMessage_UsesGivenMessage()
+    {
+        DriveLockedException exception = new("drive is locked");
+        exception.Message.Should().Be("drive is locked");
+    }
+}

--- a/madowaku.tests/Io/DriveNotReadyExceptionTests.cs
+++ b/madowaku.tests/Io/DriveNotReadyExceptionTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+
+namespace Madowaku.Io;
+
+[TestClass]
+public class DriveNotReadyExceptionTests
+{
+    [TestMethod]
+    public void Constructor_SetsHResultForErrorNotReady()
+    {
+        DriveNotReadyException exception = new();
+        exception.HResult.Should().Be((int)WIN32_ERROR.ERROR_NOT_READY.ToHRESULT());
+    }
+
+    [TestMethod]
+    public void Constructor_NullMessage_UsesErrorToString()
+    {
+        DriveNotReadyException exception = new();
+        exception.Message.Should().Be(WIN32_ERROR.ERROR_NOT_READY.ErrorToString());
+    }
+
+    [TestMethod]
+    public void Constructor_WithMessage_UsesGivenMessage()
+    {
+        DriveNotReadyException exception = new("drive is not ready");
+        exception.Message.Should().Be("drive is not ready");
+    }
+}

--- a/madowaku.tests/Io/FileExistsExceptionTests.cs
+++ b/madowaku.tests/Io/FileExistsExceptionTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+
+namespace Madowaku.Io;
+
+[TestClass]
+public class FileExistsExceptionTests
+{
+    [TestMethod]
+    public void Constructor_FileExists_SetsHResultForError()
+    {
+        FileExistsException exception = new(WIN32_ERROR.ERROR_FILE_EXISTS);
+        exception.HResult.Should().Be((int)WIN32_ERROR.ERROR_FILE_EXISTS.ToHRESULT());
+    }
+
+    [TestMethod]
+    public void Constructor_AlreadyExists_SetsHResultForError()
+    {
+        FileExistsException exception = new(WIN32_ERROR.ERROR_ALREADY_EXISTS);
+        exception.HResult.Should().Be((int)WIN32_ERROR.ERROR_ALREADY_EXISTS.ToHRESULT());
+    }
+
+    [TestMethod]
+    public void Constructor_NullMessage_UsesErrorToString()
+    {
+        FileExistsException exception = new(WIN32_ERROR.ERROR_FILE_EXISTS);
+        exception.Message.Should().Be(WIN32_ERROR.ERROR_FILE_EXISTS.ErrorToString());
+    }
+
+    [TestMethod]
+    public void Constructor_WithMessage_UsesGivenMessage()
+    {
+        FileExistsException exception = new(WIN32_ERROR.ERROR_FILE_EXISTS, "file already there");
+        exception.Message.Should().Be("file already there");
+    }
+}

--- a/madowaku.tests/Io/MadowakuIoExceptionTests.cs
+++ b/madowaku.tests/Io/MadowakuIoExceptionTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+
+namespace Madowaku.Io;
+
+[TestClass]
+public class MadowakuIoExceptionTests
+{
+    [TestMethod]
+    public void Constructor_Default_DoesNotThrow()
+    {
+        MadowakuIoException exception = new();
+        exception.Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void Constructor_HRESULT_SetsHResult()
+    {
+        MadowakuIoException exception = new(HRESULT.COR_E_OBJECTDISPOSED);
+        exception.HResult.Should().Be(HRESULT.COR_E_OBJECTDISPOSED.Value);
+    }
+
+    [TestMethod]
+    public void Constructor_HRESULT_NullMessage_UsesDescription()
+    {
+        MadowakuIoException exception = new(HRESULT.COR_E_OBJECTDISPOSED);
+        exception.Message.Should().Be(HRESULT.COR_E_OBJECTDISPOSED.ToStringWithDescription());
+    }
+
+    [TestMethod]
+    public void Constructor_HRESULT_WithMessage_UsesGivenMessage()
+    {
+        MadowakuIoException exception = new(HRESULT.COR_E_OBJECTDISPOSED, "custom message");
+        exception.Message.Should().Be("custom message");
+    }
+
+    [TestMethod]
+    public void Constructor_WIN32_ERROR_SetsHResultFromHResultForWin32()
+    {
+        MadowakuIoException exception = new(WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+        exception.HResult.Should().Be(unchecked((int)0x80070002));
+    }
+
+    [TestMethod]
+    public void Constructor_WIN32_ERROR_NullMessage_UsesErrorToString()
+    {
+        MadowakuIoException exception = new(WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+        exception.Message.Should().Be(WIN32_ERROR.ERROR_FILE_NOT_FOUND.ErrorToString());
+    }
+
+    [TestMethod]
+    public void Constructor_WIN32_ERROR_WithMessage_UsesGivenMessage()
+    {
+        MadowakuIoException exception = new(WIN32_ERROR.ERROR_FILE_NOT_FOUND, "custom message");
+        exception.Message.Should().Be("custom message");
+    }
+}

--- a/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/ErrorTests.cs
@@ -1,8 +1,9 @@
-// Copyright (c) 2025 Jeremy W Kuhne
+﻿// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
 using System.ComponentModel;
+using Madowaku.Io;
 
 namespace Windows.Win32.Foundation;
 
@@ -126,24 +127,24 @@ public class ErrorTests
     }
 
     [TestMethod]
-    public void GetException_NotReady_ReturnsWin32Exception()
+    public void GetException_NotReady_ReturnsDriveNotReadyException()
     {
         Exception ex = WIN32_ERROR.ERROR_NOT_READY.GetException();
-        ex.Should().BeOfType<Win32Exception>();
+        ex.Should().BeOfType<DriveNotReadyException>();
     }
 
     [TestMethod]
-    public void GetException_FileExists_ReturnsWin32Exception()
+    public void GetException_FileExists_ReturnsFileExistsException()
     {
         Exception ex = WIN32_ERROR.ERROR_FILE_EXISTS.GetException();
-        ex.Should().BeOfType<Win32Exception>();
+        ex.Should().BeOfType<FileExistsException>();
     }
 
     [TestMethod]
-    public void GetException_AlreadyExists_ReturnsWin32Exception()
+    public void GetException_AlreadyExists_ReturnsFileExistsException()
     {
         Exception ex = WIN32_ERROR.ERROR_ALREADY_EXISTS.GetException();
-        ex.Should().BeOfType<Win32Exception>();
+        ex.Should().BeOfType<FileExistsException>();
     }
 
     [TestMethod]

--- a/madowaku.tests/Windows/Win32/Foundation/HGLOBALTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HGLOBALTests.cs
@@ -17,7 +17,7 @@ public unsafe class HGLOBALTests
 
         try
         {
-            global.Size.Should().Be((nuint)(sizeof(int) * 4));
+            global.Size.Should().Be(sizeof(int) * 4);
         }
         finally
         {
@@ -30,7 +30,7 @@ public unsafe class HGLOBALTests
     {
         HGLOBAL global = default;
 
-        global.Size.Should().Be((nuint)0);
+        global.Size.Should().Be(0);
     }
 
     [TestMethod]

--- a/madowaku.tests/Windows/Win32/Foundation/HGLOBALTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/HGLOBALTests.cs
@@ -17,7 +17,7 @@ public unsafe class HGLOBALTests
 
         try
         {
-            global.Size.Should().Be(sizeof(int) * 4);
+            global.Size.Should().Be((nuint)(sizeof(int) * 4));
         }
         finally
         {
@@ -30,7 +30,7 @@ public unsafe class HGLOBALTests
     {
         HGLOBAL global = default;
 
-        global.Size.Should().Be(0);
+        global.Size.Should().Be((nuint)0);
     }
 
     [TestMethod]

--- a/madowaku.tests/Windows/Win32/Foundation/Win32ExceptionExtensionsTests.cs
+++ b/madowaku.tests/Windows/Win32/Foundation/Win32ExceptionExtensionsTests.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.ComponentModel;
+
+namespace Windows.Win32.Foundation;
+
+[TestClass]
+public class Win32ExceptionExtensionsTests
+{
+    [TestMethod]
+    public void Create_FromWin32Error_SetsNativeErrorCode()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+        exception.NativeErrorCode.Should().Be((int)WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+    }
+
+    [TestMethod]
+    public void Create_FromWin32Error_SetsHResultFromHResultForWin32()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+        exception.HResult.Should().Be(unchecked((int)0x80070002));
+    }
+
+    [TestMethod]
+    public void Create_FromWin32Error_Success_SetsHResultZero()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(WIN32_ERROR.ERROR_SUCCESS);
+        exception.HResult.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Create_FromWin32Error_NullMessage_UsesSystemMessage()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+        exception.Message.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void Create_FromWin32Error_WithMessage_UsesGivenMessage()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(WIN32_ERROR.ERROR_FILE_NOT_FOUND, "custom message");
+        exception.Message.Should().Be("custom message");
+    }
+
+    [TestMethod]
+    public void Create_FromHRESULT_Win32Facility_SetsNativeErrorCodeToHResultCode()
+    {
+        HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND;
+        Win32Exception exception = Win32ExceptionExtensions.Create(hr);
+        exception.NativeErrorCode.Should().Be((int)WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+    }
+
+    [TestMethod]
+    public void Create_FromHRESULT_Win32Facility_SetsHResultToRawValue()
+    {
+        HRESULT hr = (HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND;
+        Win32Exception exception = Win32ExceptionExtensions.Create(hr);
+        exception.HResult.Should().Be(hr.Value);
+    }
+
+    [TestMethod]
+    public void Create_FromHRESULT_NonWin32Facility_SetsNativeErrorCodeToRawValue()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(HRESULT.COR_E_OBJECTDISPOSED);
+        exception.NativeErrorCode.Should().Be(HRESULT.COR_E_OBJECTDISPOSED.Value);
+    }
+
+    [TestMethod]
+    public void Create_FromHRESULT_NonWin32Facility_SetsHResultToRawValue()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(HRESULT.COR_E_OBJECTDISPOSED);
+        exception.HResult.Should().Be(HRESULT.COR_E_OBJECTDISPOSED.Value);
+    }
+
+    [TestMethod]
+    public void Create_FromHRESULT_WithMessage_UsesGivenMessage()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create(HRESULT.COR_E_OBJECTDISPOSED, "custom message");
+        exception.Message.Should().Be("custom message");
+    }
+
+    [TestMethod]
+    public void Create_FromHRESULT_NullMessage_UsesSystemMessage()
+    {
+        Win32Exception exception = Win32ExceptionExtensions.Create((HRESULT)WIN32_ERROR.ERROR_FILE_NOT_FOUND);
+        exception.Message.Should().NotBeNullOrEmpty();
+    }
+}

--- a/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
@@ -43,7 +43,7 @@ public class ComScopeTests
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
         nint p = scope;
-        p.Should().Be((nint)0);
+        p.Should().Be(0);
     }
 
     [TestMethod]

--- a/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Com/ComScopeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Jeremy W Kuhne
+﻿// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -43,7 +43,7 @@ public class ComScopeTests
     {
         using ComScope<IUnknown> scope = new((IUnknown*)null);
         nint p = scope;
-        p.Should().Be(0);
+        p.Should().Be((nint)0);
     }
 
     [TestMethod]

--- a/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
+++ b/madowaku.tests/Windows/Win32/System/Variant/VariantTests.cs
@@ -1251,7 +1251,7 @@ public partial class VariantTests
         ui8.GetValue(5).Should().Be(3UL);
         ui8.GetValue(6).Should().Be(6UL);
 
-        Array r4 = ConvertNonZeroLowerBoundArray(VARENUM.VT_R4, VARENUM.VT_R4, (float[])[1.25f, 2.5f]);
+        Array r4 = ConvertNonZeroLowerBoundArray(VARENUM.VT_R4, VARENUM.VT_R4, [1.25f, 2.5f]);
         r4.GetValue(5).Should().Be(1.25f);
         r4.GetValue(6).Should().Be(2.5f);
     }

--- a/madowaku/GlobalUsings.cs
+++ b/madowaku/GlobalUsings.cs
@@ -27,6 +27,7 @@ global using FileNotFoundException = System.IO.FileNotFoundException;
 global using DirectoryNotFoundException = System.IO.DirectoryNotFoundException;
 global using PathTooLongException = System.IO.PathTooLongException;
 global using DriveNotFoundException = System.IO.DriveNotFoundException;
+global using IOException = System.IO.IOException;
 
 global using Marshal = System.Runtime.InteropServices.Marshal;
 global using FILETIME = Windows.Win32.Foundation.FILETIME;

--- a/madowaku/Io/DriveLockedException.cs
+++ b/madowaku/Io/DriveLockedException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Madowaku.Io;
+
+/// <summary>
+///  Thrown when a drive is locked.
+/// </summary>
+public class DriveLockedException(string? message = null) : MadowakuIoException(HRESULT.FVE_E_LOCKED_VOLUME, message)
+{
+}

--- a/madowaku/Io/DriveNotReadyException.cs
+++ b/madowaku/Io/DriveNotReadyException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Madowaku.Io;
+
+/// <summary>
+///  Thrown when a drive is not ready for access.
+/// </summary>
+public class DriveNotReadyException(string? message = null) : MadowakuIoException(WIN32_ERROR.ERROR_NOT_READY, message)
+{
+}

--- a/madowaku/Io/FileExistsException.cs
+++ b/madowaku/Io/FileExistsException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Madowaku.Io;
+
+/// <summary>
+///  Thrown when a file already exists.
+/// </summary>
+public class FileExistsException(WIN32_ERROR error, string? message = null) : MadowakuIoException(error, message)
+{
+}

--- a/madowaku/Io/MadowakuIoException.cs
+++ b/madowaku/Io/MadowakuIoException.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Madowaku.Io;
+
+/// <summary>
+///  Base class for IO exceptions thrown by Madowaku.
+/// </summary>
+public class MadowakuIoException : IOException
+{
+    /// <summary>
+    ///  Constructs a new <see cref="MadowakuIoException"/>.
+    /// </summary>
+    public MadowakuIoException()
+        : base() { }
+
+    /// <summary>
+    ///  Constructs a new <see cref="MadowakuIoException"/> with the specified error and message.
+    /// </summary>
+    public MadowakuIoException(HRESULT hr, string? message = null)
+        : base(message ?? hr.ToStringWithDescription(), hresult: hr) { }
+
+    /// <summary>
+    ///  Constructs a new <see cref="MadowakuIoException"/> with the specified error and message.
+    /// </summary>
+    public MadowakuIoException(WIN32_ERROR error, string? message = null)
+        : base(message ?? error.ErrorToString(), (int)error.ToHRESULT()) { }
+}

--- a/madowaku/Windows/Win32/Foundation/Error.cs
+++ b/madowaku/Windows/Win32/Foundation/Error.cs
@@ -1,8 +1,9 @@
-// Copyright (c) 2025 Jeremy W Kuhne
+﻿// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
 using System.ComponentModel;
+using Madowaku.Io;
 using Windows.Win32.System.Diagnostics.Debug;
 
 namespace Windows.Win32.Foundation;
@@ -118,61 +119,43 @@ public static unsafe class Error
         // There are a few defintions for '0', we'll always use ERROR_SUCCESS
         return error == WIN32_ERROR.ERROR_SUCCESS
             ? $"ERROR_SUCCESS ({(uint)error}): {message}"
-#if NETFRAMEWORK
-            : Enum.IsDefined(typeof(WIN32_ERROR), error)
-                ? $"{error} ({(uint)error}): {message}"
-                : $"Error {error}: {message}";
-#else
             : Enum.IsDefined(error)
                 ? $"{error} ({(uint)error}): {message}"
                 : $"Error {error}: {message}";
-#endif
     }
 
-    internal static Exception WindowsErrorToException(WIN32_ERROR error, string? message, string? path)
+    internal static Exception WindowsErrorToException(WIN32_ERROR error, string? message, string? path) => error switch
     {
-        switch (error)
-        {
-            case WIN32_ERROR.ERROR_FILE_NOT_FOUND:
-                return new FileNotFoundException(message, path);
-            case WIN32_ERROR.ERROR_PATH_NOT_FOUND:
-                return new DirectoryNotFoundException(message);
-            case WIN32_ERROR.ERROR_ACCESS_DENIED:
-            // Network access doesn't throw UnauthorizedAccess in .NET
-            case WIN32_ERROR.ERROR_NETWORK_ACCESS_DENIED:
-                return new UnauthorizedAccessException(message);
-            case WIN32_ERROR.ERROR_FILENAME_EXCED_RANGE:
-                return new PathTooLongException(message);
-            case WIN32_ERROR.ERROR_INVALID_DRIVE:
-                // Not available in Portable libraries
-                return new DriveNotFoundException(message);
-            case WIN32_ERROR.ERROR_OPERATION_ABORTED:
-            case WIN32_ERROR.ERROR_CANCELLED:
-                return new OperationCanceledException(message);
-            case WIN32_ERROR.ERROR_NOT_READY:
-                // Drive not ready
-                return new Win32Exception((int)error, message);
-            case WIN32_ERROR.ERROR_FILE_EXISTS:
-            case WIN32_ERROR.ERROR_ALREADY_EXISTS:
-                // File or directory already exists
-                return new Win32Exception((int)error, message);
-            case WIN32_ERROR.ERROR_INVALID_PARAMETER:
-                return new ArgumentException(message);
-            case WIN32_ERROR.ERROR_NOT_SUPPORTED:
-            case WIN32_ERROR.ERROR_NOT_SUPPORTED_IN_APPCONTAINER:
-                return new NotSupportedException(message);
-            case WIN32_ERROR.ERROR_SHARING_VIOLATION:
-            default:
-                if (error == (WIN32_ERROR)(int)HRESULT.FVE_E_LOCKED_VOLUME)
-                {
-                    // Drive locked
-                    return new Win32Exception((int)error, message);
-                }
+        WIN32_ERROR.ERROR_FILE_NOT_FOUND => new FileNotFoundException(message, path),
+        WIN32_ERROR.ERROR_PATH_NOT_FOUND => new DirectoryNotFoundException(message),
+        WIN32_ERROR.ERROR_ACCESS_DENIED or WIN32_ERROR.ERROR_NETWORK_ACCESS_DENIED => new UnauthorizedAccessException(message),
+        WIN32_ERROR.ERROR_FILENAME_EXCED_RANGE => new PathTooLongException(message),
+        // Not available in Portable libraries
+        WIN32_ERROR.ERROR_INVALID_DRIVE => new DriveNotFoundException(message),
+        WIN32_ERROR.ERROR_OPERATION_ABORTED or WIN32_ERROR.ERROR_CANCELLED => new OperationCanceledException(message),
+        WIN32_ERROR.ERROR_NOT_READY => new DriveNotReadyException(message),
+        // File or directory already exists
+        WIN32_ERROR.ERROR_FILE_EXISTS or WIN32_ERROR.ERROR_ALREADY_EXISTS => new FileExistsException(error, message),
+        WIN32_ERROR.ERROR_INVALID_PARAMETER => new ArgumentException(message),
+        WIN32_ERROR.ERROR_NOT_SUPPORTED or WIN32_ERROR.ERROR_NOT_SUPPORTED_IN_APPCONTAINER => new NotSupportedException(message),
+        _ => error == (WIN32_ERROR)(int)HRESULT.FVE_E_LOCKED_VOLUME
+            // Drive locked
+            ? new DriveLockedException(message)
+            : Win32Exception.Create(error, message),
+    };
 
-                return new Win32Exception((int)error, message);
-        }
-    }
+    /// <inheritdoc cref="FormatMessage(uint, HINSTANCE, ReadOnlySpan{string})"/>
+    public static string FormatMessage(
+        uint messageId,
+        HINSTANCE source = default,
+        params string[] args) => FormatMessage(messageId, source, args.AsSpan());
 
+    /// <summary>
+    ///  Formats a Windows error code into a string using FormatMessage.
+    /// </summary>
+    /// <param name="messageId">The message ID to format.</param>
+    /// <param name="source">The source of the message. If <see langword="null"/>, the system message table is used.</param>
+    /// <param name="args">Optional arguments to format into the message.</param>
     /// <remarks>
     ///  <para>
     ///   .NET's Win32Exception impements the error code lookup on FormatMessage using FORMAT_MESSAGE_FROM_SYSTEM.
@@ -182,14 +165,14 @@ public static unsafe class Error
     public static string FormatMessage(
         uint messageId,
         HINSTANCE source = default,
-        params string[] args)
+        params ReadOnlySpan<string> args)
     {
         FORMAT_MESSAGE_OPTIONS flags =
             // Let the API allocate the buffer
             FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_ALLOCATE_BUFFER
             | FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_FROM_SYSTEM;
 
-        if (args is null || args.Length == 0)
+        if (args.Length == 0)
         {
             flags.SetFlags(FORMAT_MESSAGE_OPTIONS.FORMAT_MESSAGE_IGNORE_INSERTS);
         }
@@ -213,11 +196,11 @@ public static unsafe class Error
         PWSTR buffer = default;
         uint result = PInvoke.FormatMessage(
             dwFlags: flags,
-            lpSource: (void*)source.Value,
+            lpSource: source.Value,
             dwMessageId: messageId,
             // Do the default language lookup
             dwLanguageId: 0,
-            lpBuffer: (PWSTR)(void*)(&buffer),
+            lpBuffer: (PWSTR)(char*)(&buffer),
             nSize: 0,
             Arguments: sargs);
 

--- a/madowaku/Windows/Win32/Foundation/Error.cs
+++ b/madowaku/Windows/Win32/Foundation/Error.cs
@@ -154,7 +154,7 @@ public static unsafe class Error
     ///  Formats a Windows error code into a string using FormatMessage.
     /// </summary>
     /// <param name="messageId">The message ID to format.</param>
-    /// <param name="source">The source of the message. If <see langword="null"/>, the system message table is used.</param>
+    /// <param name="source">The source of the message. If <see cref="HINSTANCE.Null"/>, the system message table is used.</param>
     /// <param name="args">Optional arguments to format into the message.</param>
     /// <remarks>
     ///  <para>

--- a/madowaku/Windows/Win32/Foundation/StringParameterArray.cs
+++ b/madowaku/Windows/Win32/Foundation/StringParameterArray.cs
@@ -8,6 +8,11 @@ namespace Windows.Win32.Foundation;
 ///  Helper to allow pinning an array of strings to pass to a native method that takes an
 ///  array of null-terminated UTF-16 strings.
 /// </summary>
+/// <remarks>
+///  <para>
+///   Use in a <see langword="using"/> statement to ensure the memory is unpinned when done.
+///  </para>
+/// </remarks>
 public readonly unsafe ref struct StringParameterArray
 {
     private readonly GCHandle[]? _pins;
@@ -16,21 +21,28 @@ public readonly unsafe ref struct StringParameterArray
     /// <summary>
     ///  Initializes a new instance of the <see cref="StringParameterArray"/> struct.
     /// </summary>
-    public StringParameterArray(string[]? values)
+    public StringParameterArray(params string[]? values) : this(values is null ? null : values.AsSpan())
     {
-        int length = values?.Length ?? 0;
-        if (length > 0)
-        {
-            _param = new nint[length];
-            _pins = new GCHandle[length + 1];
-            for (int i = 0; i < length; i++)
-            {
-                _pins[i] = GCHandle.Alloc(values![i], GCHandleType.Pinned);
-                _param[i] = _pins[i].AddrOfPinnedObject();
-            }
+    }
 
-            _pins[length] = GCHandle.Alloc(_param, GCHandleType.Pinned);
+    /// <inheritdoc cref="StringParameterArray(string[])"/>
+    public StringParameterArray(params ReadOnlySpan<string> values)
+    {
+        int length = values.Length;
+        if (length <= 0)
+        {
+            return;
         }
+
+        _param = new nint[length];
+        _pins = new GCHandle[length + 1];
+        for (int i = 0; i < length; i++)
+        {
+            _pins[i] = GCHandle.Alloc(values![i], GCHandleType.Pinned);
+            _param[i] = _pins[i].AddrOfPinnedObject();
+        }
+
+        _pins[length] = GCHandle.Alloc(_param, GCHandleType.Pinned);
     }
 
     /// <summary>

--- a/madowaku/Windows/Win32/Foundation/Win32ExceptionExtensions.cs
+++ b/madowaku/Windows/Win32/Foundation/Win32ExceptionExtensions.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.ComponentModel;
+#if NETFRAMEWORK
+using System.Reflection;
+#endif
+using Windows.Win32.System.Diagnostics.Debug;
+
+namespace Windows.Win32.Foundation;
+
+/// <summary>
+///  Provides methods for creating <see cref="Win32Exception"/> instances with correctly
+///  populated <see cref="Exception.HResult"/> and <see cref="Win32Exception.NativeErrorCode"/> values.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="Win32Exception"/>'s constructors set <see cref="Win32Exception.NativeErrorCode"/>
+///   but do not derive <see cref="Exception.HResult"/> from it, leaving the base
+///   <see cref="Exception"/> default in place. These methods ensure both properties reflect the
+///   given error.
+///  </para>
+/// </remarks>
+public static class Win32ExceptionExtensions
+{
+    extension(Win32Exception)
+    {
+        /// <summary>
+        ///  Creates a <see cref="Win32Exception"/> for the given <paramref name="error"/>.
+        /// </summary>
+        /// <param name="error">The Windows error code.</param>
+        /// <param name="message">Optional message. If <see langword="null"/>, the system message for
+        ///  <paramref name="error"/> is used.</param>
+        public static Win32Exception Create(WIN32_ERROR error, string? message = null)
+        {
+            Win32Exception exception = message is null
+                ? new Win32Exception((int)error)
+                : new Win32Exception((int)error, message);
+
+            SetHResult(exception, (int)error.ToHRESULT());
+            return exception;
+        }
+
+        /// <summary>
+        ///  Creates a <see cref="Win32Exception"/> for the given <paramref name="hr"/>.
+        /// </summary>
+        /// <param name="hr">The failing <see cref="HRESULT"/>.</param>
+        /// <param name="message">Optional message. If <see langword="null"/>, the system message for
+        ///  the native error code is used.</param>
+        /// <remarks>
+        ///  <para>
+        ///   When <paramref name="hr"/> has the <see cref="FACILITY_CODE.FACILITY_WIN32"/> facility,
+        ///   <see cref="Win32Exception.NativeErrorCode"/> is set to the encoded Win32 error code
+        ///   ([HRESULT_CODE]). Otherwise it is set to the raw <see cref="HRESULT"/> value.
+        ///  </para>
+        /// </remarks>
+        public static Win32Exception Create(HRESULT hr, string? message = null)
+        {
+            int nativeErrorCode = hr.Facility == FACILITY_CODE.FACILITY_WIN32 ? hr.Code : hr.Value;
+
+            Win32Exception exception = message is null
+                ? new Win32Exception(nativeErrorCode)
+                : new Win32Exception(nativeErrorCode, message);
+
+            SetHResult(exception, hr.Value);
+            return exception;
+        }
+    }
+
+#if NETFRAMEWORK
+    // .NET Framework's Exception.HResult setter is protected, so it can't be assigned from here directly.
+    private static readonly FieldInfo s_hResultField =
+        typeof(Exception).GetField("_HResult", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static void SetHResult(Exception exception, int hResult) =>
+        s_hResultField.SetValue(exception, hResult);
+#else
+    // Exception.HResult's setter is public on modern .NET.
+    private static void SetHResult(Exception exception, int hResult) =>
+        exception.HResult = hResult;
+#endif
+}


### PR DESCRIPTION
## Summary

- Add `Win32ExceptionExtensions.Create(WIN32_ERROR)` / `Create(HRESULT)` factory methods that construct a `Win32Exception` with correctly populated `HResult` and `NativeErrorCode` (public `HResult` setter on net10, cached-reflection field set on net472/net481).
- Add a `Madowaku.Io` exception hierarchy (`MadowakuIoException`, `DriveLockedException`, `DriveNotReadyException`, `FileExistsException`) deriving from `IOException`, with `HResult` set from the given `HRESULT`/`WIN32_ERROR`.
- `Error.cs`: route the fallback case in `WindowsErrorToException` through `Win32Exception.Create`; modernize it to a switch expression; add a `ReadOnlySpan<string>` `FormatMessage` overload.
- `StringParameterArray`: add a `ReadOnlySpan<string>` `params` constructor overload.
- Strip a stray BOM from `ComScopeTests.cs` / `VariantTests.cs`; drop now-unnecessary casts in a couple of assertions.

## Testing

- `dotnet build` succeeds across `net10.0`, `net10.0-windows10.0.22000.0`, and `net472`/`net481`.
- Added test coverage for all new types (`Win32ExceptionExtensionsTests`, `MadowakuIoExceptionTests`, `DriveLockedExceptionTests`, `DriveNotReadyExceptionTests`, `FileExistsExceptionTests`); full suite passes.
