### PR TITLE
Update vendored agent skills to v0.13.0

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -23,7 +23,7 @@ pinned ref (also with an `overlay.md`). See
 | ----- | ---------------- |
 | [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" |
 
-### Vendored (commons `v0.11.0`)
+### Vendored (commons `v0.13.0`)
 
 | Skill | Trigger phrasing |
 | ----- | ---------------- |
@@ -44,6 +44,15 @@ pinned ref (also with an `overlay.md`). See
 | [engineering-baseline](./engineering-baseline/SKILL.md) | "ensure this repo follows modern engineering best practices", "audit this repository", "bring this repo up to standard" |
 | [github-actions-cost-optimization](./github-actions-cost-optimization/SKILL.md) | "reduce CI cost / spend / minutes", optimize GitHub Actions triggers, matrices, runners, caches, artifacts |
 
+### Not vendored (project-gated)
+
+The commons `v0.13.0` portfolio contains two additional skills that do not apply
+to this repository:
+
+- `fuzz-testing` requires an existing fuzz harness; madowaku has no fuzz project.
+- `roslyn-analyzers` applies when authoring a `DiagnosticAnalyzer`, code fix, or
+  suppressor; madowaku has no analyzer project.
+
 ## Vendoring model
 
 Skills are authored once as a portable **core** in the commons and shared from
@@ -60,7 +69,7 @@ core plus a thin repo-specific **overlay**:
   (the `KlutzyNinja.Madowaku` release-tag flow), carries no provenance, and is
   never upstreamed.
 
-All 16 vendored cores are pinned to the commons `v0.11.0` tag. The
+All 16 vendored cores are pinned to the commons `v0.13.0` tag. The
 [manage-skills](./manage-skills/SKILL.md) skill drives find / build / update,
 and [agent-files-review](./agent-files-review/SKILL.md) validates the resulting
 files.

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/address-pr-feedback
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: ceb544da854ef7ba911679b8af8bca2631150ef9
+    github-tree-sha: 7db8903886f6ce4509f97eae6f72fca6c883abe0
     maturity: canary
     portability: portable
     related: create-pr, pre-pr-self-review, agent-files-review
@@ -33,10 +33,9 @@ authorizes you to *edit*:
 - This skill authorizes editing files in response to review feedback or
   CI failures on an existing PR. Same approval gate before commit/push.
 
-Your repo's agent guidance (the "Working with the user on changes" rules in
-`AGENTS.md`) is the source of truth for the commit/push approval rule. Re-read it
-at the start of every invocation; this skill is the decision-point reminder, not
-a replacement.
+Repository guidance is the source of truth for commit/push approval. Re-read it
+at the start of every invocation when present; this skill is a reminder, not a
+replacement.
 
 ## Recognizing approval
 
@@ -65,11 +64,15 @@ Stop and ask one short yes/no question.
 
 ## Workflow
 
-1. **Fetch the feedback.** Read review comments, PR conversation, and check-run
-   logs via the GitHub PR tools (or `Invoke-RestMethod` against
-   `api.github.com/repos/<owner>/<repo>/pulls/<N>/comments`). With multiple
-   review passes, fetch the **latest** review's comments (filter by the newest
-   review id) so you act on the current round.
+1. **Confirm the PR is open, then fetch feedback.** If it was merged, stop and
+    propose a user-approved follow-up such as a revert or new PR. If it was closed
+    without merging, stop and propose reopening it or creating a new PR. Do not
+    mutate the old branch in either case. Read every unresolved review thread
+    across all review passes, including replies, plus the PR conversation and
+    compact check statuses. Fetch logs only for failed checks being investigated.
+    Do not filter by newest review id - older unresolved threads remain
+    actionable. Prefer a PR tool; use
+    [thread-workflow.md](thread-workflow.md) for the `gh` fallback.
 
    Automated reviewers (e.g. Copilot) post asynchronously - on open, on push, or
    when requested - a minute or two after the trigger. If one was requested but
