### PR TITLE
Pin the GA .NET SDK and drop preview quality from CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
-        dotnet-quality: 'preview'
+        dotnet-quality: 'ga'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
-        dotnet-quality: 'preview'
+        dotnet-quality: 'ga'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "10.0.301",
+    "rollForward": "latestFeature"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }


### PR DESCRIPTION
## Summary

Removes preview .NET SDK usage ahead of the first stable `KlutzyNinja.Madowaku` release.

- pin the SDK in `global.json` to `10.0.301` with `rollForward: latestFeature`
- change `dotnet-quality` from `preview` to `ga` in both the build and publish workflows

Without an SDK pin, local builds silently resolved to the **.NET 11 preview SDK** (`11.0.100-preview.5`), which is the source of the recurring `NETSDK1057: You are using a preview version of .NET` notice. `dotnet --version` now resolves to `10.0.301` and the notice is gone.

This must merge **before** the release tag is pushed: tag-triggered workflows use the workflow file at the tag, so tagging first would pack and publish the package built on a preview SDK.

## Release readiness

Packing with a simulated stable version produces a nuspec with no prerelease dependencies, so `NU5104` will not fail the packed build: `KlutzyNinja.Touki` 0.6.0, `Microsoft.Bcl.Memory` 10.0.8, `Microsoft.IO.Redist` 6.1.3, `System.Memory` 4.6.3.

## Validation

- `dotnet build .\madowaku.slnx -c Release` (all projects, no `NETSDK1057`)
- `dotnet test .\madowaku.slnx -c Debug` (611 passed)
- `dotnet test .\madowaku.slnx -c Release` (611 passed)
- `dotnet pack` with a stable version override, nuspec dependencies inspected
- `git diff --check`