@@ -92,27 +95,33 @@ Stop and ask one short yes/no question.
    commit`, or `git push`.
 5. **Wait** for an explicit publishing verb (see "Recognizing approval"
    above).
-6. **Only then** stage by path, commit with a message that summarizes the
-   round of changes, and push. The staging/commit/push mechanics are the
-   same as in the `create-pr` skill (its "Commit changes" and "Push the
-   branch" steps).
-7. **Resolve the threads, with explanations.** Replying and resolving are remote
-   actions, so they ride in the same approved publish step as the push; honor
-   explicit scoping ("push and resolve only", "don't re-request") and report
-   what you did. For each comment, reply then resolve:
-   - **Fixed** - one line on what changed (reference the commit or behavior).
-   - **False positive / won't-fix** - the rationale or the evidence. Leave a
-     thread open only to invite a human onto a contested point, and say so.
-   With the PR tool, use its resolve action; with `gh`, resolve via the GraphQL
-   `resolveReviewThread` mutation on the thread node id (not the comment id).
-8. **Re-request review when non-trivial.** After real code changes, request a
-   fresh pass from the same reviewer - also a remote action in the publish step.
-   Skip it for trivial rounds (typo, reword, one-line nit) to avoid an endless
-   trickle, and say which you did.
+6. **Only then** recheck that the PR is open before staging or committing. Commit
+    the round, then confirm the PR is still open immediately before each remote
+    write in steps 6-8; abort and report if it is not. Push using the mechanics in
+    the `create-pr` skill.
+7. **Reply in-thread, then resolve.** These are PR write actions. Follow repository
+    guidance; when it does not bundle them with push/update approval, get explicit
+    approval. Refresh each targeted thread before writing: skip one already
+    resolved, and reclassify one with new replies. Write one scoped reply per
+    thread: state what changed for a fix, or give the evidence for a false positive
+    or won't-fix. Do not combine answers across threads or post the review summary
+    to the PR conversation. Leave a thread open only to invite a human onto a
+    contested point, and say so.
+    Verify both operations; a reply does not resolve a thread. Report what you did.
+8. **Get the next review when non-trivial.** If the repository automatically
+    reviews pushes, never request or re-request review; let the automatic pass run
+    without polling. Otherwise, after real code changes, request a fresh pass from
+    the same reviewer using the repository's PR-write approval policy. Skip a
+    manual request for trivial rounds (typo, reword, one-line nit), and say which
+    path applies.
 
 **When to stop.** Later auto-review passes drift toward nits and false positives.
-Once comments stop being substantive, stop re-requesting, say so, and let the
-user merge.
+Before calling the PR ready, confirm it is open, non-draft, mergeable, required
+checks and reviews are satisfied, no review threads remain unresolved, and the
+latest requested or automatic review has completed. Account for every actionable
+PR-conversation comment with a response or recorded disposition as well.
+Otherwise report what is pending. Once comments stop being substantive, stop
+requesting additional manual reviews and let the user merge.
 
 ## When you've already violated the rule
 
@@ -123,7 +132,7 @@ force-push, or leave the commit in place.
 
 ## Related
 
-- Your repo's agent guidance (`AGENTS.md`) - the rule itself.
+- Repository agent guidance, when present - the local approval rule.
 - The `create-pr` skill - opening the initial PR (same publish gate,
   different edit scope).
 - The `pre-pr-self-review` skill - the validation checklist that applies

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: address-pr-feedback
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - address-pr-feedback
@@ -11,7 +11,7 @@ skill. The `SKILL.md` is a **pinned copy of the portable core** from
 `metadata.github-*` provenance in its frontmatter). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/address-pr-feedback/thread-workflow.md
+++ b/.agents/skills/address-pr-feedback/thread-workflow.md
@@ -1,0 +1,103 @@
+# GitHub review-thread fallback
+
+Use this only when the PR tool cannot list, reply to, or resolve review threads.
+Target the repository that owns the PR explicitly; the checkout may be a fork.
+
+Create each query and reply file below with a unique name in the OS temporary
+directory, never in the repository. Delete it immediately after use.
+
+## Fetch all unresolved feedback
+
+Save the thread query:
+
+```graphql
+query(
+  $owner: String!
+  $repo: String!
+  $number: Int!
+  $endCursor: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $endCursor) {
+        nodes { id isResolved }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+Replace the uppercase tokens below with actual values and temporary-file paths.
+Run the query with pagination and keep unresolved thread node IDs:
+
+```text
+gh api graphql --paginate -F owner=BASE_OWNER -F repo=BASE_REPO -F number=PULL_NUMBER -F query=@THREADS_QUERY_FILE --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id'
+```
+
+For each unresolved thread, save and run this paginated comments query:
+
+```graphql
+query($threadId: ID!, $endCursor: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $endCursor) {
+        nodes {
+          id
+          body
+          url
+          path
+          line
+          author { login }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+```text
+gh api graphql --paginate -F threadId=THREAD_NODE_ID -F query=@COMMENTS_QUERY_FILE --jq '.data.node.comments.nodes[]'
+```
+
+Classify every unresolved thread after reading all its replies.
+
+## Reply in-thread
+
+Write the response to a unique temporary Markdown file, then use the thread node
+ID to reply. This cannot create a top-level PR comment:
+
+```graphql
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(
+    input: { pullRequestReviewThreadId: $threadId, body: $body }
+  ) {
+    comment { id url body }
+  }
+}
+```
+
+```text
+gh api graphql -F threadId=THREAD_NODE_ID -F body=@REPLY_FILE -F query=@REPLY_QUERY_FILE --jq '.data.addPullRequestReviewThreadReply.comment'
+```
+
+Require a non-null comment `id` before reporting that the reply was posted.
+
+## Resolve separately
+
+Save and run the resolve mutation:
+
+```graphql
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}
+```
+
+```text
+gh api graphql -F threadId=THREAD_NODE_ID -F query=@RESOLVE_QUERY_FILE --jq '.data.resolveReviewThread.thread'
+```
+
+Require `isResolved: true` before reporting success.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: agent-customization
     binding: optional-overlay
     github-path: skills/agent-files-review
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 64a00d548909d8f84fb8ac6f6e3db77deceab270
     maturity: canary

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: agent-files-review
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - agent-files-review
@@ -12,7 +12,7 @@ portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku scaffold paths
 

--- a/.agents/skills/code-comprehension/SKILL.md
+++ b/.agents/skills/code-comprehension/SKILL.md
@@ -5,8 +5,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/code-comprehension
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: d2e1be7b63a31345f054a1d0785a67d5ba2aa604
     maturity: canary

--- a/.agents/skills/code-comprehension/overlay.md
+++ b/.agents/skills/code-comprehension/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: code-comprehension
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - code-comprehension
@@ -12,7 +12,7 @@ copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/create-pr
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: dcdd58e7cad32b4907ce6a8bf0fe6bf01cb14f59
+    github-tree-sha: 6fef038602c67d66b0c8278e8f7681b56803a95f
     maturity: canary
     portability: portable
     related: pre-pr-self-review, address-pr-feedback
@@ -34,6 +34,12 @@ once the user supplies an explicit publishing verb - `commit`, `push`,
 `ship it`, or equivalent. See your repo's agent guidance (the "Working with
 the user on changes" rules in `AGENTS.md`) for the canonical rule and the
 recurring not-approval phrasings.
+
+Branch-name confirmation is a separate prerequisite, not part of publish
+approval. If the current branch is `main`, do not choose or create a branch
+until the user confirms its name. In a non-interactive run where confirmation
+cannot be requested, stop and report the proposed name; never infer confirmation
+from the request to open a PR.
 
 Before running this workflow, walk through the `pre-pr-self-review` checklist -
 it catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
@@ -67,6 +73,9 @@ Decide the PR base:
   before creating it. Offer the suggested kebab-case name and a way to enter a
   different name. If the host has no structured question tool, ask in chat.
   Known client adapters are in [host-adapters.md](host-adapters.md).
+- **Do not run `git switch -c`, `git checkout -b`, or `git branch <name>` until
+  that confirmation is received.** If the host cannot ask in the current mode,
+  stop with the proposed branch name.
 - Use `git switch -c <branch>` to move uncommitted changes onto the new
   branch.
 - If already on a non-`main` branch, keep using it.

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: create-pr
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - create-pr
@@ -12,7 +12,7 @@ core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku publish boundary
 

--- a/.agents/skills/cswin32-com/SKILL.md
+++ b/.agents/skills/cswin32-com/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/cswin32-com
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 16f0e262ed5b4a11f90a91b70cb4b9ab473a3d1a
     maturity: canary

--- a/.agents/skills/cswin32-com/overlay.md
+++ b/.agents/skills/cswin32-com/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: cswin32-com
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - cswin32-com
@@ -11,7 +11,7 @@ and its sibling pages are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift. Madowaku specifics live here.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku uses 0.3.287+ IComIID generation
 

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/cswin32-interop
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 14960bec081ff29eaa9bf5593b7a6ca9d5201ae8
     maturity: canary

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: cswin32-interop
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - cswin32-interop
@@ -11,7 +11,7 @@ Repository-specific companion to the [cswin32-interop](SKILL.md) core. The
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift. Everything madowaku-specific lives here.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## Targeting model
 

--- a/.agents/skills/dotnet-polyfills/SKILL.md
+++ b/.agents/skills/dotnet-polyfills/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/dotnet-polyfills
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: ae0aa41d3c5c002298172ba4e5f7b24eb615d9db
     maturity: canary

--- a/.agents/skills/dotnet-polyfills/overlay.md
+++ b/.agents/skills/dotnet-polyfills/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: dotnet-polyfills
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - dotnet-polyfills
@@ -12,7 +12,7 @@ portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/engineering-baseline/SKILL.md
+++ b/.agents/skills/engineering-baseline/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/engineering-baseline
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: b0e52e484192142c2b3083ee181b4f7a5b61b0d6
     maturity: canary

--- a/.agents/skills/engineering-baseline/overlay.md
+++ b/.agents/skills/engineering-baseline/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: engineering-baseline
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - engineering-baseline
@@ -13,7 +13,7 @@ scaffolding tree are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/framework-jit-optimization
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 97120f8dc990d4af91d9dbfb1c191a48ecce48f1
     maturity: canary

--- a/.agents/skills/framework-jit-optimization/overlay.md
+++ b/.agents/skills/framework-jit-optimization/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: framework-jit-optimization
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - framework-jit-optimization
@@ -12,7 +12,7 @@ pages are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/github-actions-cost-optimization/SKILL.md
+++ b/.agents/skills/github-actions-cost-optimization/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/github-actions-cost-optimization
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 1fac6778d86ec0879641e2b593e881f49b43c648
     maturity: canary

--- a/.agents/skills/github-actions-cost-optimization/overlay.md
+++ b/.agents/skills/github-actions-cost-optimization/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: github-actions-cost-optimization
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - github-actions-cost-optimization
@@ -12,7 +12,7 @@ sibling pages are a **pinned copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/il-copy-inspection
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 07bce64dc12f798aeeec01aab716d26bbde5c0ed
     maturity: canary

--- a/.agents/skills/il-copy-inspection/overlay.md
+++ b/.agents/skills/il-copy-inspection/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: il-copy-inspection
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - il-copy-inspection
@@ -12,7 +12,7 @@ copy of the portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/manage-skills
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 5b881e8d4c0a1d5e9bdf3d48cb91d515088e44d2
     maturity: canary

--- a/.agents/skills/manage-skills/overlay.md
+++ b/.agents/skills/manage-skills/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: manage-skills
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - manage-skills
@@ -13,12 +13,12 @@ bundled `scripts/Validate-Skills.ps1`, and `assets/overlay.md.tmpl` are a
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 
 - **The commons is `JeremyKuhne/agent-skills`; madowaku pins all vendored cores
-  to `v0.11.0`.**
+  to `v0.13.0`.**
 - **The catalog is** [.agents/skills/README.md](../README.md); add or update its
   inventory row and disambiguation in the same change as any vendor, tweak, or
   new skill.

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-project-gated
     binding: optional-overlay
     github-path: skills/performance-testing
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 9cdddfa386a045ddc14a9799126929da23341e89
     maturity: canary

--- a/.agents/skills/performance-testing/overlay.md
+++ b/.agents/skills/performance-testing/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: performance-testing
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - performance-testing
@@ -13,7 +13,7 @@ skill. The `SKILL.md` and its sibling pages (`authoring.md`, `running.md`,
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift. Everything madowaku-specific lives here.
 
-> **Pinned to the commons v0.11.0 tag.** Pull later upstream changes with
+> **Pinned to the commons v0.13.0 tag.** Pull later upstream changes with
 > `gh skill update performance-testing`, review the diff, then re-pin `core-pin`.
 
 ## Concrete bindings for the core's placeholders

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/pre-pr-self-review
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: c172ca7a01a7368bb4fee88b4d0b756442d38976
     maturity: canary

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: pre-pr-self-review
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - pre-pr-self-review
@@ -11,7 +11,7 @@ skill. The `SKILL.md` is a **pinned copy of the portable core** from
 `metadata.github-*` provenance in its frontmatter). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku recurring mistakes to self-check
 

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/scratch-buffer-strategy
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 3ae67f801e33d4b55730633f22e27c0fa941ea99
     maturity: canary

--- a/.agents/skills/scratch-buffer-strategy/overlay.md
+++ b/.agents/skills/scratch-buffer-strategy/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: scratch-buffer-strategy
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - scratch-buffer-strategy
@@ -12,7 +12,7 @@ core** from [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skil
 (see the `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/security-review
-    github-pinned: v0.11.0
-    github-ref: refs/tags/v0.11.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 883a99623b74cd6f5bfc2e0706b71a1513d1c62f
+    github-tree-sha: 8f2b820c678065733b6582b6dcb1685bd49854f3
     maturity: canary
     portability: portable
     related: pre-pr-self-review, performance-testing, fuzz-testing

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -52,8 +52,8 @@ outside. Specialized fast paths often bypass the affected code
 - Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
   per call (acceptable if bounded), or grow without limit (red flag)?
 
-**Tests:** a "large but legitimate" input completes within a
-`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
+**Tests:** a "large but legitimate" input completes within a `Stopwatch`
+bound (`Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(2))`).
 Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
 allocation count.
 
@@ -73,17 +73,17 @@ allocation count.
 **Tests** (pin the safe property):
 
 ```csharp
-[Fact]
+[TestMethod]
 public void Method_PathologicalInput_TerminatesPromptly()
 {
-    /* construct adversarial pattern + input */
+    /* construct adversarial pattern, input, matcher, and expected result */
 
-    Stopwatch sw = Stopwatch.StartNew();
-    bool result = m.IsMatch(input);
-    sw.Stop();
+    Stopwatch stopwatch = Stopwatch.StartNew();
+    bool result = matcher.IsMatch(input);
+    stopwatch.Stop();
 
-    result.Should().Be(/* expected */);
-    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+    Assert.AreEqual(expectedResult, result);
+    Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
 }
 ```
 

--- a/.agents/skills/security-review/overlay.md
+++ b/.agents/skills/security-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: security-review
-core-pin: v0.11.0
+core-pin: v0.13.0
 ---
 
 # madowaku overlay - security-review
@@ -12,7 +12,7 @@ The `SKILL.md` and its sibling pages (`checklist.md`, `principles.md`,
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core;
 `gh skill update` would flag the drift.
 
-> **Pinned to the commons v0.11.0 tag.**
+> **Pinned to the commons v0.13.0 tag.**
 
 ## madowaku bindings
 


### PR DESCRIPTION
## Summary

- Update all 16 applicable vendored skill cores and overlays to v0.13.0.
- Add the review-thread fallback and adopt the release's PR safety updates.
- Document why `fuzz-testing` and `roslyn-analyzers` remain project-gated.

## Validation

- Agent-file and strict portfolio validators
- Exact-tag file and hash audit
- Markdownlint and 90-file offline link audit
- `dotnet test madowaku.slnx -c Debug` (611 passed)
- `dotnet test madowaku.slnx -c Release` (611 passed)